### PR TITLE
Local countability for first two uncountable ordinals

### DIFF
--- a/spaces/S000035/properties/P000024.md
+++ b/spaces/S000035/properties/P000024.md
@@ -8,5 +8,7 @@ refs:
   name: Counterexamples in Topology
 ---
 
+Every $\alpha\in\Omega$ has $[0,\alpha]$ as a closed compact neighborhood.
+
 Asserted in the General Reference Chart for space #42 in
 {{doi:10.1007/978-1-4612-6290-9_6}}.

--- a/spaces/S000035/properties/P000093.md
+++ b/spaces/S000035/properties/P000093.md
@@ -1,11 +1,10 @@
 ---
-uid: T000695
 space: S000035
-property: P000008
+property: P000093
 value: true
 refs:
 - doi: 10.1007/978-1-4612-6290-9_6
   name: Counterexamples in Topology
 ---
 
-See item #4 for space #42 in {{doi:10.1007/978-1-4612-6290-9_6}}.
+Every $\alpha\in\Omega$ has $[0,\alpha]$ as a countable neighborhood.

--- a/spaces/S000036/properties/P000081.md
+++ b/spaces/S000036/properties/P000081.md
@@ -1,0 +1,10 @@
+---
+space: S000036
+property: P000081
+value: false
+refs:
+- doi: 10.1007/978-1-4612-6290-9_6
+  name: Counterexamples in Topology
+---
+
+The point $\omega_1$ of $X=[0,\omega_1]$ is in the closure of $A=[0,\omega_1)$.  But any countable subset $B\subseteq A$ has a supremum $\alpha<\omega_1$, and $(\alpha,\omega_1]$ is a neighborhood of $\omega_1$ disjoint from $B$.  This shows that $X$ is not countably tight.


### PR DESCRIPTION
- omega_1 is locally countable.  This gives a counterexample to the converse of T238 (Countable implies Locally countable).
- omega_1 + 1 is not countably tight.  This implies the space is not locally countable by T186 (Locally countable implies Countably tight).