### PR TITLE
Scrub uid's from traits (issue #58), part 1

### DIFF
--- a/spaces/S000001/properties/P000024.md
+++ b/spaces/S000001/properties/P000024.md
@@ -1,5 +1,4 @@
 ---
-uid: T000003
 space: S000001
 property: P000024
 value: true

--- a/spaces/S000001/properties/P000036.md
+++ b/spaces/S000001/properties/P000036.md
@@ -1,5 +1,4 @@
 ---
-uid: T000009
 space: S000001
 property: P000036
 value: false

--- a/spaces/S000001/properties/P000052.md
+++ b/spaces/S000001/properties/P000052.md
@@ -1,5 +1,4 @@
 ---
-uid: T000028
 space: S000001
 property: P000052
 value: true

--- a/spaces/S000001/properties/P000078.md
+++ b/spaces/S000001/properties/P000078.md
@@ -1,5 +1,4 @@
 ---
-uid: T024776
 space: S000001
 property: P000078
 value: true

--- a/spaces/S000002/properties/P000019.md
+++ b/spaces/S000002/properties/P000019.md
@@ -1,5 +1,4 @@
 ---
-uid: T000160
 space: S000002
 property: P000019
 value: false

--- a/spaces/S000002/properties/P000022.md
+++ b/spaces/S000002/properties/P000022.md
@@ -1,5 +1,4 @@
 ---
-uid: T000161
 space: S000002
 property: P000022
 value: false

--- a/spaces/S000002/properties/P000024.md
+++ b/spaces/S000002/properties/P000024.md
@@ -1,5 +1,4 @@
 ---
-uid: T000004
 space: S000002
 property: P000024
 value: true

--- a/spaces/S000002/properties/P000036.md
+++ b/spaces/S000002/properties/P000036.md
@@ -1,5 +1,4 @@
 ---
-uid: T000010
 space: S000002
 property: P000036
 value: false

--- a/spaces/S000002/properties/P000057.md
+++ b/spaces/S000002/properties/P000057.md
@@ -1,5 +1,4 @@
 ---
-uid: T000159
 space: S000002
 property: P000057
 value: true

--- a/spaces/S000003/properties/P000017.md
+++ b/spaces/S000003/properties/P000017.md
@@ -1,5 +1,4 @@
 ---
-uid: T000007
 space: S000003
 property: P000017
 value: false

--- a/spaces/S000003/properties/P000022.md
+++ b/spaces/S000003/properties/P000022.md
@@ -1,5 +1,4 @@
 ---
-uid: T000162
 space: S000003
 property: P000022
 value: false

--- a/spaces/S000003/properties/P000024.md
+++ b/spaces/S000003/properties/P000024.md
@@ -1,5 +1,4 @@
 ---
-uid: T000005
 space: S000003
 property: P000024
 value: true

--- a/spaces/S000003/properties/P000029.md
+++ b/spaces/S000003/properties/P000029.md
@@ -1,5 +1,4 @@
 ---
-uid: T000163
 space: S000003
 property: P000029
 value: false

--- a/spaces/S000003/properties/P000036.md
+++ b/spaces/S000003/properties/P000036.md
@@ -1,5 +1,4 @@
 ---
-uid: T000011
 space: S000003
 property: P000036
 value: false

--- a/spaces/S000003/properties/P000052.md
+++ b/spaces/S000003/properties/P000052.md
@@ -1,5 +1,4 @@
 ---
-uid: T000030
 space: S000003
 property: P000052
 value: true

--- a/spaces/S000004/properties/P000001.md
+++ b/spaces/S000004/properties/P000001.md
@@ -1,5 +1,4 @@
 ---
-uid: T000021
 space: S000004
 property: P000001
 value: false

--- a/spaces/S000004/properties/P000027.md
+++ b/spaces/S000004/properties/P000027.md
@@ -1,5 +1,4 @@
 ---
-uid: T000017
 space: S000004
 property: P000027
 value: true

--- a/spaces/S000004/properties/P000037.md
+++ b/spaces/S000004/properties/P000037.md
@@ -1,5 +1,4 @@
 ---
-uid: T000018
 space: S000004
 property: P000037
 value: true

--- a/spaces/S000004/properties/P000039.md
+++ b/spaces/S000004/properties/P000039.md
@@ -1,5 +1,4 @@
 ---
-uid: T000019
 space: S000004
 property: P000039
 value: true

--- a/spaces/S000004/properties/P000040.md
+++ b/spaces/S000004/properties/P000040.md
@@ -1,5 +1,4 @@
 ---
-uid: T000020
 space: S000004
 property: P000040
 value: true

--- a/spaces/S000004/properties/P000042.md
+++ b/spaces/S000004/properties/P000042.md
@@ -1,5 +1,4 @@
 ---
-uid: T000844
 space: S000004
 property: P000042
 value: true

--- a/spaces/S000004/properties/P000044.md
+++ b/spaces/S000004/properties/P000044.md
@@ -1,5 +1,4 @@
 ---
-uid: T000845
 space: S000004
 property: P000044
 value: false

--- a/spaces/S000004/properties/P000050.md
+++ b/spaces/S000004/properties/P000050.md
@@ -1,5 +1,4 @@
 ---
-uid: T000843
 space: S000004
 property: P000050
 value: true

--- a/spaces/S000004/properties/P000056.md
+++ b/spaces/S000004/properties/P000056.md
@@ -1,5 +1,4 @@
 ---
-uid: T000016
 space: S000004
 property: P000056
 value: false

--- a/spaces/S000005/properties/P000001.md
+++ b/spaces/S000005/properties/P000001.md
@@ -1,5 +1,4 @@
 ---
-uid: T000039
 space: S000005
 property: P000001
 value: false

--- a/spaces/S000005/properties/P000011.md
+++ b/spaces/S000005/properties/P000011.md
@@ -1,5 +1,4 @@
 ---
-uid: T000040
 space: S000005
 property: P000011
 value: true

--- a/spaces/S000005/properties/P000019.md
+++ b/spaces/S000005/properties/P000019.md
@@ -1,5 +1,4 @@
 ---
-uid: T000038
 space: S000005
 property: P000019
 value: false

--- a/spaces/S000005/properties/P000021.md
+++ b/spaces/S000005/properties/P000021.md
@@ -1,5 +1,4 @@
 ---
-uid: T000037
 space: S000005
 property: P000021
 value: true

--- a/spaces/S000005/properties/P000022.md
+++ b/spaces/S000005/properties/P000022.md
@@ -1,5 +1,4 @@
 ---
-uid: T000848
 space: S000005
 property: P000022
 value: false

--- a/spaces/S000005/properties/P000024.md
+++ b/spaces/S000005/properties/P000024.md
@@ -1,5 +1,4 @@
 ---
-uid: T000849
 space: S000005
 property: P000024
 value: true

--- a/spaces/S000005/properties/P000027.md
+++ b/spaces/S000005/properties/P000027.md
@@ -1,5 +1,4 @@
 ---
-uid: T000036
 space: S000005
 property: P000027
 value: true

--- a/spaces/S000005/properties/P000030.md
+++ b/spaces/S000005/properties/P000030.md
@@ -1,5 +1,4 @@
 ---
-uid: T000850
 space: S000005
 property: P000030
 value: true

--- a/spaces/S000005/properties/P000042.md
+++ b/spaces/S000005/properties/P000042.md
@@ -1,5 +1,4 @@
 ---
-uid: T000851
 space: S000005
 property: P000042
 value: true

--- a/spaces/S000005/properties/P000050.md
+++ b/spaces/S000005/properties/P000050.md
@@ -1,5 +1,4 @@
 ---
-uid: T000852
 space: S000005
 property: P000050
 value: true

--- a/spaces/S000005/properties/P000051.md
+++ b/spaces/S000005/properties/P000051.md
@@ -1,5 +1,4 @@
 ---
-uid: T000853
 space: S000005
 property: P000051
 value: false

--- a/spaces/S000005/properties/P000056.md
+++ b/spaces/S000005/properties/P000056.md
@@ -1,5 +1,4 @@
 ---
-uid: T000854
 space: S000005
 property: P000056
 value: false

--- a/spaces/S000005/properties/P000057.md
+++ b/spaces/S000005/properties/P000057.md
@@ -1,5 +1,4 @@
 ---
-uid: T000847
 space: S000005
 property: P000057
 value: true

--- a/spaces/S000006/properties/P000001.md
+++ b/spaces/S000006/properties/P000001.md
@@ -1,5 +1,4 @@
 ---
-uid: T000041
 space: S000006
 property: P000001
 value: false

--- a/spaces/S000006/properties/P000014.md
+++ b/spaces/S000006/properties/P000014.md
@@ -1,5 +1,4 @@
 ---
-uid: T000045
 space: S000006
 property: P000014
 value: true

--- a/spaces/S000006/properties/P000021.md
+++ b/spaces/S000006/properties/P000021.md
@@ -1,5 +1,4 @@
 ---
-uid: T000047
 space: S000006
 property: P000021
 value: true

--- a/spaces/S000007/properties/P000001.md
+++ b/spaces/S000007/properties/P000001.md
@@ -1,5 +1,4 @@
 ---
-uid: T000049
 space: S000007
 property: P000001
 value: true

--- a/spaces/S000007/properties/P000002.md
+++ b/spaces/S000007/properties/P000002.md
@@ -1,5 +1,4 @@
 ---
-uid: T000050
 space: S000007
 property: P000002
 value: false

--- a/spaces/S000007/properties/P000011.md
+++ b/spaces/S000007/properties/P000011.md
@@ -1,5 +1,4 @@
 ---
-uid: T022299
 space: S000007
 property: P000011
 value: false

--- a/spaces/S000007/properties/P000016.md
+++ b/spaces/S000007/properties/P000016.md
@@ -1,5 +1,4 @@
 ---
-uid: T000051
 space: S000007
 property: P000016
 value: true

--- a/spaces/S000007/properties/P000026.md
+++ b/spaces/S000007/properties/P000026.md
@@ -1,5 +1,4 @@
 ---
-uid: T000052
 space: S000007
 property: P000026
 value: true

--- a/spaces/S000007/properties/P000027.md
+++ b/spaces/S000007/properties/P000027.md
@@ -1,5 +1,4 @@
 ---
-uid: T000872
 space: S000007
 property: P000027
 value: true

--- a/spaces/S000007/properties/P000037.md
+++ b/spaces/S000007/properties/P000037.md
@@ -1,5 +1,4 @@
 ---
-uid: T000056
 space: S000007
 property: P000037
 value: true

--- a/spaces/S000007/properties/P000038.md
+++ b/spaces/S000007/properties/P000038.md
@@ -1,5 +1,4 @@
 ---
-uid: T000057
 space: S000007
 property: P000038
 value: false

--- a/spaces/S000007/properties/P000039.md
+++ b/spaces/S000007/properties/P000039.md
@@ -1,5 +1,4 @@
 ---
-uid: T000054
 space: S000007
 property: P000039
 value: true

--- a/spaces/S000007/properties/P000040.md
+++ b/spaces/S000007/properties/P000040.md
@@ -1,5 +1,4 @@
 ---
-uid: T000055
 space: S000007
 property: P000040
 value: false

--- a/spaces/S000007/properties/P000042.md
+++ b/spaces/S000007/properties/P000042.md
@@ -1,5 +1,4 @@
 ---
-uid: T000072
 space: S000007
 property: P000042
 value: true

--- a/spaces/S000007/properties/P000045.md
+++ b/spaces/S000007/properties/P000045.md
@@ -1,5 +1,4 @@
 ---
-uid: T000863
 space: S000007
 property: P000045
 value: true

--- a/spaces/S000007/properties/P000051.md
+++ b/spaces/S000007/properties/P000051.md
@@ -1,5 +1,4 @@
 ---
-uid: T000053
 space: S000007
 property: P000051
 value: true

--- a/spaces/S000007/properties/P000056.md
+++ b/spaces/S000007/properties/P000056.md
@@ -1,5 +1,4 @@
 ---
-uid: T000058
 space: S000007
 property: P000056
 value: false

--- a/spaces/S000007/properties/P000078.md
+++ b/spaces/S000007/properties/P000078.md
@@ -1,5 +1,4 @@
 ---
-uid: T024778
 space: S000007
 property: P000078
 value: true

--- a/spaces/S000008/properties/P000001.md
+++ b/spaces/S000008/properties/P000001.md
@@ -1,5 +1,4 @@
 ---
-uid: T000059
 space: S000008
 property: P000001
 value: true

--- a/spaces/S000008/properties/P000002.md
+++ b/spaces/S000008/properties/P000002.md
@@ -1,5 +1,4 @@
 ---
-uid: T000060
 space: S000008
 property: P000002
 value: false

--- a/spaces/S000008/properties/P000016.md
+++ b/spaces/S000008/properties/P000016.md
@@ -1,5 +1,4 @@
 ---
-uid: T000061
 space: S000008
 property: P000016
 value: false

--- a/spaces/S000008/properties/P000021.md
+++ b/spaces/S000008/properties/P000021.md
@@ -1,5 +1,4 @@
 ---
-uid: T000069
 space: S000008
 property: P000021
 value: false

--- a/spaces/S000008/properties/P000023.md
+++ b/spaces/S000008/properties/P000023.md
@@ -1,5 +1,4 @@
 ---
-uid: T000062
 space: S000008
 property: P000023
 value: true

--- a/spaces/S000008/properties/P000024.md
+++ b/spaces/S000008/properties/P000024.md
@@ -1,5 +1,4 @@
 ---
-uid: T000064
 space: S000008
 property: P000024
 value: false

--- a/spaces/S000008/properties/P000026.md
+++ b/spaces/S000008/properties/P000026.md
@@ -1,5 +1,4 @@
 ---
-uid: T000065
 space: S000008
 property: P000026
 value: true

--- a/spaces/S000008/properties/P000027.md
+++ b/spaces/S000008/properties/P000027.md
@@ -1,5 +1,4 @@
 ---
-uid: T000873
 space: S000008
 property: P000027
 value: true

--- a/spaces/S000008/properties/P000030.md
+++ b/spaces/S000008/properties/P000030.md
@@ -1,5 +1,4 @@
 ---
-uid: T000063
 space: S000008
 property: P000030
 value: false

--- a/spaces/S000008/properties/P000033.md
+++ b/spaces/S000008/properties/P000033.md
@@ -1,5 +1,4 @@
 ---
-uid: T000868
 space: S000008
 property: P000033
 value: false

--- a/spaces/S000008/properties/P000037.md
+++ b/spaces/S000008/properties/P000037.md
@@ -1,5 +1,4 @@
 ---
-uid: T000070
 space: S000008
 property: P000037
 value: true

--- a/spaces/S000008/properties/P000038.md
+++ b/spaces/S000008/properties/P000038.md
@@ -1,5 +1,4 @@
 ---
-uid: T000073
 space: S000008
 property: P000038
 value: false

--- a/spaces/S000008/properties/P000039.md
+++ b/spaces/S000008/properties/P000039.md
@@ -1,5 +1,4 @@
 ---
-uid: T000067
 space: S000008
 property: P000039
 value: true

--- a/spaces/S000008/properties/P000040.md
+++ b/spaces/S000008/properties/P000040.md
@@ -1,5 +1,4 @@
 ---
-uid: T000068
 space: S000008
 property: P000040
 value: false

--- a/spaces/S000008/properties/P000042.md
+++ b/spaces/S000008/properties/P000042.md
@@ -1,5 +1,4 @@
 ---
-uid: T000071
 space: S000008
 property: P000042
 value: true

--- a/spaces/S000008/properties/P000045.md
+++ b/spaces/S000008/properties/P000045.md
@@ -1,5 +1,4 @@
 ---
-uid: T000864
 space: S000008
 property: P000045
 value: true

--- a/spaces/S000008/properties/P000051.md
+++ b/spaces/S000008/properties/P000051.md
@@ -1,5 +1,4 @@
 ---
-uid: T000066
 space: S000008
 property: P000051
 value: true

--- a/spaces/S000008/properties/P000056.md
+++ b/spaces/S000008/properties/P000056.md
@@ -1,5 +1,4 @@
 ---
-uid: T000074
 space: S000008
 property: P000056
 value: false

--- a/spaces/S000008/properties/P000057.md
+++ b/spaces/S000008/properties/P000057.md
@@ -1,5 +1,4 @@
 ---
-uid: T000856
 space: S000008
 property: P000057
 value: true

--- a/spaces/S000009/properties/P000001.md
+++ b/spaces/S000009/properties/P000001.md
@@ -1,5 +1,4 @@
 ---
-uid: T000075
 space: S000009
 property: P000001
 value: true

--- a/spaces/S000009/properties/P000002.md
+++ b/spaces/S000009/properties/P000002.md
@@ -1,5 +1,4 @@
 ---
-uid: T000076
 space: S000009
 property: P000002
 value: false

--- a/spaces/S000009/properties/P000016.md
+++ b/spaces/S000009/properties/P000016.md
@@ -1,5 +1,4 @@
 ---
-uid: T000077
 space: S000009
 property: P000016
 value: false

--- a/spaces/S000009/properties/P000018.md
+++ b/spaces/S000009/properties/P000018.md
@@ -1,5 +1,4 @@
 ---
-uid: T000081
 space: S000009
 property: P000018
 value: false

--- a/spaces/S000009/properties/P000021.md
+++ b/spaces/S000009/properties/P000021.md
@@ -1,5 +1,4 @@
 ---
-uid: T000085
 space: S000009
 property: P000021
 value: false

--- a/spaces/S000009/properties/P000023.md
+++ b/spaces/S000009/properties/P000023.md
@@ -1,5 +1,4 @@
 ---
-uid: T000078
 space: S000009
 property: P000023
 value: true

--- a/spaces/S000009/properties/P000024.md
+++ b/spaces/S000009/properties/P000024.md
@@ -1,5 +1,4 @@
 ---
-uid: T000079
 space: S000009
 property: P000024
 value: false

--- a/spaces/S000009/properties/P000026.md
+++ b/spaces/S000009/properties/P000026.md
@@ -1,5 +1,4 @@
 ---
-uid: T000080
 space: S000009
 property: P000026
 value: true

--- a/spaces/S000009/properties/P000028.md
+++ b/spaces/S000009/properties/P000028.md
@@ -1,5 +1,4 @@
 ---
-uid: T000866
 space: S000009
 property: P000028
 value: true

--- a/spaces/S000009/properties/P000033.md
+++ b/spaces/S000009/properties/P000033.md
@@ -1,5 +1,4 @@
 ---
-uid: T000869
 space: S000009
 property: P000033
 value: false

--- a/spaces/S000009/properties/P000037.md
+++ b/spaces/S000009/properties/P000037.md
@@ -1,5 +1,4 @@
 ---
-uid: T000086
 space: S000009
 property: P000037
 value: true

--- a/spaces/S000009/properties/P000038.md
+++ b/spaces/S000009/properties/P000038.md
@@ -1,5 +1,4 @@
 ---
-uid: T000088
 space: S000009
 property: P000038
 value: false

--- a/spaces/S000009/properties/P000039.md
+++ b/spaces/S000009/properties/P000039.md
@@ -1,5 +1,4 @@
 ---
-uid: T000083
 space: S000009
 property: P000039
 value: true

--- a/spaces/S000009/properties/P000040.md
+++ b/spaces/S000009/properties/P000040.md
@@ -1,5 +1,4 @@
 ---
-uid: T000084
 space: S000009
 property: P000040
 value: false

--- a/spaces/S000009/properties/P000042.md
+++ b/spaces/S000009/properties/P000042.md
@@ -1,5 +1,4 @@
 ---
-uid: T000087
 space: S000009
 property: P000042
 value: true

--- a/spaces/S000009/properties/P000043.md
+++ b/spaces/S000009/properties/P000043.md
@@ -1,5 +1,4 @@
 ---
-uid: T000870
 space: S000009
 property: P000043
 value: false

--- a/spaces/S000009/properties/P000045.md
+++ b/spaces/S000009/properties/P000045.md
@@ -1,5 +1,4 @@
 ---
-uid: T000865
 space: S000009
 property: P000045
 value: true

--- a/spaces/S000009/properties/P000051.md
+++ b/spaces/S000009/properties/P000051.md
@@ -1,5 +1,4 @@
 ---
-uid: T000082
 space: S000009
 property: P000051
 value: true

--- a/spaces/S000009/properties/P000056.md
+++ b/spaces/S000009/properties/P000056.md
@@ -1,5 +1,4 @@
 ---
-uid: T000089
 space: S000009
 property: P000056
 value: false

--- a/spaces/S000010/properties/P000001.md
+++ b/spaces/S000010/properties/P000001.md
@@ -1,5 +1,4 @@
 ---
-uid: T000867
 space: S000010
 property: P000001
 value: true

--- a/spaces/S000010/properties/P000014.md
+++ b/spaces/S000010/properties/P000014.md
@@ -1,5 +1,4 @@
 ---
-uid: T000509
 space: S000010
 property: P000014
 value: true

--- a/spaces/S000010/properties/P000016.md
+++ b/spaces/S000010/properties/P000016.md
@@ -1,5 +1,4 @@
 ---
-uid: T000510
 space: S000010
 property: P000016
 value: true

--- a/spaces/S000010/properties/P000026.md
+++ b/spaces/S000010/properties/P000026.md
@@ -1,5 +1,4 @@
 ---
-uid: T000511
 space: S000010
 property: P000026
 value: true

--- a/spaces/S000010/properties/P000027.md
+++ b/spaces/S000010/properties/P000027.md
@@ -1,5 +1,4 @@
 ---
-uid: T000512
 space: S000010
 property: P000027
 value: true

--- a/spaces/S000010/properties/P000034.md
+++ b/spaces/S000010/properties/P000034.md
@@ -1,5 +1,4 @@
 ---
-uid: T000874
 space: S000010
 property: P000034
 value: true

--- a/spaces/S000010/properties/P000038.md
+++ b/spaces/S000010/properties/P000038.md
@@ -1,5 +1,4 @@
 ---
-uid: T000516
 space: S000010
 property: P000038
 value: false

--- a/spaces/S000010/properties/P000039.md
+++ b/spaces/S000010/properties/P000039.md
@@ -1,5 +1,4 @@
 ---
-uid: T000514
 space: S000010
 property: P000039
 value: true

--- a/spaces/S000010/properties/P000042.md
+++ b/spaces/S000010/properties/P000042.md
@@ -1,5 +1,4 @@
 ---
-uid: T000875
 space: S000010
 property: P000042
 value: true

--- a/spaces/S000010/properties/P000045.md
+++ b/spaces/S000010/properties/P000045.md
@@ -1,5 +1,4 @@
 ---
-uid: T000515
 space: S000010
 property: P000045
 value: true

--- a/spaces/S000010/properties/P000051.md
+++ b/spaces/S000010/properties/P000051.md
@@ -1,5 +1,4 @@
 ---
-uid: T000513
 space: S000010
 property: P000051
 value: true

--- a/spaces/S000010/properties/P000056.md
+++ b/spaces/S000010/properties/P000056.md
@@ -1,5 +1,4 @@
 ---
-uid: T000876
 space: S000010
 property: P000056
 value: false

--- a/spaces/S000010/properties/P000057.md
+++ b/spaces/S000010/properties/P000057.md
@@ -1,5 +1,4 @@
 ---
-uid: T000857
 space: S000010
 property: P000057
 value: true

--- a/spaces/S000010/properties/P000078.md
+++ b/spaces/S000010/properties/P000078.md
@@ -1,5 +1,4 @@
 ---
-uid: T024779
 space: S000010
 property: P000078
 value: true

--- a/spaces/S000011/properties/P000001.md
+++ b/spaces/S000011/properties/P000001.md
@@ -1,5 +1,4 @@
 ---
-uid: T000517
 space: S000011
 property: P000001
 value: true

--- a/spaces/S000011/properties/P000002.md
+++ b/spaces/S000011/properties/P000002.md
@@ -1,5 +1,4 @@
 ---
-uid: T000518
 space: S000011
 property: P000002
 value: false

--- a/spaces/S000011/properties/P000014.md
+++ b/spaces/S000011/properties/P000014.md
@@ -1,5 +1,4 @@
 ---
-uid: T000520
 space: S000011
 property: P000014
 value: true

--- a/spaces/S000011/properties/P000016.md
+++ b/spaces/S000011/properties/P000016.md
@@ -1,5 +1,4 @@
 ---
-uid: T000521
 space: S000011
 property: P000016
 value: true

--- a/spaces/S000011/properties/P000027.md
+++ b/spaces/S000011/properties/P000027.md
@@ -1,5 +1,4 @@
 ---
-uid: T014603
 space: S000011
 property: P000027
 value: true

--- a/spaces/S000011/properties/P000034.md
+++ b/spaces/S000011/properties/P000034.md
@@ -1,5 +1,4 @@
 ---
-uid: T000880
 space: S000011
 property: P000034
 value: true

--- a/spaces/S000011/properties/P000039.md
+++ b/spaces/S000011/properties/P000039.md
@@ -1,5 +1,4 @@
 ---
-uid: T000524
 space: S000011
 property: P000039
 value: false

--- a/spaces/S000011/properties/P000040.md
+++ b/spaces/S000011/properties/P000040.md
@@ -1,5 +1,4 @@
 ---
-uid: T000523
 space: S000011
 property: P000040
 value: true

--- a/spaces/S000011/properties/P000042.md
+++ b/spaces/S000011/properties/P000042.md
@@ -1,5 +1,4 @@
 ---
-uid: T000526
 space: S000011
 property: P000042
 value: true

--- a/spaces/S000011/properties/P000045.md
+++ b/spaces/S000011/properties/P000045.md
@@ -1,5 +1,4 @@
 ---
-uid: T000529
 space: S000011
 property: P000045
 value: true

--- a/spaces/S000011/properties/P000051.md
+++ b/spaces/S000011/properties/P000051.md
@@ -1,5 +1,4 @@
 ---
-uid: T000528
 space: S000011
 property: P000051
 value: true

--- a/spaces/S000011/properties/P000056.md
+++ b/spaces/S000011/properties/P000056.md
@@ -1,5 +1,4 @@
 ---
-uid: T000877
 space: S000011
 property: P000056
 value: false

--- a/spaces/S000011/properties/P000078.md
+++ b/spaces/S000011/properties/P000078.md
@@ -1,5 +1,4 @@
 ---
-uid: T024777
 space: S000011
 property: P000078
 value: true

--- a/spaces/S000012/properties/P000001.md
+++ b/spaces/S000012/properties/P000001.md
@@ -1,5 +1,4 @@
 ---
-uid: T000532
 space: S000012
 property: P000001
 value: true

--- a/spaces/S000012/properties/P000002.md
+++ b/spaces/S000012/properties/P000002.md
@@ -1,5 +1,4 @@
 ---
-uid: T000533
 space: S000012
 property: P000002
 value: false

--- a/spaces/S000012/properties/P000014.md
+++ b/spaces/S000012/properties/P000014.md
@@ -1,5 +1,4 @@
 ---
-uid: T000535
 space: S000012
 property: P000014
 value: true

--- a/spaces/S000012/properties/P000016.md
+++ b/spaces/S000012/properties/P000016.md
@@ -1,5 +1,4 @@
 ---
-uid: T000536
 space: S000012
 property: P000016
 value: true

--- a/spaces/S000012/properties/P000027.md
+++ b/spaces/S000012/properties/P000027.md
@@ -1,5 +1,4 @@
 ---
-uid: T000546
 space: S000012
 property: P000027
 value: true

--- a/spaces/S000012/properties/P000034.md
+++ b/spaces/S000012/properties/P000034.md
@@ -1,5 +1,4 @@
 ---
-uid: T000881
 space: S000012
 property: P000034
 value: true

--- a/spaces/S000012/properties/P000039.md
+++ b/spaces/S000012/properties/P000039.md
@@ -1,5 +1,4 @@
 ---
-uid: T000539
 space: S000012
 property: P000039
 value: false

--- a/spaces/S000012/properties/P000040.md
+++ b/spaces/S000012/properties/P000040.md
@@ -1,5 +1,4 @@
 ---
-uid: T000538
 space: S000012
 property: P000040
 value: true

--- a/spaces/S000012/properties/P000042.md
+++ b/spaces/S000012/properties/P000042.md
@@ -1,5 +1,4 @@
 ---
-uid: T000541
 space: S000012
 property: P000042
 value: true

--- a/spaces/S000012/properties/P000045.md
+++ b/spaces/S000012/properties/P000045.md
@@ -1,5 +1,4 @@
 ---
-uid: T000544
 space: S000012
 property: P000045
 value: true

--- a/spaces/S000012/properties/P000051.md
+++ b/spaces/S000012/properties/P000051.md
@@ -1,5 +1,4 @@
 ---
-uid: T000543
 space: S000012
 property: P000051
 value: true

--- a/spaces/S000012/properties/P000056.md
+++ b/spaces/S000012/properties/P000056.md
@@ -1,5 +1,4 @@
 ---
-uid: T000878
 space: S000012
 property: P000056
 value: false

--- a/spaces/S000012/properties/P000057.md
+++ b/spaces/S000012/properties/P000057.md
@@ -1,5 +1,4 @@
 ---
-uid: T000859
 space: S000012
 property: P000057
 value: true

--- a/spaces/S000013/properties/P000001.md
+++ b/spaces/S000013/properties/P000001.md
@@ -1,5 +1,4 @@
 ---
-uid: T000547
 space: S000013
 property: P000001
 value: true

--- a/spaces/S000013/properties/P000002.md
+++ b/spaces/S000013/properties/P000002.md
@@ -1,5 +1,4 @@
 ---
-uid: T000548
 space: S000013
 property: P000002
 value: false

--- a/spaces/S000013/properties/P000014.md
+++ b/spaces/S000013/properties/P000014.md
@@ -1,5 +1,4 @@
 ---
-uid: T000550
 space: S000013
 property: P000014
 value: true

--- a/spaces/S000013/properties/P000016.md
+++ b/spaces/S000013/properties/P000016.md
@@ -1,5 +1,4 @@
 ---
-uid: T000551
 space: S000013
 property: P000016
 value: true

--- a/spaces/S000013/properties/P000026.md
+++ b/spaces/S000013/properties/P000026.md
@@ -1,5 +1,4 @@
 ---
-uid: T000562
 space: S000013
 property: P000026
 value: false

--- a/spaces/S000013/properties/P000028.md
+++ b/spaces/S000013/properties/P000028.md
@@ -1,5 +1,4 @@
 ---
-uid: T000560
 space: S000013
 property: P000028
 value: true

--- a/spaces/S000013/properties/P000029.md
+++ b/spaces/S000013/properties/P000029.md
@@ -1,5 +1,4 @@
 ---
-uid: T000883
 space: S000013
 property: P000029
 value: false

--- a/spaces/S000013/properties/P000034.md
+++ b/spaces/S000013/properties/P000034.md
@@ -1,5 +1,4 @@
 ---
-uid: T000882
 space: S000013
 property: P000034
 value: true

--- a/spaces/S000013/properties/P000038.md
+++ b/spaces/S000013/properties/P000038.md
@@ -1,5 +1,4 @@
 ---
-uid: T024171
 space: S000013
 property: P000038
 value: false

--- a/spaces/S000013/properties/P000039.md
+++ b/spaces/S000013/properties/P000039.md
@@ -1,5 +1,4 @@
 ---
-uid: T000554
 space: S000013
 property: P000039
 value: false

--- a/spaces/S000013/properties/P000040.md
+++ b/spaces/S000013/properties/P000040.md
@@ -1,5 +1,4 @@
 ---
-uid: T000553
 space: S000013
 property: P000040
 value: true

--- a/spaces/S000013/properties/P000042.md
+++ b/spaces/S000013/properties/P000042.md
@@ -1,5 +1,4 @@
 ---
-uid: T000556
 space: S000013
 property: P000042
 value: true

--- a/spaces/S000013/properties/P000045.md
+++ b/spaces/S000013/properties/P000045.md
@@ -1,5 +1,4 @@
 ---
-uid: T000559
 space: S000013
 property: P000045
 value: true

--- a/spaces/S000013/properties/P000051.md
+++ b/spaces/S000013/properties/P000051.md
@@ -1,5 +1,4 @@
 ---
-uid: T000558
 space: S000013
 property: P000051
 value: true

--- a/spaces/S000013/properties/P000054.md
+++ b/spaces/S000013/properties/P000054.md
@@ -1,5 +1,4 @@
 ---
-uid: T000892
 space: S000013
 property: P000054
 value: false

--- a/spaces/S000013/properties/P000056.md
+++ b/spaces/S000013/properties/P000056.md
@@ -1,5 +1,4 @@
 ---
-uid: T000879
 space: S000013
 property: P000056
 value: false

--- a/spaces/S000013/properties/P000060.md
+++ b/spaces/S000013/properties/P000060.md
@@ -1,5 +1,4 @@
 ---
-uid: T000884
 space: S000013
 property: P000060
 value: true

--- a/spaces/S000014/properties/P000001.md
+++ b/spaces/S000014/properties/P000001.md
@@ -1,5 +1,4 @@
 ---
-uid: T000563
 space: S000014
 property: P000001
 value: true

--- a/spaces/S000014/properties/P000002.md
+++ b/spaces/S000014/properties/P000002.md
@@ -1,5 +1,4 @@
 ---
-uid: T000565
 space: S000014
 property: P000002
 value: false

--- a/spaces/S000014/properties/P000013.md
+++ b/spaces/S000014/properties/P000013.md
@@ -1,5 +1,4 @@
 ---
-uid: T000564
 space: S000014
 property: P000013
 value: true

--- a/spaces/S000014/properties/P000014.md
+++ b/spaces/S000014/properties/P000014.md
@@ -1,5 +1,4 @@
 ---
-uid: T000566
 space: S000014
 property: P000014
 value: true

--- a/spaces/S000014/properties/P000016.md
+++ b/spaces/S000014/properties/P000016.md
@@ -1,5 +1,4 @@
 ---
-uid: T000567
 space: S000014
 property: P000016
 value: true

--- a/spaces/S000014/properties/P000026.md
+++ b/spaces/S000014/properties/P000026.md
@@ -1,5 +1,4 @@
 ---
-uid: T000569
 space: S000014
 property: P000026
 value: false

--- a/spaces/S000014/properties/P000028.md
+++ b/spaces/S000014/properties/P000028.md
@@ -1,5 +1,4 @@
 ---
-uid: T000568
 space: S000014
 property: P000028
 value: true

--- a/spaces/S000014/properties/P000029.md
+++ b/spaces/S000014/properties/P000029.md
@@ -1,5 +1,4 @@
 ---
-uid: T000888
 space: S000014
 property: P000029
 value: false

--- a/spaces/S000014/properties/P000034.md
+++ b/spaces/S000014/properties/P000034.md
@@ -1,5 +1,4 @@
 ---
-uid: T000889
 space: S000014
 property: P000034
 value: true

--- a/spaces/S000014/properties/P000036.md
+++ b/spaces/S000014/properties/P000036.md
@@ -1,5 +1,4 @@
 ---
-uid: T000885
 space: S000014
 property: P000036
 value: false

--- a/spaces/S000014/properties/P000042.md
+++ b/spaces/S000014/properties/P000042.md
@@ -1,5 +1,4 @@
 ---
-uid: T000571
 space: S000014
 property: P000042
 value: true

--- a/spaces/S000014/properties/P000043.md
+++ b/spaces/S000014/properties/P000043.md
@@ -1,5 +1,4 @@
 ---
-uid: T000572
 space: S000014
 property: P000043
 value: false

--- a/spaces/S000014/properties/P000051.md
+++ b/spaces/S000014/properties/P000051.md
@@ -1,5 +1,4 @@
 ---
-uid: T000573
 space: S000014
 property: P000051
 value: true

--- a/spaces/S000014/properties/P000054.md
+++ b/spaces/S000014/properties/P000054.md
@@ -1,5 +1,4 @@
 ---
-uid: T000893
 space: S000014
 property: P000054
 value: false

--- a/spaces/S000014/properties/P000056.md
+++ b/spaces/S000014/properties/P000056.md
@@ -1,5 +1,4 @@
 ---
-uid: T000570
 space: S000014
 property: P000056
 value: false

--- a/spaces/S000014/properties/P000058.md
+++ b/spaces/S000014/properties/P000058.md
@@ -1,5 +1,4 @@
 ---
-uid: T000887
 space: S000014
 property: P000058
 value: false

--- a/spaces/S000014/properties/P000059.md
+++ b/spaces/S000014/properties/P000059.md
@@ -1,5 +1,4 @@
 ---
-uid: T000886
 space: S000014
 property: P000059
 value: true

--- a/spaces/S000015/properties/P000002.md
+++ b/spaces/S000015/properties/P000002.md
@@ -1,5 +1,4 @@
 ---
-uid: T000576
 space: S000015
 property: P000002
 value: true

--- a/spaces/S000015/properties/P000016.md
+++ b/spaces/S000015/properties/P000016.md
@@ -1,5 +1,4 @@
 ---
-uid: T000575
 space: S000015
 property: P000016
 value: true

--- a/spaces/S000015/properties/P000020.md
+++ b/spaces/S000015/properties/P000020.md
@@ -1,5 +1,4 @@
 ---
-uid: T000890
 space: S000015
 property: P000020
 value: true

--- a/spaces/S000015/properties/P000027.md
+++ b/spaces/S000015/properties/P000027.md
@@ -1,5 +1,4 @@
 ---
-uid: T000894
 space: S000015
 property: P000027
 value: true

--- a/spaces/S000015/properties/P000037.md
+++ b/spaces/S000015/properties/P000037.md
@@ -1,5 +1,4 @@
 ---
-uid: T000578
 space: S000015
 property: P000037
 value: false

--- a/spaces/S000015/properties/P000039.md
+++ b/spaces/S000015/properties/P000039.md
@@ -1,5 +1,4 @@
 ---
-uid: T000577
 space: S000015
 property: P000039
 value: true

--- a/spaces/S000015/properties/P000044.md
+++ b/spaces/S000015/properties/P000044.md
@@ -1,5 +1,4 @@
 ---
-uid: T000897
 space: S000015
 property: P000044
 value: false

--- a/spaces/S000015/properties/P000046.md
+++ b/spaces/S000015/properties/P000046.md
@@ -1,5 +1,4 @@
 ---
-uid: T000898
 space: S000015
 property: P000046
 value: true

--- a/spaces/S000015/properties/P000056.md
+++ b/spaces/S000015/properties/P000056.md
@@ -1,5 +1,4 @@
 ---
-uid: T000895
 space: S000015
 property: P000056
 value: true

--- a/spaces/S000015/properties/P000057.md
+++ b/spaces/S000015/properties/P000057.md
@@ -1,5 +1,4 @@
 ---
-uid: T000860
 space: S000015
 property: P000057
 value: true

--- a/spaces/S000016/properties/P000002.md
+++ b/spaces/S000016/properties/P000002.md
@@ -1,5 +1,4 @@
 ---
-uid: T000583
 space: S000016
 property: P000002
 value: true

--- a/spaces/S000016/properties/P000015.md
+++ b/spaces/S000016/properties/P000015.md
@@ -1,5 +1,4 @@
 ---
-uid: T000580
 space: S000016
 property: P000015
 value: false

--- a/spaces/S000016/properties/P000016.md
+++ b/spaces/S000016/properties/P000016.md
@@ -1,5 +1,4 @@
 ---
-uid: T000579
 space: S000016
 property: P000016
 value: true

--- a/spaces/S000016/properties/P000020.md
+++ b/spaces/S000016/properties/P000020.md
@@ -1,5 +1,4 @@
 ---
-uid: T000891
 space: S000016
 property: P000020
 value: true

--- a/spaces/S000016/properties/P000026.md
+++ b/spaces/S000016/properties/P000026.md
@@ -1,5 +1,4 @@
 ---
-uid: T000582
 space: S000016
 property: P000026
 value: true

--- a/spaces/S000016/properties/P000028.md
+++ b/spaces/S000016/properties/P000028.md
@@ -1,5 +1,4 @@
 ---
-uid: T000581
 space: S000016
 property: P000028
 value: false

--- a/spaces/S000016/properties/P000038.md
+++ b/spaces/S000016/properties/P000038.md
@@ -1,5 +1,4 @@
 ---
-uid: T000923
 space: S000016
 property: P000038
 value: true

--- a/spaces/S000016/properties/P000039.md
+++ b/spaces/S000016/properties/P000039.md
@@ -1,5 +1,4 @@
 ---
-uid: T000584
 space: S000016
 property: P000039
 value: true

--- a/spaces/S000016/properties/P000043.md
+++ b/spaces/S000016/properties/P000043.md
@@ -1,5 +1,4 @@
 ---
-uid: T000922
 space: S000016
 property: P000043
 value: true

--- a/spaces/S000016/properties/P000044.md
+++ b/spaces/S000016/properties/P000044.md
@@ -1,5 +1,4 @@
 ---
-uid: T000899
 space: S000016
 property: P000044
 value: false

--- a/spaces/S000016/properties/P000054.md
+++ b/spaces/S000016/properties/P000054.md
@@ -1,5 +1,4 @@
 ---
-uid: T000969
 space: S000016
 property: P000054
 value: false

--- a/spaces/S000016/properties/P000056.md
+++ b/spaces/S000016/properties/P000056.md
@@ -1,5 +1,4 @@
 ---
-uid: T000896
 space: S000016
 property: P000056
 value: false

--- a/spaces/S000016/properties/P000057.md
+++ b/spaces/S000016/properties/P000057.md
@@ -1,5 +1,4 @@
 ---
-uid: T000900
 space: S000016
 property: P000057
 value: false

--- a/spaces/S000016/properties/P000059.md
+++ b/spaces/S000016/properties/P000059.md
@@ -1,5 +1,4 @@
 ---
-uid: T000921
 space: S000016
 property: P000059
 value: true

--- a/spaces/S000017/properties/P000002.md
+++ b/spaces/S000017/properties/P000002.md
@@ -1,5 +1,4 @@
 ---
-uid: T000090
 space: S000017
 property: P000002
 value: true

--- a/spaces/S000017/properties/P000003.md
+++ b/spaces/S000017/properties/P000003.md
@@ -1,5 +1,4 @@
 ---
-uid: T000091
 space: S000017
 property: P000003
 value: false

--- a/spaces/S000017/properties/P000017.md
+++ b/spaces/S000017/properties/P000017.md
@@ -1,5 +1,4 @@
 ---
-uid: T000094
 space: S000017
 property: P000017
 value: false

--- a/spaces/S000017/properties/P000018.md
+++ b/spaces/S000017/properties/P000018.md
@@ -1,5 +1,4 @@
 ---
-uid: T000092
 space: S000017
 property: P000018
 value: true

--- a/spaces/S000017/properties/P000019.md
+++ b/spaces/S000017/properties/P000019.md
@@ -1,5 +1,4 @@
 ---
-uid: T000093
 space: S000017
 property: P000019
 value: false

--- a/spaces/S000017/properties/P000026.md
+++ b/spaces/S000017/properties/P000026.md
@@ -1,5 +1,4 @@
 ---
-uid: T000585
 space: S000017
 property: P000026
 value: false

--- a/spaces/S000017/properties/P000028.md
+++ b/spaces/S000017/properties/P000028.md
@@ -1,5 +1,4 @@
 ---
-uid: T000095
 space: S000017
 property: P000028
 value: false

--- a/spaces/S000017/properties/P000029.md
+++ b/spaces/S000017/properties/P000029.md
@@ -1,5 +1,4 @@
 ---
-uid: T000586
 space: S000017
 property: P000029
 value: true

--- a/spaces/S000017/properties/P000033.md
+++ b/spaces/S000017/properties/P000033.md
@@ -1,5 +1,4 @@
 ---
-uid: T000588
 space: S000017
 property: P000033
 value: false

--- a/spaces/S000017/properties/P000037.md
+++ b/spaces/S000017/properties/P000037.md
@@ -1,5 +1,4 @@
 ---
-uid: T000970
 space: S000017
 property: P000037
 value: false

--- a/spaces/S000017/properties/P000039.md
+++ b/spaces/S000017/properties/P000039.md
@@ -1,5 +1,4 @@
 ---
-uid: T000587
 space: S000017
 property: P000039
 value: true

--- a/spaces/S000017/properties/P000044.md
+++ b/spaces/S000017/properties/P000044.md
@@ -1,5 +1,4 @@
 ---
-uid: T000972
 space: S000017
 property: P000044
 value: false

--- a/spaces/S000017/properties/P000046.md
+++ b/spaces/S000017/properties/P000046.md
@@ -1,5 +1,4 @@
 ---
-uid: T000971
 space: S000017
 property: P000046
 value: true

--- a/spaces/S000017/properties/P000054.md
+++ b/spaces/S000017/properties/P000054.md
@@ -1,5 +1,4 @@
 ---
-uid: T000974
 space: S000017
 property: P000054
 value: false

--- a/spaces/S000017/properties/P000056.md
+++ b/spaces/S000017/properties/P000056.md
@@ -1,5 +1,4 @@
 ---
-uid: T000976
 space: S000017
 property: P000056
 value: false

--- a/spaces/S000018/properties/P000001.md
+++ b/spaces/S000018/properties/P000001.md
@@ -1,5 +1,4 @@
 ---
-uid: T000589
 space: S000018
 property: P000001
 value: false

--- a/spaces/S000018/properties/P000011.md
+++ b/spaces/S000018/properties/P000011.md
@@ -1,5 +1,4 @@
 ---
-uid: T000932
 space: S000018
 property: P000011
 value: false

--- a/spaces/S000018/properties/P000013.md
+++ b/spaces/S000018/properties/P000013.md
@@ -1,5 +1,4 @@
 ---
-uid: T000936
 space: S000018
 property: P000013
 value: false

--- a/spaces/S000018/properties/P000017.md
+++ b/spaces/S000018/properties/P000017.md
@@ -1,5 +1,4 @@
 ---
-uid: T000933
 space: S000018
 property: P000017
 value: false

--- a/spaces/S000018/properties/P000018.md
+++ b/spaces/S000018/properties/P000018.md
@@ -1,5 +1,4 @@
 ---
-uid: T000925
 space: S000018
 property: P000018
 value: true

--- a/spaces/S000018/properties/P000021.md
+++ b/spaces/S000018/properties/P000021.md
@@ -1,5 +1,4 @@
 ---
-uid: T000590
 space: S000018
 property: P000021
 value: true

--- a/spaces/S000018/properties/P000026.md
+++ b/spaces/S000018/properties/P000026.md
@@ -1,5 +1,4 @@
 ---
-uid: T000934
 space: S000018
 property: P000026
 value: false

--- a/spaces/S000018/properties/P000028.md
+++ b/spaces/S000018/properties/P000028.md
@@ -1,5 +1,4 @@
 ---
-uid: T000980
 space: S000018
 property: P000028
 value: false

--- a/spaces/S000018/properties/P000029.md
+++ b/spaces/S000018/properties/P000029.md
@@ -1,5 +1,4 @@
 ---
-uid: T000926
 space: S000018
 property: P000029
 value: true

--- a/spaces/S000018/properties/P000033.md
+++ b/spaces/S000018/properties/P000033.md
@@ -1,5 +1,4 @@
 ---
-uid: T000927
 space: S000018
 property: P000033
 value: false

--- a/spaces/S000018/properties/P000037.md
+++ b/spaces/S000018/properties/P000037.md
@@ -1,5 +1,4 @@
 ---
-uid: T000979
 space: S000018
 property: P000037
 value: false

--- a/spaces/S000018/properties/P000039.md
+++ b/spaces/S000018/properties/P000039.md
@@ -1,5 +1,4 @@
 ---
-uid: T000924
 space: S000018
 property: P000039
 value: true

--- a/spaces/S000018/properties/P000042.md
+++ b/spaces/S000018/properties/P000042.md
@@ -1,5 +1,4 @@
 ---
-uid: T000978
 space: S000018
 property: P000042
 value: false

--- a/spaces/S000018/properties/P000044.md
+++ b/spaces/S000018/properties/P000044.md
@@ -1,5 +1,4 @@
 ---
-uid: T000973
 space: S000018
 property: P000044
 value: false

--- a/spaces/S000018/properties/P000046.md
+++ b/spaces/S000018/properties/P000046.md
@@ -1,5 +1,4 @@
 ---
-uid: T000928
 space: S000018
 property: P000046
 value: false

--- a/spaces/S000018/properties/P000051.md
+++ b/spaces/S000018/properties/P000051.md
@@ -1,5 +1,4 @@
 ---
-uid: T000981
 space: S000018
 property: P000051
 value: false

--- a/spaces/S000018/properties/P000054.md
+++ b/spaces/S000018/properties/P000054.md
@@ -1,5 +1,4 @@
 ---
-uid: T000975
 space: S000018
 property: P000054
 value: false

--- a/spaces/S000018/properties/P000056.md
+++ b/spaces/S000018/properties/P000056.md
@@ -1,5 +1,4 @@
 ---
-uid: T000977
 space: S000018
 property: P000056
 value: false

--- a/spaces/S000018/properties/P000057.md
+++ b/spaces/S000018/properties/P000057.md
@@ -1,5 +1,4 @@
 ---
-uid: T000861
 space: S000018
 property: P000057
 value: false

--- a/spaces/S000019/properties/P000002.md
+++ b/spaces/S000019/properties/P000002.md
@@ -1,5 +1,4 @@
 ---
-uid: T000591
 space: S000019
 property: P000002
 value: true

--- a/spaces/S000019/properties/P000003.md
+++ b/spaces/S000019/properties/P000003.md
@@ -1,5 +1,4 @@
 ---
-uid: T000592
 space: S000019
 property: P000003
 value: false

--- a/spaces/S000019/properties/P000016.md
+++ b/spaces/S000019/properties/P000016.md
@@ -1,5 +1,4 @@
 ---
-uid: T000594
 space: S000019
 property: P000016
 value: true

--- a/spaces/S000019/properties/P000027.md
+++ b/spaces/S000019/properties/P000027.md
@@ -1,5 +1,4 @@
 ---
-uid: T000596
 space: S000019
 property: P000027
 value: true

--- a/spaces/S000019/properties/P000028.md
+++ b/spaces/S000019/properties/P000028.md
@@ -1,5 +1,4 @@
 ---
-uid: T000595
 space: S000019
 property: P000028
 value: true

--- a/spaces/S000019/properties/P000038.md
+++ b/spaces/S000019/properties/P000038.md
@@ -1,5 +1,4 @@
 ---
-uid: T000930
 space: S000019
 property: P000038
 value: true

--- a/spaces/S000019/properties/P000039.md
+++ b/spaces/S000019/properties/P000039.md
@@ -1,5 +1,4 @@
 ---
-uid: T000593
 space: S000019
 property: P000039
 value: true

--- a/spaces/S000019/properties/P000043.md
+++ b/spaces/S000019/properties/P000043.md
@@ -1,5 +1,4 @@
 ---
-uid: T000929
 space: S000019
 property: P000043
 value: true

--- a/spaces/S000019/properties/P000044.md
+++ b/spaces/S000019/properties/P000044.md
@@ -1,5 +1,4 @@
 ---
-uid: T000935
 space: S000019
 property: P000044
 value: false

--- a/spaces/S000019/properties/P000056.md
+++ b/spaces/S000019/properties/P000056.md
@@ -1,5 +1,4 @@
 ---
-uid: T001006
 space: S000019
 property: P000056
 value: true

--- a/spaces/S000019/properties/P000059.md
+++ b/spaces/S000019/properties/P000059.md
@@ -1,5 +1,4 @@
 ---
-uid: T000931
 space: S000019
 property: P000059
 value: true

--- a/spaces/S000020/properties/P000002.md
+++ b/spaces/S000020/properties/P000002.md
@@ -1,5 +1,4 @@
 ---
-uid: T000597
 space: S000020
 property: P000002
 value: true

--- a/spaces/S000020/properties/P000016.md
+++ b/spaces/S000020/properties/P000016.md
@@ -1,5 +1,4 @@
 ---
-uid: T000600
 space: S000020
 property: P000016
 value: true

--- a/spaces/S000020/properties/P000020.md
+++ b/spaces/S000020/properties/P000020.md
@@ -1,5 +1,4 @@
 ---
-uid: T000601
 space: S000020
 property: P000020
 value: true

--- a/spaces/S000020/properties/P000027.md
+++ b/spaces/S000020/properties/P000027.md
@@ -1,5 +1,4 @@
 ---
-uid: T000602
 space: S000020
 property: P000027
 value: true

--- a/spaces/S000020/properties/P000048.md
+++ b/spaces/S000020/properties/P000048.md
@@ -1,5 +1,4 @@
 ---
-uid: T000603
 space: S000020
 property: P000048
 value: true

--- a/spaces/S000020/properties/P000049.md
+++ b/spaces/S000020/properties/P000049.md
@@ -1,5 +1,4 @@
 ---
-uid: T000604
 space: S000020
 property: P000049
 value: false

--- a/spaces/S000020/properties/P000050.md
+++ b/spaces/S000020/properties/P000050.md
@@ -1,5 +1,4 @@
 ---
-uid: T000606
 space: S000020
 property: P000050
 value: true

--- a/spaces/S000020/properties/P000051.md
+++ b/spaces/S000020/properties/P000051.md
@@ -1,5 +1,4 @@
 ---
-uid: T000605
 space: S000020
 property: P000051
 value: true

--- a/spaces/S000020/properties/P000057.md
+++ b/spaces/S000020/properties/P000057.md
@@ -1,5 +1,4 @@
 ---
-uid: T000862
 space: S000020
 property: P000057
 value: true

--- a/spaces/S000022/properties/P000008.md
+++ b/spaces/S000022/properties/P000008.md
@@ -1,5 +1,4 @@
 ---
-uid: T000618
 space: S000022
 property: P000008
 value: true

--- a/spaces/S000022/properties/P000015.md
+++ b/spaces/S000022/properties/P000015.md
@@ -1,5 +1,4 @@
 ---
-uid: T000983
 space: S000022
 property: P000015
 value: false

--- a/spaces/S000022/properties/P000016.md
+++ b/spaces/S000022/properties/P000016.md
@@ -1,5 +1,4 @@
 ---
-uid: T000620
 space: S000022
 property: P000016
 value: false

--- a/spaces/S000022/properties/P000017.md
+++ b/spaces/S000022/properties/P000017.md
@@ -1,5 +1,4 @@
 ---
-uid: T000624
 space: S000022
 property: P000017
 value: false

--- a/spaces/S000022/properties/P000018.md
+++ b/spaces/S000022/properties/P000018.md
@@ -1,5 +1,4 @@
 ---
-uid: T000619
 space: S000022
 property: P000018
 value: true

--- a/spaces/S000022/properties/P000022.md
+++ b/spaces/S000022/properties/P000022.md
@@ -1,5 +1,4 @@
 ---
-uid: T000625
 space: S000022
 property: P000022
 value: false

--- a/spaces/S000022/properties/P000026.md
+++ b/spaces/S000022/properties/P000026.md
@@ -1,5 +1,4 @@
 ---
-uid: T000621
 space: S000022
 property: P000026
 value: false

--- a/spaces/S000022/properties/P000028.md
+++ b/spaces/S000022/properties/P000028.md
@@ -1,5 +1,4 @@
 ---
-uid: T000622
 space: S000022
 property: P000028
 value: false

--- a/spaces/S000022/properties/P000029.md
+++ b/spaces/S000022/properties/P000029.md
@@ -1,5 +1,4 @@
 ---
-uid: T000982
 space: S000022
 property: P000029
 value: false

--- a/spaces/S000022/properties/P000030.md
+++ b/spaces/S000022/properties/P000030.md
@@ -1,5 +1,4 @@
 ---
-uid: T000623
 space: S000022
 property: P000030
 value: true

--- a/spaces/S000022/properties/P000049.md
+++ b/spaces/S000022/properties/P000049.md
@@ -1,5 +1,4 @@
 ---
-uid: T001356
 space: S000022
 property: P000049
 value: false

--- a/spaces/S000022/properties/P000050.md
+++ b/spaces/S000022/properties/P000050.md
@@ -1,5 +1,4 @@
 ---
-uid: T000937
 space: S000022
 property: P000050
 value: true

--- a/spaces/S000022/properties/P000051.md
+++ b/spaces/S000022/properties/P000051.md
@@ -1,5 +1,4 @@
 ---
-uid: T001355
 space: S000022
 property: P000051
 value: true

--- a/spaces/S000022/properties/P000056.md
+++ b/spaces/S000022/properties/P000056.md
@@ -1,5 +1,4 @@
 ---
-uid: T001358
 space: S000022
 property: P000056
 value: false

--- a/spaces/S000023/properties/P000003.md
+++ b/spaces/S000023/properties/P000003.md
@@ -1,5 +1,4 @@
 ---
-uid: T000626
 space: S000023
 property: P000003
 value: true

--- a/spaces/S000023/properties/P000022.md
+++ b/spaces/S000023/properties/P000022.md
@@ -1,5 +1,4 @@
 ---
-uid: T000901
 space: S000023
 property: P000022
 value: false

--- a/spaces/S000023/properties/P000023.md
+++ b/spaces/S000023/properties/P000023.md
@@ -1,5 +1,4 @@
 ---
-uid: T000629
 space: S000023
 property: P000023
 value: false

--- a/spaces/S000023/properties/P000028.md
+++ b/spaces/S000023/properties/P000028.md
@@ -1,5 +1,4 @@
 ---
-uid: T000628
 space: S000023
 property: P000028
 value: false

--- a/spaces/S000023/properties/P000030.md
+++ b/spaces/S000023/properties/P000030.md
@@ -1,5 +1,4 @@
 ---
-uid: T000631
 space: S000023
 property: P000030
 value: true

--- a/spaces/S000023/properties/P000041.md
+++ b/spaces/S000023/properties/P000041.md
@@ -1,5 +1,4 @@
 ---
-uid: T000632
 space: S000023
 property: P000041
 value: false

--- a/spaces/S000023/properties/P000049.md
+++ b/spaces/S000023/properties/P000049.md
@@ -1,5 +1,4 @@
 ---
-uid: T000636
 space: S000023
 property: P000049
 value: false

--- a/spaces/S000023/properties/P000050.md
+++ b/spaces/S000023/properties/P000050.md
@@ -1,5 +1,4 @@
 ---
-uid: T000633
 space: S000023
 property: P000050
 value: true

--- a/spaces/S000023/properties/P000051.md
+++ b/spaces/S000023/properties/P000051.md
@@ -1,5 +1,4 @@
 ---
-uid: T000634
 space: S000023
 property: P000051
 value: true

--- a/spaces/S000023/properties/P000056.md
+++ b/spaces/S000023/properties/P000056.md
@@ -1,5 +1,4 @@
 ---
-uid: T000635
 space: S000023
 property: P000056
 value: false

--- a/spaces/S000023/properties/P000057.md
+++ b/spaces/S000023/properties/P000057.md
@@ -1,5 +1,4 @@
 ---
-uid: T000902
 space: S000023
 property: P000057
 value: true

--- a/spaces/S000024/properties/P000002.md
+++ b/spaces/S000024/properties/P000002.md
@@ -1,5 +1,4 @@
 ---
-uid: T000638
 space: S000024
 property: P000002
 value: true

--- a/spaces/S000024/properties/P000003.md
+++ b/spaces/S000024/properties/P000003.md
@@ -1,5 +1,4 @@
 ---
-uid: T000639
 space: S000024
 property: P000003
 value: false

--- a/spaces/S000024/properties/P000016.md
+++ b/spaces/S000024/properties/P000016.md
@@ -1,5 +1,4 @@
 ---
-uid: T000637
 space: S000024
 property: P000016
 value: true

--- a/spaces/S000024/properties/P000028.md
+++ b/spaces/S000024/properties/P000028.md
@@ -1,5 +1,4 @@
 ---
-uid: T000919
 space: S000024
 property: P000028
 value: false

--- a/spaces/S000024/properties/P000029.md
+++ b/spaces/S000024/properties/P000029.md
@@ -1,5 +1,4 @@
 ---
-uid: T000918
 space: S000024
 property: P000029
 value: false

--- a/spaces/S000024/properties/P000047.md
+++ b/spaces/S000024/properties/P000047.md
@@ -1,5 +1,4 @@
 ---
-uid: T000640
 space: S000024
 property: P000047
 value: true

--- a/spaces/S000024/properties/P000051.md
+++ b/spaces/S000024/properties/P000051.md
@@ -1,5 +1,4 @@
 ---
-uid: T000641
 space: S000024
 property: P000051
 value: true

--- a/spaces/S000024/properties/P000054.md
+++ b/spaces/S000024/properties/P000054.md
@@ -1,5 +1,4 @@
 ---
-uid: T001357
 space: S000024
 property: P000054
 value: false

--- a/spaces/S000024/properties/P000056.md
+++ b/spaces/S000024/properties/P000056.md
@@ -1,5 +1,4 @@
 ---
-uid: T001359
 space: S000024
 property: P000056
 value: false

--- a/spaces/S000025/properties/P000019.md
+++ b/spaces/S000025/properties/P000019.md
@@ -1,5 +1,4 @@
 ---
-uid: T000646
 space: S000025
 property: P000019
 value: false

--- a/spaces/S000025/properties/P000022.md
+++ b/spaces/S000025/properties/P000022.md
@@ -1,5 +1,4 @@
 ---
-uid: T000907
 space: S000025
 property: P000022
 value: false

--- a/spaces/S000025/properties/P000023.md
+++ b/spaces/S000025/properties/P000023.md
@@ -1,5 +1,4 @@
 ---
-uid: T000647
 space: S000025
 property: P000023
 value: true

--- a/spaces/S000025/properties/P000024.md
+++ b/spaces/S000025/properties/P000024.md
@@ -1,5 +1,4 @@
 ---
-uid: T000908
 space: S000025
 property: P000024
 value: true

--- a/spaces/S000025/properties/P000027.md
+++ b/spaces/S000025/properties/P000027.md
@@ -1,5 +1,4 @@
 ---
-uid: T000645
 space: S000025
 property: P000027
 value: true

--- a/spaces/S000025/properties/P000036.md
+++ b/spaces/S000025/properties/P000036.md
@@ -1,5 +1,4 @@
 ---
-uid: T000910
 space: S000025
 property: P000036
 value: true

--- a/spaces/S000025/properties/P000038.md
+++ b/spaces/S000025/properties/P000038.md
@@ -1,5 +1,4 @@
 ---
-uid: T000984
 space: S000025
 property: P000038
 value: true

--- a/spaces/S000025/properties/P000043.md
+++ b/spaces/S000025/properties/P000043.md
@@ -1,5 +1,4 @@
 ---
-uid: T000909
 space: S000025
 property: P000043
 value: true

--- a/spaces/S000025/properties/P000053.md
+++ b/spaces/S000025/properties/P000053.md
@@ -1,5 +1,4 @@
 ---
-uid: T000643
 space: S000025
 property: P000053
 value: true

--- a/spaces/S000025/properties/P000056.md
+++ b/spaces/S000025/properties/P000056.md
@@ -1,5 +1,4 @@
 ---
-uid: T000644
 space: S000025
 property: P000056
 value: false

--- a/spaces/S000026/properties/P000016.md
+++ b/spaces/S000026/properties/P000016.md
@@ -1,5 +1,4 @@
 ---
-uid: T000648
 space: S000026
 property: P000016
 value: true

--- a/spaces/S000026/properties/P000048.md
+++ b/spaces/S000026/properties/P000048.md
@@ -1,5 +1,4 @@
 ---
-uid: T000651
 space: S000026
 property: P000048
 value: true

--- a/spaces/S000026/properties/P000050.md
+++ b/spaces/S000026/properties/P000050.md
@@ -1,5 +1,4 @@
 ---
-uid: T000906
 space: S000026
 property: P000050
 value: true

--- a/spaces/S000026/properties/P000051.md
+++ b/spaces/S000026/properties/P000051.md
@@ -1,5 +1,4 @@
 ---
-uid: T000650
 space: S000026
 property: P000051
 value: false

--- a/spaces/S000026/properties/P000055.md
+++ b/spaces/S000026/properties/P000055.md
@@ -1,5 +1,4 @@
 ---
-uid: T000649
 space: S000026
 property: P000055
 value: true

--- a/spaces/S000026/properties/P000058.md
+++ b/spaces/S000026/properties/P000058.md
@@ -1,5 +1,4 @@
 ---
-uid: T000905
 space: S000026
 property: P000058
 value: false

--- a/spaces/S000027/properties/P000022.md
+++ b/spaces/S000027/properties/P000022.md
@@ -1,5 +1,4 @@
 ---
-uid: T000904
 space: S000027
 property: P000022
 value: false

--- a/spaces/S000027/properties/P000048.md
+++ b/spaces/S000027/properties/P000048.md
@@ -1,5 +1,4 @@
 ---
-uid: T000655
 space: S000027
 property: P000048
 value: true

--- a/spaces/S000027/properties/P000050.md
+++ b/spaces/S000027/properties/P000050.md
@@ -1,5 +1,4 @@
 ---
-uid: T000657
 space: S000027
 property: P000050
 value: true

--- a/spaces/S000027/properties/P000051.md
+++ b/spaces/S000027/properties/P000051.md
@@ -1,5 +1,4 @@
 ---
-uid: T000656
 space: S000027
 property: P000051
 value: false

--- a/spaces/S000027/properties/P000053.md
+++ b/spaces/S000027/properties/P000053.md
@@ -1,5 +1,4 @@
 ---
-uid: T000652
 space: S000027
 property: P000053
 value: true

--- a/spaces/S000027/properties/P000056.md
+++ b/spaces/S000027/properties/P000056.md
@@ -1,5 +1,4 @@
 ---
-uid: T000653
 space: S000027
 property: P000056
 value: true

--- a/spaces/S000027/properties/P000057.md
+++ b/spaces/S000027/properties/P000057.md
@@ -1,5 +1,4 @@
 ---
-uid: T000654
 space: S000027
 property: P000057
 value: true

--- a/spaces/S000028/properties/P000017.md
+++ b/spaces/S000028/properties/P000017.md
@@ -1,5 +1,4 @@
 ---
-uid: T000916
 space: S000028
 property: P000017
 value: false

--- a/spaces/S000028/properties/P000022.md
+++ b/spaces/S000028/properties/P000022.md
@@ -1,5 +1,4 @@
 ---
-uid: T000917
 space: S000028
 property: P000022
 value: false

--- a/spaces/S000028/properties/P000023.md
+++ b/spaces/S000028/properties/P000023.md
@@ -1,5 +1,4 @@
 ---
-uid: T000661
 space: S000028
 property: P000023
 value: false

--- a/spaces/S000028/properties/P000026.md
+++ b/spaces/S000028/properties/P000026.md
@@ -1,5 +1,4 @@
 ---
-uid: T000660
 space: S000028
 property: P000026
 value: true

--- a/spaces/S000028/properties/P000048.md
+++ b/spaces/S000028/properties/P000048.md
@@ -1,5 +1,4 @@
 ---
-uid: T000662
 space: S000028
 property: P000048
 value: true

--- a/spaces/S000028/properties/P000050.md
+++ b/spaces/S000028/properties/P000050.md
@@ -1,5 +1,4 @@
 ---
-uid: T000664
 space: S000028
 property: P000050
 value: true

--- a/spaces/S000028/properties/P000051.md
+++ b/spaces/S000028/properties/P000051.md
@@ -1,5 +1,4 @@
 ---
-uid: T000663
 space: S000028
 property: P000051
 value: false

--- a/spaces/S000028/properties/P000053.md
+++ b/spaces/S000028/properties/P000053.md
@@ -1,5 +1,4 @@
 ---
-uid: T000658
 space: S000028
 property: P000053
 value: true

--- a/spaces/S000028/properties/P000055.md
+++ b/spaces/S000028/properties/P000055.md
@@ -1,5 +1,4 @@
 ---
-uid: T000659
 space: S000028
 property: P000055
 value: true

--- a/spaces/S000028/properties/P000058.md
+++ b/spaces/S000028/properties/P000058.md
@@ -1,5 +1,4 @@
 ---
-uid: T000986
 space: S000028
 property: P000058
 value: false

--- a/spaces/S000029/properties/P000002.md
+++ b/spaces/S000029/properties/P000002.md
@@ -1,5 +1,4 @@
 ---
-uid: T000670
 space: S000029
 property: P000002
 value: true

--- a/spaces/S000029/properties/P000003.md
+++ b/spaces/S000029/properties/P000003.md
@@ -1,5 +1,4 @@
 ---
-uid: T000668
 space: S000029
 property: P000003
 value: false

--- a/spaces/S000029/properties/P000016.md
+++ b/spaces/S000029/properties/P000016.md
@@ -1,5 +1,4 @@
 ---
-uid: T000669
 space: S000029
 property: P000016
 value: true

--- a/spaces/S000029/properties/P000020.md
+++ b/spaces/S000029/properties/P000020.md
@@ -1,5 +1,4 @@
 ---
-uid: T000672
 space: S000029
 property: P000020
 value: true

--- a/spaces/S000029/properties/P000028.md
+++ b/spaces/S000029/properties/P000028.md
@@ -1,5 +1,4 @@
 ---
-uid: T001079
 space: S000029
 property: P000028
 value: false

--- a/spaces/S000029/properties/P000041.md
+++ b/spaces/S000029/properties/P000041.md
@@ -1,5 +1,4 @@
 ---
-uid: T001352
 space: S000029
 property: P000041
 value: false

--- a/spaces/S000029/properties/P000045.md
+++ b/spaces/S000029/properties/P000045.md
@@ -1,5 +1,4 @@
 ---
-uid: T000671
 space: S000029
 property: P000045
 value: true

--- a/spaces/S000029/properties/P000046.md
+++ b/spaces/S000029/properties/P000046.md
@@ -1,5 +1,4 @@
 ---
-uid: T001353
 space: S000029
 property: P000046
 value: true

--- a/spaces/S000029/properties/P000056.md
+++ b/spaces/S000029/properties/P000056.md
@@ -1,5 +1,4 @@
 ---
-uid: T001354
 space: S000029
 property: P000056
 value: true

--- a/spaces/S000029/properties/P000057.md
+++ b/spaces/S000029/properties/P000057.md
@@ -1,5 +1,4 @@
 ---
-uid: T000911
 space: S000029
 property: P000057
 value: true

--- a/spaces/S000029/properties/P000100.md
+++ b/spaces/S000029/properties/P000100.md
@@ -1,5 +1,4 @@
 ---
-uid: T000669
 space: S000029
 property: P000100
 value: true


### PR DESCRIPTION
Trying to reduce the backlog of pending issues by tackling #58.  The following command

`grep '^uid: ' S*/properties/*.md | wc -l`

shows there is a total of 1504 files to be cleaned up.  As it seems a bit much to review in a single shot, I am breaking it into more palatable chunks.  The first chunk (323 entries) was generated like this:

`sed -b -i '/^uid: /d' S0000[012]*/properties/*.md`

I'll generate further chunks after each one gets approved.  But please let me know if you have different suggestions.
