### PR TITLE
fix: push to s3

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -7,43 +7,43 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Compile bundle
-      uses: pi-base/compile@releases/v1
-      with:
-        out: bundle.json
-    - name: Persist bundle as artifact
-      uses: actions/upload-artifact@v1.0.0
-      with:
-        name: bundle.json
-        path: bundle.json
-    - name: Upload bundle to S3
-      run: |
-        aws s3 cp --acl public-read bundle.json s3://pi-base-bundles/${GITHUB_REF:-unknown}.json
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    - name: Notify Slack
-      run: |
-        curl -X POST \
-          -H 'Content-type: application/json' \
-          -H 'Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}' \
-          --data '{
-            "channel": "activity",
-            "icon_emoji": ":female_scientist:",
-            "attachments": [
-              {
-          	    "mrkdwn_in": ["text"],
-                "text": "New release for *${{ github.repository }}*",
-          		  "color": "good",
-          		  "fields": [
-                  { "title": "Message", "value": "${{ github.event.head_commit.message }}"},
-          		    { "title": "Author", "value": "${{ github.actor }}" },
-          		    { "title": "Ref", "value": "${{ github.ref }}", "short": true },
-          		    { "title": "Sha", "value": "${{ github.sha }}", "short": true }
-                ]
-              }
-            ]
-          }' \
-          https://slack.com/api/chat.postMessage
-
+      - uses: actions/checkout@v2
+      - name: Compile bundle
+        uses: pi-base/compile@releases/v1
+        with:
+          out: bundle.json
+      - name: Persist bundle as artifact
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          name: bundle.json
+          path: bundle.json
+      - name: Upload bundle to S3
+        run: |
+          aws s3 cp --acl public-read bundle.json s3://pi-base-bundles/${GITHUB_REF:-unknown}.json
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-2
+      - name: Notify Slack
+        run: |
+          curl -X POST \
+            -H 'Content-type: application/json' \
+            -H 'Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}' \
+            --data '{
+              "channel": "activity",
+              "icon_emoji": ":female_scientist:",
+              "attachments": [
+                {
+            	    "mrkdwn_in": ["text"],
+                  "text": "New release for *${{ github.repository }}*",
+            		  "color": "good",
+            		  "fields": [
+                    { "title": "Message", "value": "${{ github.event.head_commit.message }}"},
+            		    { "title": "Author", "value": "${{ github.actor }}" },
+            		    { "title": "Ref", "value": "${{ github.ref }}", "short": true },
+            		    { "title": "Sha", "value": "${{ github.sha }}", "short": true }
+                  ]
+                }
+              ]
+            }' \
+            https://slack.com/api/chat.postMessage


### PR DESCRIPTION
The `compile` action runs on `ubuntu-latest`, which recently updated from `18.x` to `20.x`. This bumped the `aws` cli tool, and the new version expects the added `ENV` variable to be set.