### PR TITLE
Hereditarily Lindelof and G_delta space properties

### DIFF
--- a/properties/P000015.md
+++ b/properties/P000015.md
@@ -11,6 +11,6 @@ refs:
 
 A space $X$ for which, for any disjoint closed sets $A$ and $B$, there is a continuous function $f: X \rightarrow [0,1]$ such that $f^{-1}(\{0\}) = A$ and $f^{-1}(\{1\}) = B$.  Equivalently, a normal space in which every closed set is a $G_\delta$.  Equivalently, a space in which every closed set is a zero-set.
 
-The equivalence between the three definitions (Vedenissoff's theorem) is shown for example in Theorem 1.5.19 of {{mr:MR1039321}} (under the assumption of a $T_1$ space, but the proof is equally valid without the $T_1$ assumption).
+The equivalence between the three definitions (Vedenissoff's theorem) is shown for example in Theorem 1.5.19 of {{mr:MR1039321}} (under the assumption of a $T_1$ space, but the proof is equally valid without the $T_1$ assumption).  See also here: <https://math.stackexchange.com/questions/72138>.
 
 Defined on page 16 of {{doi:10.1007/978-1-4612-6290-9}} (as perfectly \(T_4\)).

--- a/properties/P000015.md
+++ b/properties/P000015.md
@@ -1,11 +1,16 @@
 ---
 uid: P000015
 slug: perfectly-normal
-name: Perfectly Normal
+name: Perfectly normal
 refs:
   - doi: 10.1007/978-1-4612-6290-9
     name: Counterexamples in Topology
+  - mr: MR1039321
+    name: General Topology (Engelking, 1989)
 ---
-A space $X$ is perfectly normal if, for any disjoint closed sets $A$ and $B$, there is a continuous function $f: X \rightarrow \mathbb{R}$ such that $f^{-1}(\{0\}) = A$ and $f^{-1}(\{1\}) = B$.
+
+A space $X$ for which, for any disjoint closed sets $A$ and $B$, there is a continuous function $f: X \rightarrow [0,1]$ such that $f^{-1}(\{0\}) = A$ and $f^{-1}(\{1\}) = B$.  Equivalently, a normal space in which every closed set is a $G_\delta$.  Equivalently, a space in which every closed set is a zero-set.
+
+The equivalence between the three definitions (Vedenissoff's theorem) is shown for example in Theorem 1.5.19 of {{mr:MR1039321}} (under the assumption of a $T_1$ space, but the proof is equally valid without the $T_1$ assumption).
 
 Defined on page 16 of {{doi:10.1007/978-1-4612-6290-9}} (as perfectly \(T_4\)).

--- a/properties/P000131.md
+++ b/properties/P000131.md
@@ -11,4 +11,6 @@ refs:
 
 A space for which every subspace is Lindelöf.  Equivalently, a space in which every open set is Lindelöf.
 
+The equivalence between the two is shown for example in <https://math.stackexchange.com/questions/494918>.
+
 Defined in 16E of {{mr:MR2048350}}.

--- a/properties/P000131.md
+++ b/properties/P000131.md
@@ -1,0 +1,14 @@
+---
+uid: P000131
+slug: hereditarily-lindelof
+name: Hereditarily Lindelöf
+refs:
+  - mr: MR2048350
+    name: General Topology (Willard)
+  - wikipedia: Lindelöf_space
+    name: Lindelöf space
+---
+
+A space for which every subspace is Lindelöf.  Equivalently, a space in which every open set is Lindelöf.
+
+Defined in 16E of {{mr:MR2048350}}.

--- a/properties/P000132.md
+++ b/properties/P000132.md
@@ -1,0 +1,16 @@
+---
+uid: P000132
+slug: G-delta
+name: $G_\delta$ space
+refs:
+  - doi: 10.1007/978-1-4612-6290-9
+    name: Counterexamples in Topology
+  - wikipedia: Gδ_space
+    name: G-delta space
+---
+
+A space in which every closed set is a $G_\delta$.  Equivalently, a space in which every open set is an $F_\sigma$.
+
+Defined on page 162 of {{doi:10.1007/978-1-4612-6290-9}}.
+
+Note: A $G_\delta$ space is sometimes called a "perfect space" (Exercise 1.5.H(a) in {{mr:MR1039321}}). But that could be confused with a space that is a "perfect" in the sense of "perfect set" (= a set equal to its derived set), that is, a space without isolated point. See the discussion in <https://en.wikipedia.org/wiki/Talk:Perfect_set#Terminology_issue>.

--- a/theorems/T000254.md
+++ b/theorems/T000254.md
@@ -1,0 +1,12 @@
+---
+uid: T000254
+if:
+  P000131: true
+then:
+  P000018: true
+refs:
+  - wikipedia: Lindelöf_space
+    name: Lindelöf space
+---
+
+Evident from the definitions.

--- a/theorems/T000255.md
+++ b/theorems/T000255.md
@@ -1,0 +1,17 @@
+---
+uid: T000255
+if:
+  and:
+  - P000018: true
+  - P000132: true
+then:
+  P000131: true
+refs:
+  - mr: MR2048350
+    name: General Topology (Willard)
+---
+
+If $X$ is Lindelof and a $G_\delta$ space, every open set in $X$ is an $F_\sigma$ and hence is also Lindelof.
+This uses the facts that closed sets in a Lindelof space are Lindelof, and a countable union of Lindelof subspaces is Lindelof.
+
+See Theorem 16.6 in {{mr:MR2048350}}.

--- a/theorems/T000256.md
+++ b/theorems/T000256.md
@@ -1,0 +1,12 @@
+---
+uid: T000256
+if:
+  P000015: true
+then:
+  P000132: true
+refs:
+  - doi: 10.1007/978-1-4612-6290-9
+    name: Counterexamples in Topology
+---
+
+Follows from the definition of {P15}.

--- a/theorems/T000257.md
+++ b/theorems/T000257.md
@@ -1,0 +1,14 @@
+---
+uid: T000253
+if:
+  and:
+  - P000013: true
+  - P000132: true
+then:
+  P000015: true
+refs:
+  - doi: 10.1007/978-1-4612-6290-9
+    name: Counterexamples in Topology
+---
+
+Follows from the definition of {P15}.

--- a/theorems/T000258.md
+++ b/theorems/T000258.md
@@ -1,0 +1,14 @@
+---
+uid: T000258
+if:
+  and:
+  - P000011: true
+  - P000131: true
+then:
+  P000015: true
+refs:
+  - mathse: 322387
+    name: Another question on hereditarily lindelöf space
+---
+
+Shown in {{322387}}. <https://math.stackexchange.com/questions/322387>


### PR DESCRIPTION
Two new properties:
- P131: Hereditarily Lindelof
- P132: G_delta space

Associated theorems:
- T254: hereditarily Lindelof implies Lindelof
- T255: Lindelof + G_delta space implies hereditarily Lindelof
- T256: perfectly normal implies G_delta space
- T257: normal + G_delta space implies perfectly normal
- T258: regular + hereditarily Lindelof implies perfectly normal

This will allow to automatically deduce the Sorgenfrey line is perfectly normal by showing it is hereditarily Lindelof.
