### PR TITLE
Uncountable Fort space is not ccc

### DIFF
--- a/spaces/S000154/properties/P000029.md
+++ b/spaces/S000154/properties/P000029.md
@@ -1,14 +1,13 @@
 ---
-uid: T000903
 space: S000154
 property: P000029
-value: true
+value: false
 refs:
 - doi: 10.1007/978-1-4612-6290-9_6
   name: Counterexamples in Topology
 ---
 
-Let $ \{U_i\ |\ i \in I\} $ be a pairwise disjoint collection of open sets. Then $p \in U_i$ for at most one $i \in I). Any two other $U_j$'s would necessarily intersect, so $I$ is countable.
+All the singletons $\{x\}$ for $x\ne\infty$ form an uncountable collection of pairwise disjoint nonempty open sets.
 
-Asserted in the General Reference Chart for space #24 in
+Erroneously asserted as true in the General Reference Chart for space #24 in
 {{doi:10.1007/978-1-4612-6290-9_6}}.


### PR DESCRIPTION
Please check me on this, but it seems this is a mistake in Steen & Seebach.