### PR TITLE
Add nonempty in definition of hyperconnected and ultraconnected

### DIFF
--- a/properties/P000021.md
+++ b/properties/P000021.md
@@ -2,9 +2,13 @@
 uid: P000021
 slug: weakly-countably-compact
 name: Weakly Countably Compact
+aliases:
+  - Limit point compact
 refs:
   - doi: 10.1007/978-1-4612-6290-9
     name: Counterexamples in Topology
+  - wikipedia: Limit_point_compact
+    name: Limit point compact
 ---
 A space $X$ is weakly countably compact if every infinite subset of $X$ has a limit point.
 

--- a/properties/P000039.md
+++ b/properties/P000039.md
@@ -5,7 +5,9 @@ name: Hyperconnected
 refs:
   - doi: 10.1007/978-1-4612-6290-9
     name: Counterexamples in Topology
+  - wikipedia: Hyperconnected_space
+    name: Hyperconnected space on wikipedia
 ---
-A space is hyperconnected if it contains no disjoint open subsets.
+A space is hyperconnected if it contains no disjoint nonempty open subsets.
 
 Defined on page 29 of {{doi:10.1007/978-1-4612-6290-9}}.

--- a/properties/P000040.md
+++ b/properties/P000040.md
@@ -6,6 +6,6 @@ refs:
   - doi: 10.1007/978-1-4612-6290-9
     name: Counterexamples in Topology
 ---
-A space is ultraconnected if it contains no disjoint closed subsets.
+A space is ultraconnected if it contains no disjoint nonempty closed subsets.
 
 Defined on page 29 of {{doi:10.1007/978-1-4612-6290-9}}.

--- a/theorems/T000110.md
+++ b/theorems/T000110.md
@@ -2,7 +2,7 @@
 uid: T000110
 if:
   and:
-  - P000007: true
+  - P000013: true
   - P000022: true
 then:
   P000021: true
@@ -11,6 +11,6 @@ refs:
   name: Counterexamples in Topology
 ---
 
-Suppose $X$ is a $T_4$ space which is not weakly countably compact. Then there is some sequence $x_n$ in $X$ with no limit point. Define $f:x_n \mapsto n$. By the Tietze Extension Theorem, $f$ extends to a continuous unbounded $F: X \rightarrow \mathbb{R}$, so $X$ is not pseudocompact.
+Suppose $X$ is a normal space which is not weakly countably compact.  There is a countably infinite closed discrete subset $A=\{x_1,x_2,\ldots\}$ of $X$.  By the Tietze Extension Theorem, the continuous function $f$ on $A$ defined by $f(x_n)=n$ can be extended to an (unbounded) real-valued continuous function on all of $X$.  So $X$ is not pseudocompact.
 
-Shown on page 20 of {{doi:10.1007/978-1-4612-6290-9}}.
+Essentially shown on page 20 of {{doi:10.1007/978-1-4612-6290-9}}.


### PR DESCRIPTION
The empty set is disjoint from any other set.  So to be strictly correct, the "nonempty" qualifier should be added in the definition of hyperconnected and ultraconnected spaces.