### PR TITLE
Theorems to determine "has distinct points" for most spaces

### DIFF
--- a/spaces/S000162/properties/P000052.md
+++ b/spaces/S000162/properties/P000052.md
@@ -1,7 +1,0 @@
----
-space: S000162
-property: P000052
-value: true
----
-
-The space is discrete by definition.

--- a/spaces/S000162/properties/P000125.md
+++ b/spaces/S000162/properties/P000125.md
@@ -1,0 +1,10 @@
+---
+space: S000162
+property: P000125
+value: false
+refs:
+- wikipedia: Singleton_(mathematics)
+  name: Singleton (mathematics)
+---
+
+The space has less than two points by definition.

--- a/spaces/S000162/properties/P000129.md
+++ b/spaces/S000162/properties/P000129.md
@@ -1,7 +1,0 @@
----
-space: S000162
-property: P000129
-value: true
----
-
-The space is trivial by definition.

--- a/spaces/S000163/properties/P000052.md
+++ b/spaces/S000163/properties/P000052.md
@@ -1,7 +1,0 @@
----
-space: S000163
-property: P000052
-value: true
----
-
-The space is discrete by definition.

--- a/spaces/S000163/properties/P000125.md
+++ b/spaces/S000163/properties/P000125.md
@@ -1,0 +1,10 @@
+---
+space: S000163
+property: P000125
+value: false
+refs:
+- wikipedia: Empty_set
+  name: Empty set
+---
+
+The space has less than two points by definition.

--- a/spaces/S000163/properties/P000129.md
+++ b/spaces/S000163/properties/P000129.md
@@ -1,7 +1,0 @@
----
-space: S000163
-property: P000129
-value: true
----
-
-The space is indiscrete by definition.

--- a/theorems/T000248.md
+++ b/theorems/T000248.md
@@ -1,0 +1,13 @@
+---
+uid: T000248
+if:
+  P000125: false
+then:
+  P000052: true
+refs:
+  - wikipedia: Finite_topological_space
+    name: Finite Topological space
+---
+
+The spaces with less than two points are the empty space and the
+singleton space, which are both discrete.

--- a/theorems/T000249.md
+++ b/theorems/T000249.md
@@ -1,0 +1,13 @@
+---
+uid: T000249
+if:
+  P000125: false
+then:
+  P000129: true
+refs:
+  - wikipedia: Finite_topological_space
+    name: Finite Topological space
+---
+
+The spaces with less than two points are the empty space and the
+singleton space, which are both indiscrete.

--- a/theorems/T000250.md
+++ b/theorems/T000250.md
@@ -1,0 +1,12 @@
+---
+uid: T000250
+if:
+  P000078: false
+then:
+  P000125: true
+refs:
+  - wikipedia: Finite_set
+    name: Finite set
+---
+
+Trivially from the definitions.


### PR DESCRIPTION
Right now, a pi-base query does not show a single space with the "has distinct points" property:
https://topology.jdabbs.com/spaces?q=Has%20distinct%20points

Adding three theorems to ensure the property can be determined for most spaces (directly or via the contrapositives):
- T248: ~(has distinct points) implies discrete
- T249: ~(has distinct points) implies indiscrete
- T250: ~finite implies (has distinct points)

Note that T248 and T249 form the converse of T247.

With these new theorems, simplified the list of asserted properties of the Singleton space and Empty space to get the same result (deleted 4 traits and added 2 traits).