### PR TITLE
T3 implies T2+one-half (in T000033)

### DIFF
--- a/properties/P000005.md
+++ b/properties/P000005.md
@@ -8,6 +8,6 @@ refs:
   - mr: MR2048350
     name: General Topology (Willard)
 ---
-A $T_3$ (or regular Hausdorff) space is one that is both regular and $T_1$.
+A $T_3$ (or regular Hausdorff) space is one that is both regular and $T_1$.  Equivalently, it is a space that both regular and $T_2$.
 
 Defined in 14.1 of {{mr:MR2048350}}.

--- a/theorems/T000033.md
+++ b/theorems/T000033.md
@@ -1,9 +1,7 @@
 ---
 uid: T000033
 if:
-  and:
-  - P000003: true
-  - P000011: true
+  P000005: true
 then:
   P000004: true
 refs:
@@ -11,7 +9,7 @@ refs:
   name: Counterexamples in Topology
 ---
 
-If $X$ is $T_2$ and regular and $a,b \in X$, then there are disjoint open $O_a$ and $O_b$ containing $a$ and $b$ respectively. Then $a$ and $cl(O_b)$ are disjoint and so by $T_3$ there is an open $U$ containing $a$ with $cl(U) \cap cl(O_b) = \emptyset$.
+If $X$ is $T_3$, it is $T_2$.  So given distinct points $a,b\in X$, there are disjoint open $O_a$ and $O_b$ containing $a$ and $b$ respectively. Then $a \notin \operatorname{cl}(O_b)$ and by regularity there is an open $U$ containing $a$ with $\operatorname{cl}(U) \cap \operatorname{cl}(O_b) = \emptyset$.
 
 Asserted in Figure 1 of {{doi:10.1007/978-1-4612-6290-9}}
 (where T_3 means regular).


### PR DESCRIPTION
In pi-base, if one searches for spaces by property and the combinations of properties is impossible, it tells you so.  For example "T2 implies T1", hence "T2 + ~T1" is impossible (https://topology.jdabbs.com/spaces?q=T_2%2B~T_1).

But I noticed that does not work to show that "T3 implies T2" (or similarly T3 implies T1 or T0):
https://topology.jdabbs.com/spaces?q=T_3%2B~T_2

The proposed changes fix this, by replacing T000033 (T2 + regular implies T2+one-half) with (T3 implies T2+one-half).

Notice that we don't lose any stength of deduction, since "T3 is equivalent to T2 + regular" by combining, in one direction:
- (new T33) "T3 implies T2+one-half"
- (T32) "T2+one_half implies T2"
- (T146) "T3 implies regular"

and in the other direction:
- (T118) "T2 implies T1"
- (T119) "T1 implies T0"
- (T148) "regular + T0 implies T3"


