### PR TITLE
Theorem 66: remove misleading reasoning

### DIFF
--- a/theorems/T000066.md
+++ b/theorems/T000066.md
@@ -9,6 +9,6 @@ refs:
   name: Counterexamples in Topology
 ---
 
-A discrete space has a basis consisting of single point sets which are isolated and thus clopen.
+A discrete space has a basis consisting of single point sets which are clopen.
 
 Asserted in Figure 9 (page 32) of {{doi:10.1007/978-1-4612-6290-9}}.


### PR DESCRIPTION
The reasoning in https://topology.jdabbs.com/theorems/T000066 states "... single point sets which are isolated and thus clopen".  This is misleading to say the least.  In general an isolated point need not be clopen.  For example in the Sierpinski space X = {x,y} with open sets {x}, X and the empty set, the singleton {x} is open but not closed.  So remove the incorrect reasoning.