### PR TITLE
Scrub uid's from traits (issue #58), part 3

### DIFF
--- a/spaces/S000081/properties/P000006.md
+++ b/spaces/S000081/properties/P000006.md
@@ -1,5 +1,4 @@
 ---
-uid: T001097
 space: S000081
 property: P000006
 value: false

--- a/spaces/S000081/properties/P000009.md
+++ b/spaces/S000081/properties/P000009.md
@@ -1,5 +1,4 @@
 ---
-uid: T000282
 space: S000081
 property: P000009
 value: true

--- a/spaces/S000081/properties/P000010.md
+++ b/spaces/S000081/properties/P000010.md
@@ -1,5 +1,4 @@
 ---
-uid: T000283
 space: S000081
 property: P000010
 value: true

--- a/spaces/S000081/properties/P000011.md
+++ b/spaces/S000081/properties/P000011.md
@@ -1,5 +1,4 @@
 ---
-uid: T001232
 space: S000081
 property: P000011
 value: false

--- a/spaces/S000081/properties/P000018.md
+++ b/spaces/S000081/properties/P000018.md
@@ -1,5 +1,4 @@
 ---
-uid: T001234
 space: S000081
 property: P000018
 value: false

--- a/spaces/S000081/properties/P000019.md
+++ b/spaces/S000081/properties/P000019.md
@@ -1,5 +1,4 @@
 ---
-uid: T000284
 space: S000081
 property: P000019
 value: false

--- a/spaces/S000081/properties/P000028.md
+++ b/spaces/S000081/properties/P000028.md
@@ -1,5 +1,4 @@
 ---
-uid: T001250
 space: S000081
 property: P000028
 value: false

--- a/spaces/S000081/properties/P000029.md
+++ b/spaces/S000081/properties/P000029.md
@@ -1,5 +1,4 @@
 ---
-uid: T001102
 space: S000081
 property: P000029
 value: false

--- a/spaces/S000081/properties/P000031.md
+++ b/spaces/S000081/properties/P000031.md
@@ -1,5 +1,4 @@
 ---
-uid: T000285
 space: S000081
 property: P000031
 value: false

--- a/spaces/S000081/properties/P000036.md
+++ b/spaces/S000081/properties/P000036.md
@@ -1,5 +1,4 @@
 ---
-uid: T001257
 space: S000081
 property: P000036
 value: false

--- a/spaces/S000081/properties/P000041.md
+++ b/spaces/S000081/properties/P000041.md
@@ -1,5 +1,4 @@
 ---
-uid: T001263
 space: S000081
 property: P000041
 value: false

--- a/spaces/S000081/properties/P000046.md
+++ b/spaces/S000081/properties/P000046.md
@@ -1,5 +1,4 @@
 ---
-uid: T001264
 space: S000081
 property: P000046
 value: false

--- a/spaces/S000081/properties/P000056.md
+++ b/spaces/S000081/properties/P000056.md
@@ -1,5 +1,4 @@
 ---
-uid: T001274
 space: S000081
 property: P000056
 value: false

--- a/spaces/S000081/properties/P000058.md
+++ b/spaces/S000081/properties/P000058.md
@@ -1,5 +1,4 @@
 ---
-uid: T001280
 space: S000081
 property: P000058
 value: false

--- a/spaces/S000081/properties/P000059.md
+++ b/spaces/S000081/properties/P000059.md
@@ -1,5 +1,4 @@
 ---
-uid: T001284
 space: S000081
 property: P000059
 value: true

--- a/spaces/S000087/properties/P000004.md
+++ b/spaces/S000087/properties/P000004.md
@@ -1,5 +1,4 @@
 ---
-uid: T015406
 space: S000087
 property: P000004
 value: true

--- a/spaces/S000087/properties/P000011.md
+++ b/spaces/S000087/properties/P000011.md
@@ -1,5 +1,4 @@
 ---
-uid: T024280
 space: S000087
 property: P000011
 value: true

--- a/spaces/S000087/properties/P000013.md
+++ b/spaces/S000087/properties/P000013.md
@@ -1,5 +1,4 @@
 ---
-uid: T024285
 space: S000087
 property: P000013
 value: false

--- a/spaces/S000087/properties/P000021.md
+++ b/spaces/S000087/properties/P000021.md
@@ -1,5 +1,4 @@
 ---
-uid: T015411
 space: S000087
 property: P000021
 value: false

--- a/spaces/S000087/properties/P000031.md
+++ b/spaces/S000087/properties/P000031.md
@@ -1,5 +1,4 @@
 ---
-uid: T015415
 space: S000087
 property: P000031
 value: true

--- a/spaces/S000087/properties/P000032.md
+++ b/spaces/S000087/properties/P000032.md
@@ -1,5 +1,4 @@
 ---
-uid: T015417
 space: S000087
 property: P000032
 value: false

--- a/spaces/S000088/properties/P000011.md
+++ b/spaces/S000088/properties/P000011.md
@@ -1,5 +1,4 @@
 ---
-uid: T024365
 space: S000088
 property: P000011
 value: true

--- a/spaces/S000088/properties/P000013.md
+++ b/spaces/S000088/properties/P000013.md
@@ -1,5 +1,4 @@
 ---
-uid: T024367
 space: S000088
 property: P000013
 value: false

--- a/spaces/S000088/properties/P000016.md
+++ b/spaces/S000088/properties/P000016.md
@@ -1,5 +1,4 @@
 ---
-uid: T024164
 space: S000088
 property: P000016
 value: false

--- a/spaces/S000088/properties/P000022.md
+++ b/spaces/S000088/properties/P000022.md
@@ -1,5 +1,4 @@
 ---
-uid: T024165
 space: S000088
 property: P000022
 value: true

--- a/spaces/S000089/properties/P000005.md
+++ b/spaces/S000089/properties/P000005.md
@@ -1,5 +1,4 @@
 ---
-uid: T000296
 space: S000089
 property: P000005
 value: true

--- a/spaces/S000089/properties/P000006.md
+++ b/spaces/S000089/properties/P000006.md
@@ -1,5 +1,4 @@
 ---
-uid: T000298
 space: S000089
 property: P000006
 value: false

--- a/spaces/S000089/properties/P000009.md
+++ b/spaces/S000089/properties/P000009.md
@@ -1,5 +1,4 @@
 ---
-uid: T000297
 space: S000089
 property: P000009
 value: true

--- a/spaces/S000089/properties/P000021.md
+++ b/spaces/S000089/properties/P000021.md
@@ -1,5 +1,4 @@
 ---
-uid: T001187
 space: S000089
 property: P000021
 value: false

--- a/spaces/S000089/properties/P000028.md
+++ b/spaces/S000089/properties/P000028.md
@@ -1,5 +1,4 @@
 ---
-uid: T001199
 space: S000089
 property: P000028
 value: false

--- a/spaces/S000089/properties/P000029.md
+++ b/spaces/S000089/properties/P000029.md
@@ -1,5 +1,4 @@
 ---
-uid: T001105
 space: S000089
 property: P000029
 value: false

--- a/spaces/S000089/properties/P000048.md
+++ b/spaces/S000089/properties/P000048.md
@@ -1,5 +1,4 @@
 ---
-uid: T000301
 space: S000089
 property: P000048
 value: true

--- a/spaces/S000089/properties/P000049.md
+++ b/spaces/S000089/properties/P000049.md
@@ -1,5 +1,4 @@
 ---
-uid: T001210
 space: S000089
 property: P000049
 value: false

--- a/spaces/S000089/properties/P000050.md
+++ b/spaces/S000089/properties/P000050.md
@@ -1,5 +1,4 @@
 ---
-uid: T000300
 space: S000089
 property: P000050
 value: false

--- a/spaces/S000089/properties/P000051.md
+++ b/spaces/S000089/properties/P000051.md
@@ -1,5 +1,4 @@
 ---
-uid: T000302
 space: S000089
 property: P000051
 value: true

--- a/spaces/S000089/properties/P000059.md
+++ b/spaces/S000089/properties/P000059.md
@@ -1,5 +1,4 @@
 ---
-uid: T001223
 space: S000089
 property: P000059
 value: true

--- a/spaces/S000090/properties/P000005.md
+++ b/spaces/S000090/properties/P000005.md
@@ -1,5 +1,4 @@
 ---
-uid: T001098
 space: S000090
 property: P000005
 value: true

--- a/spaces/S000090/properties/P000013.md
+++ b/spaces/S000090/properties/P000013.md
@@ -1,5 +1,4 @@
 ---
-uid: T024302
 space: S000090
 property: P000013
 value: false

--- a/spaces/S000090/properties/P000016.md
+++ b/spaces/S000090/properties/P000016.md
@@ -1,5 +1,4 @@
 ---
-uid: T024144
 space: S000090
 property: P000016
 value: false

--- a/spaces/S000090/properties/P000059.md
+++ b/spaces/S000090/properties/P000059.md
@@ -1,5 +1,4 @@
 ---
-uid: T001224
 space: S000090
 property: P000059
 value: true

--- a/spaces/S000090/properties/P000060.md
+++ b/spaces/S000090/properties/P000060.md
@@ -1,5 +1,4 @@
 ---
-uid: T000963
 space: S000090
 property: P000060
 value: true

--- a/spaces/S000091/properties/P000006.md
+++ b/spaces/S000091/properties/P000006.md
@@ -1,5 +1,4 @@
 ---
-uid: T000305
 space: S000091
 property: P000006
 value: true

--- a/spaces/S000091/properties/P000007.md
+++ b/spaces/S000091/properties/P000007.md
@@ -1,5 +1,4 @@
 ---
-uid: T000306
 space: S000091
 property: P000007
 value: false

--- a/spaces/S000091/properties/P000022.md
+++ b/spaces/S000091/properties/P000022.md
@@ -1,5 +1,4 @@
 ---
-uid: T001185
 space: S000091
 property: P000022
 value: false

--- a/spaces/S000091/properties/P000024.md
+++ b/spaces/S000091/properties/P000024.md
@@ -1,5 +1,4 @@
 ---
-uid: T001190
 space: S000091
 property: P000024
 value: true

--- a/spaces/S000091/properties/P000028.md
+++ b/spaces/S000091/properties/P000028.md
@@ -1,5 +1,4 @@
 ---
-uid: T001200
 space: S000091
 property: P000028
 value: false

--- a/spaces/S000091/properties/P000029.md
+++ b/spaces/S000091/properties/P000029.md
@@ -1,5 +1,4 @@
 ---
-uid: T001106
 space: S000091
 property: P000029
 value: false

--- a/spaces/S000091/properties/P000031.md
+++ b/spaces/S000091/properties/P000031.md
@@ -1,5 +1,4 @@
 ---
-uid: T001193
 space: S000091
 property: P000031
 value: true

--- a/spaces/S000091/properties/P000032.md
+++ b/spaces/S000091/properties/P000032.md
@@ -1,5 +1,4 @@
 ---
-uid: T001196
 space: S000091
 property: P000032
 value: false

--- a/spaces/S000091/properties/P000049.md
+++ b/spaces/S000091/properties/P000049.md
@@ -1,5 +1,4 @@
 ---
-uid: T001211
 space: S000091
 property: P000049
 value: false

--- a/spaces/S000091/properties/P000050.md
+++ b/spaces/S000091/properties/P000050.md
@@ -1,5 +1,4 @@
 ---
-uid: T000304
 space: S000091
 property: P000050
 value: true

--- a/spaces/S000091/properties/P000051.md
+++ b/spaces/S000091/properties/P000051.md
@@ -1,5 +1,4 @@
 ---
-uid: T001212
 space: S000091
 property: P000051
 value: true

--- a/spaces/S000091/properties/P000058.md
+++ b/spaces/S000091/properties/P000058.md
@@ -1,5 +1,4 @@
 ---
-uid: T001217
 space: S000091
 property: P000058
 value: false

--- a/spaces/S000091/properties/P000059.md
+++ b/spaces/S000091/properties/P000059.md
@@ -1,5 +1,4 @@
 ---
-uid: T001225
 space: S000091
 property: P000059
 value: true

--- a/spaces/S000092/properties/P000011.md
+++ b/spaces/S000092/properties/P000011.md
@@ -1,5 +1,4 @@
 ---
-uid: T024351
 space: S000092
 property: P000011
 value: true

--- a/spaces/S000092/properties/P000013.md
+++ b/spaces/S000092/properties/P000013.md
@@ -1,5 +1,4 @@
 ---
-uid: T024339
 space: S000092
 property: P000013
 value: false

--- a/spaces/S000093/properties/P000016.md
+++ b/spaces/S000093/properties/P000016.md
@@ -1,5 +1,4 @@
 ---
-uid: T026660
 space: S000093
 property: P000016
 value: true

--- a/spaces/S000093/properties/P000026.md
+++ b/spaces/S000093/properties/P000026.md
@@ -1,5 +1,4 @@
 ---
-uid: T026690
 space: S000093
 property: P000026
 value: true

--- a/spaces/S000093/properties/P000027.md
+++ b/spaces/S000093/properties/P000027.md
@@ -1,5 +1,4 @@
 ---
-uid: T026696
 space: S000093
 property: P000027
 value: false

--- a/spaces/S000093/properties/P000028.md
+++ b/spaces/S000093/properties/P000028.md
@@ -1,5 +1,4 @@
 ---
-uid: T026685
 space: S000093
 property: P000028
 value: true

--- a/spaces/S000093/properties/P000041.md
+++ b/spaces/S000093/properties/P000041.md
@@ -1,5 +1,4 @@
 ---
-uid: T026646
 space: S000093
 property: P000041
 value: false

--- a/spaces/S000093/properties/P000048.md
+++ b/spaces/S000093/properties/P000048.md
@@ -1,5 +1,4 @@
 ---
-uid: T026652
 space: S000093
 property: P000048
 value: true

--- a/spaces/S000093/properties/P000049.md
+++ b/spaces/S000093/properties/P000049.md
@@ -1,5 +1,4 @@
 ---
-uid: T026705
 space: S000093
 property: P000049
 value: false

--- a/spaces/S000093/properties/P000050.md
+++ b/spaces/S000093/properties/P000050.md
@@ -1,5 +1,4 @@
 ---
-uid: T026703
 space: S000093
 property: P000050
 value: true

--- a/spaces/S000093/properties/P000051.md
+++ b/spaces/S000093/properties/P000051.md
@@ -1,5 +1,4 @@
 ---
-uid: T026704
 space: S000093
 property: P000051
 value: false

--- a/spaces/S000093/properties/P000067.md
+++ b/spaces/S000093/properties/P000067.md
@@ -1,5 +1,4 @@
 ---
-uid: T026694
 space: S000093
 property: P000067
 value: true

--- a/spaces/S000094/properties/P000010.md
+++ b/spaces/S000094/properties/P000010.md
@@ -1,5 +1,4 @@
 ---
-uid: T001203
 space: S000094
 property: P000010
 value: false

--- a/spaces/S000094/properties/P000011.md
+++ b/spaces/S000094/properties/P000011.md
@@ -1,5 +1,4 @@
 ---
-uid: T000310
 space: S000094
 property: P000011
 value: false

--- a/spaces/S000094/properties/P000017.md
+++ b/spaces/S000094/properties/P000017.md
@@ -1,5 +1,4 @@
 ---
-uid: T000315
 space: S000094
 property: P000017
 value: false

--- a/spaces/S000094/properties/P000018.md
+++ b/spaces/S000094/properties/P000018.md
@@ -1,5 +1,4 @@
 ---
-uid: T000317
 space: S000094
 property: P000018
 value: true

--- a/spaces/S000094/properties/P000026.md
+++ b/spaces/S000094/properties/P000026.md
@@ -1,5 +1,4 @@
 ---
-uid: T000318
 space: S000094
 property: P000026
 value: true

--- a/spaces/S000094/properties/P000027.md
+++ b/spaces/S000094/properties/P000027.md
@@ -1,5 +1,4 @@
 ---
-uid: T000319
 space: S000094
 property: P000027
 value: false

--- a/spaces/S000094/properties/P000028.md
+++ b/spaces/S000094/properties/P000028.md
@@ -1,5 +1,4 @@
 ---
-uid: T000316
 space: S000094
 property: P000028
 value: true

--- a/spaces/S000094/properties/P000031.md
+++ b/spaces/S000094/properties/P000031.md
@@ -1,5 +1,4 @@
 ---
-uid: T001195
 space: S000094
 property: P000031
 value: true

--- a/spaces/S000094/properties/P000048.md
+++ b/spaces/S000094/properties/P000048.md
@@ -1,5 +1,4 @@
 ---
-uid: T000313
 space: S000094
 property: P000048
 value: true

--- a/spaces/S000094/properties/P000049.md
+++ b/spaces/S000094/properties/P000049.md
@@ -1,5 +1,4 @@
 ---
-uid: T000327
 space: S000094
 property: P000049
 value: false

--- a/spaces/S000094/properties/P000051.md
+++ b/spaces/S000094/properties/P000051.md
@@ -1,5 +1,4 @@
 ---
-uid: T000325
 space: S000094
 property: P000051
 value: false

--- a/spaces/S000094/properties/P000058.md
+++ b/spaces/S000094/properties/P000058.md
@@ -1,5 +1,4 @@
 ---
-uid: T001220
 space: S000094
 property: P000058
 value: false

--- a/spaces/S000095/properties/P000003.md
+++ b/spaces/S000095/properties/P000003.md
@@ -1,5 +1,4 @@
 ---
-uid: T000328
 space: S000095
 property: P000003
 value: true

--- a/spaces/S000095/properties/P000014.md
+++ b/spaces/S000095/properties/P000014.md
@@ -1,5 +1,4 @@
 ---
-uid: T000329
 space: S000095
 property: P000014
 value: true

--- a/spaces/S000095/properties/P000015.md
+++ b/spaces/S000095/properties/P000015.md
@@ -1,5 +1,4 @@
 ---
-uid: T001204
 space: S000095
 property: P000015
 value: false

--- a/spaces/S000095/properties/P000016.md
+++ b/spaces/S000095/properties/P000016.md
@@ -1,5 +1,4 @@
 ---
-uid: T000330
 space: S000095
 property: P000016
 value: true

--- a/spaces/S000095/properties/P000020.md
+++ b/spaces/S000095/properties/P000020.md
@@ -1,5 +1,4 @@
 ---
-uid: T000331
 space: S000095
 property: P000020
 value: true

--- a/spaces/S000095/properties/P000026.md
+++ b/spaces/S000095/properties/P000026.md
@@ -1,5 +1,4 @@
 ---
-uid: T000334
 space: S000095
 property: P000026
 value: false

--- a/spaces/S000095/properties/P000027.md
+++ b/spaces/S000095/properties/P000027.md
@@ -1,5 +1,4 @@
 ---
-uid: T000332
 space: S000095
 property: P000027
 value: false

--- a/spaces/S000095/properties/P000028.md
+++ b/spaces/S000095/properties/P000028.md
@@ -1,5 +1,4 @@
 ---
-uid: T000333
 space: S000095
 property: P000028
 value: true

--- a/spaces/S000095/properties/P000029.md
+++ b/spaces/S000095/properties/P000029.md
@@ -1,5 +1,4 @@
 ---
-uid: T001108
 space: S000095
 property: P000029
 value: false

--- a/spaces/S000095/properties/P000036.md
+++ b/spaces/S000095/properties/P000036.md
@@ -1,5 +1,4 @@
 ---
-uid: T001188
 space: S000095
 property: P000036
 value: false

--- a/spaces/S000095/properties/P000041.md
+++ b/spaces/S000095/properties/P000041.md
@@ -1,5 +1,4 @@
 ---
-uid: T001207
 space: S000095
 property: P000041
 value: false

--- a/spaces/S000095/properties/P000046.md
+++ b/spaces/S000095/properties/P000046.md
@@ -1,5 +1,4 @@
 ---
-uid: T001209
 space: S000095
 property: P000046
 value: false

--- a/spaces/S000095/properties/P000058.md
+++ b/spaces/S000095/properties/P000058.md
@@ -1,5 +1,4 @@
 ---
-uid: T001221
 space: S000095
 property: P000058
 value: false

--- a/spaces/S000095/properties/P000059.md
+++ b/spaces/S000095/properties/P000059.md
@@ -1,5 +1,4 @@
 ---
-uid: T001227
 space: S000095
 property: P000059
 value: true

--- a/spaces/S000095/properties/P000065.md
+++ b/spaces/S000095/properties/P000065.md
@@ -1,5 +1,4 @@
 ---
-uid: T026174
 space: S000095
 property: P000065
 value: true

--- a/spaces/S000096/properties/P000002.md
+++ b/spaces/S000096/properties/P000002.md
@@ -1,5 +1,4 @@
 ---
-uid: T000335
 space: S000096
 property: P000002
 value: true

--- a/spaces/S000096/properties/P000023.md
+++ b/spaces/S000096/properties/P000023.md
@@ -1,5 +1,4 @@
 ---
-uid: T000337
 space: S000096
 property: P000023
 value: false

--- a/spaces/S000096/properties/P000028.md
+++ b/spaces/S000096/properties/P000028.md
@@ -1,5 +1,4 @@
 ---
-uid: T001202
 space: S000096
 property: P000028
 value: false

--- a/spaces/S000096/properties/P000030.md
+++ b/spaces/S000096/properties/P000030.md
@@ -1,5 +1,4 @@
 ---
-uid: T001184
 space: S000096
 property: P000030
 value: true

--- a/spaces/S000096/properties/P000049.md
+++ b/spaces/S000096/properties/P000049.md
@@ -1,5 +1,4 @@
 ---
-uid: T000340
 space: S000096
 property: P000049
 value: false

--- a/spaces/S000096/properties/P000050.md
+++ b/spaces/S000096/properties/P000050.md
@@ -1,5 +1,4 @@
 ---
-uid: T000339
 space: S000096
 property: P000050
 value: true

--- a/spaces/S000096/properties/P000051.md
+++ b/spaces/S000096/properties/P000051.md
@@ -1,5 +1,4 @@
 ---
-uid: T000338
 space: S000096
 property: P000051
 value: true

--- a/spaces/S000096/properties/P000056.md
+++ b/spaces/S000096/properties/P000056.md
@@ -1,5 +1,4 @@
 ---
-uid: T001215
 space: S000096
 property: P000056
 value: false

--- a/spaces/S000096/properties/P000057.md
+++ b/spaces/S000096/properties/P000057.md
@@ -1,5 +1,4 @@
 ---
-uid: T000336
 space: S000096
 property: P000057
 value: true

--- a/spaces/S000097/properties/P000003.md
+++ b/spaces/S000097/properties/P000003.md
@@ -1,5 +1,4 @@
 ---
-uid: T000341
 space: S000097
 property: P000003
 value: false

--- a/spaces/S000097/properties/P000016.md
+++ b/spaces/S000097/properties/P000016.md
@@ -1,5 +1,4 @@
 ---
-uid: T000342
 space: S000097
 property: P000016
 value: true

--- a/spaces/S000097/properties/P000020.md
+++ b/spaces/S000097/properties/P000020.md
@@ -1,5 +1,4 @@
 ---
-uid: T001192
 space: S000097
 property: P000020
 value: true

--- a/spaces/S000097/properties/P000028.md
+++ b/spaces/S000097/properties/P000028.md
@@ -1,5 +1,4 @@
 ---
-uid: T000343
 space: S000097
 property: P000028
 value: false

--- a/spaces/S000097/properties/P000047.md
+++ b/spaces/S000097/properties/P000047.md
@@ -1,5 +1,4 @@
 ---
-uid: T000344
 space: S000097
 property: P000047
 value: true

--- a/spaces/S000097/properties/P000051.md
+++ b/spaces/S000097/properties/P000051.md
@@ -1,5 +1,4 @@
 ---
-uid: T000345
 space: S000097
 property: P000051
 value: true

--- a/spaces/S000097/properties/P000056.md
+++ b/spaces/S000097/properties/P000056.md
@@ -1,5 +1,4 @@
 ---
-uid: T001216
 space: S000097
 property: P000056
 value: false

--- a/spaces/S000097/properties/P000057.md
+++ b/spaces/S000097/properties/P000057.md
@@ -1,5 +1,4 @@
 ---
-uid: T001109
 space: S000097
 property: P000057
 value: true

--- a/spaces/S000098/properties/P000003.md
+++ b/spaces/S000098/properties/P000003.md
@@ -1,5 +1,4 @@
 ---
-uid: T000346
 space: S000098
 property: P000003
 value: true

--- a/spaces/S000098/properties/P000004.md
+++ b/spaces/S000098/properties/P000004.md
@@ -1,5 +1,4 @@
 ---
-uid: T000347
 space: S000098
 property: P000004
 value: false

--- a/spaces/S000098/properties/P000010.md
+++ b/spaces/S000098/properties/P000010.md
@@ -1,5 +1,4 @@
 ---
-uid: T000348
 space: S000098
 property: P000010
 value: true

--- a/spaces/S000098/properties/P000022.md
+++ b/spaces/S000098/properties/P000022.md
@@ -1,5 +1,4 @@
 ---
-uid: T001157
 space: S000098
 property: P000022
 value: true

--- a/spaces/S000098/properties/P000027.md
+++ b/spaces/S000098/properties/P000027.md
@@ -1,5 +1,4 @@
 ---
-uid: T001154
 space: S000098
 property: P000027
 value: true

--- a/spaces/S000098/properties/P000031.md
+++ b/spaces/S000098/properties/P000031.md
@@ -1,5 +1,4 @@
 ---
-uid: T001156
 space: S000098
 property: P000031
 value: true

--- a/spaces/S000098/properties/P000036.md
+++ b/spaces/S000098/properties/P000036.md
@@ -1,5 +1,4 @@
 ---
-uid: T001167
 space: S000098
 property: P000036
 value: false

--- a/spaces/S000098/properties/P000041.md
+++ b/spaces/S000098/properties/P000041.md
@@ -1,5 +1,4 @@
 ---
-uid: T001172
 space: S000098
 property: P000041
 value: false

--- a/spaces/S000098/properties/P000044.md
+++ b/spaces/S000098/properties/P000044.md
@@ -1,5 +1,4 @@
 ---
-uid: T001121
 space: S000098
 property: P000044
 value: false

--- a/spaces/S000098/properties/P000046.md
+++ b/spaces/S000098/properties/P000046.md
@@ -1,5 +1,4 @@
 ---
-uid: T001155
 space: S000098
 property: P000046
 value: true

--- a/spaces/S000098/properties/P000056.md
+++ b/spaces/S000098/properties/P000056.md
@@ -1,5 +1,4 @@
 ---
-uid: T001152
 space: S000098
 property: P000056
 value: false

--- a/spaces/S000098/properties/P000057.md
+++ b/spaces/S000098/properties/P000057.md
@@ -1,5 +1,4 @@
 ---
-uid: T001110
 space: S000098
 property: P000057
 value: true

--- a/spaces/S000099/properties/P000007.md
+++ b/spaces/S000099/properties/P000007.md
@@ -1,5 +1,4 @@
 ---
-uid: T000349
 space: S000099
 property: P000007
 value: true

--- a/spaces/S000099/properties/P000014.md
+++ b/spaces/S000099/properties/P000014.md
@@ -1,5 +1,4 @@
 ---
-uid: T000912
 space: S000099
 property: P000014
 value: false

--- a/spaces/S000099/properties/P000016.md
+++ b/spaces/S000099/properties/P000016.md
@@ -1,5 +1,4 @@
 ---
-uid: T000350
 space: S000099
 property: P000016
 value: true

--- a/spaces/S000099/properties/P000020.md
+++ b/spaces/S000099/properties/P000020.md
@@ -1,5 +1,4 @@
 ---
-uid: T000352
 space: S000099
 property: P000020
 value: true

--- a/spaces/S000099/properties/P000028.md
+++ b/spaces/S000099/properties/P000028.md
@@ -1,5 +1,4 @@
 ---
-uid: T000351
 space: S000099
 property: P000028
 value: false

--- a/spaces/S000099/properties/P000029.md
+++ b/spaces/S000099/properties/P000029.md
@@ -1,5 +1,4 @@
 ---
-uid: T001140
 space: S000099
 property: P000029
 value: false

--- a/spaces/S000099/properties/P000038.md
+++ b/spaces/S000099/properties/P000038.md
@@ -1,5 +1,4 @@
 ---
-uid: T000353
 space: S000099
 property: P000038
 value: true

--- a/spaces/S000099/properties/P000041.md
+++ b/spaces/S000099/properties/P000041.md
@@ -1,5 +1,4 @@
 ---
-uid: T000354
 space: S000099
 property: P000041
 value: false

--- a/spaces/S000099/properties/P000044.md
+++ b/spaces/S000099/properties/P000044.md
@@ -1,5 +1,4 @@
 ---
-uid: T001122
 space: S000099
 property: P000044
 value: false

--- a/spaces/S000099/properties/P000059.md
+++ b/spaces/S000099/properties/P000059.md
@@ -1,5 +1,4 @@
 ---
-uid: T001177
 space: S000099
 property: P000059
 value: true

--- a/spaces/S000101/properties/P000006.md
+++ b/spaces/S000101/properties/P000006.md
@@ -1,5 +1,4 @@
 ---
-uid: T015181
 space: S000101
 property: P000006
 value: true

--- a/spaces/S000101/properties/P000013.md
+++ b/spaces/S000101/properties/P000013.md
@@ -1,5 +1,4 @@
 ---
-uid: T015218
 space: S000101
 property: P000013
 value: false

--- a/spaces/S000101/properties/P000017.md
+++ b/spaces/S000101/properties/P000017.md
@@ -1,5 +1,4 @@
 ---
-uid: T015202
 space: S000101
 property: P000017
 value: false

--- a/spaces/S000101/properties/P000023.md
+++ b/spaces/S000101/properties/P000023.md
@@ -1,5 +1,4 @@
 ---
-uid: T015205
 space: S000101
 property: P000023
 value: false

--- a/spaces/S000101/properties/P000026.md
+++ b/spaces/S000101/properties/P000026.md
@@ -1,5 +1,4 @@
 ---
-uid: T015200
 space: S000101
 property: P000026
 value: true

--- a/spaces/S000101/properties/P000028.md
+++ b/spaces/S000101/properties/P000028.md
@@ -1,5 +1,4 @@
 ---
-uid: T015190
 space: S000101
 property: P000028
 value: false

--- a/spaces/S000101/properties/P000044.md
+++ b/spaces/S000101/properties/P000044.md
@@ -1,5 +1,4 @@
 ---
-uid: T001125
 space: S000101
 property: P000044
 value: false

--- a/spaces/S000101/properties/P000050.md
+++ b/spaces/S000101/properties/P000050.md
@@ -1,5 +1,4 @@
 ---
-uid: T015207
 space: S000101
 property: P000050
 value: true

--- a/spaces/S000101/properties/P000051.md
+++ b/spaces/S000101/properties/P000051.md
@@ -1,5 +1,4 @@
 ---
-uid: T015217
 space: S000101
 property: P000051
 value: false

--- a/spaces/S000102/properties/P000003.md
+++ b/spaces/S000102/properties/P000003.md
@@ -1,5 +1,4 @@
 ---
-uid: T000166
 space: S000102
 property: P000003
 value: true

--- a/spaces/S000102/properties/P000009.md
+++ b/spaces/S000102/properties/P000009.md
@@ -1,5 +1,4 @@
 ---
-uid: T000167
 space: S000102
 property: P000009
 value: true

--- a/spaces/S000102/properties/P000014.md
+++ b/spaces/S000102/properties/P000014.md
@@ -1,5 +1,4 @@
 ---
-uid: T000169
 space: S000102
 property: P000014
 value: true

--- a/spaces/S000102/properties/P000015.md
+++ b/spaces/S000102/properties/P000015.md
@@ -1,5 +1,4 @@
 ---
-uid: T001289
 space: S000102
 property: P000015
 value: true

--- a/spaces/S000102/properties/P000018.md
+++ b/spaces/S000102/properties/P000018.md
@@ -1,5 +1,4 @@
 ---
-uid: T000175
 space: S000102
 property: P000018
 value: false

--- a/spaces/S000102/properties/P000019.md
+++ b/spaces/S000102/properties/P000019.md
@@ -1,5 +1,4 @@
 ---
-uid: T000173
 space: S000102
 property: P000019
 value: false

--- a/spaces/S000102/properties/P000022.md
+++ b/spaces/S000102/properties/P000022.md
@@ -1,5 +1,4 @@
 ---
-uid: T000962
 space: S000102
 property: P000022
 value: false

--- a/spaces/S000102/properties/P000023.md
+++ b/spaces/S000102/properties/P000023.md
@@ -1,5 +1,4 @@
 ---
-uid: T000172
 space: S000102
 property: P000023
 value: false

--- a/spaces/S000102/properties/P000026.md
+++ b/spaces/S000102/properties/P000026.md
@@ -1,5 +1,4 @@
 ---
-uid: T000174
 space: S000102
 property: P000026
 value: false

--- a/spaces/S000102/properties/P000028.md
+++ b/spaces/S000102/properties/P000028.md
@@ -1,5 +1,4 @@
 ---
-uid: T001297
 space: S000102
 property: P000028
 value: true

--- a/spaces/S000102/properties/P000029.md
+++ b/spaces/S000102/properties/P000029.md
@@ -1,5 +1,4 @@
 ---
-uid: T000960
 space: S000102
 property: P000029
 value: false

--- a/spaces/S000102/properties/P000030.md
+++ b/spaces/S000102/properties/P000030.md
@@ -1,5 +1,4 @@
 ---
-uid: T000176
 space: S000102
 property: P000030
 value: true

--- a/spaces/S000102/properties/P000034.md
+++ b/spaces/S000102/properties/P000034.md
@@ -1,5 +1,4 @@
 ---
-uid: T001308
 space: S000102
 property: P000034
 value: true

--- a/spaces/S000102/properties/P000036.md
+++ b/spaces/S000102/properties/P000036.md
@@ -1,5 +1,4 @@
 ---
-uid: T001310
 space: S000102
 property: P000036
 value: false

--- a/spaces/S000102/properties/P000041.md
+++ b/spaces/S000102/properties/P000041.md
@@ -1,5 +1,4 @@
 ---
-uid: T001317
 space: S000102
 property: P000041
 value: false

--- a/spaces/S000102/properties/P000049.md
+++ b/spaces/S000102/properties/P000049.md
@@ -1,5 +1,4 @@
 ---
-uid: T001347
 space: S000102
 property: P000049
 value: false

--- a/spaces/S000102/properties/P000050.md
+++ b/spaces/S000102/properties/P000050.md
@@ -1,5 +1,4 @@
 ---
-uid: T001338
 space: S000102
 property: P000050
 value: true

--- a/spaces/S000102/properties/P000051.md
+++ b/spaces/S000102/properties/P000051.md
@@ -1,5 +1,4 @@
 ---
-uid: T001339
 space: S000102
 property: P000051
 value: false

--- a/spaces/S000102/properties/P000056.md
+++ b/spaces/S000102/properties/P000056.md
@@ -1,5 +1,4 @@
 ---
-uid: T001342
 space: S000102
 property: P000056
 value: false

--- a/spaces/S000102/properties/P000058.md
+++ b/spaces/S000102/properties/P000058.md
@@ -1,5 +1,4 @@
 ---
-uid: T001333
 space: S000102
 property: P000058
 value: false

--- a/spaces/S000102/properties/P000059.md
+++ b/spaces/S000102/properties/P000059.md
@@ -1,5 +1,4 @@
 ---
-uid: T001345
 space: S000102
 property: P000059
 value: true

--- a/spaces/S000102/properties/P000065.md
+++ b/spaces/S000102/properties/P000065.md
@@ -1,5 +1,4 @@
 ---
-uid: T026182
 space: S000102
 property: P000065
 value: true

--- a/spaces/S000103/properties/P000006.md
+++ b/spaces/S000103/properties/P000006.md
@@ -1,5 +1,4 @@
 ---
-uid: T001095
 space: S000103
 property: P000006
 value: true

--- a/spaces/S000103/properties/P000014.md
+++ b/spaces/S000103/properties/P000014.md
@@ -1,5 +1,4 @@
 ---
-uid: T015071
 space: S000103
 property: P000014
 value: false

--- a/spaces/S000103/properties/P000016.md
+++ b/spaces/S000103/properties/P000016.md
@@ -1,5 +1,4 @@
 ---
-uid: T014726
 space: S000103
 property: P000016
 value: true

--- a/spaces/S000103/properties/P000020.md
+++ b/spaces/S000103/properties/P000020.md
@@ -1,5 +1,4 @@
 ---
-uid: T015070
 space: S000103
 property: P000020
 value: false

--- a/spaces/S000103/properties/P000026.md
+++ b/spaces/S000103/properties/P000026.md
@@ -1,5 +1,4 @@
 ---
-uid: T026624
 space: S000103
 property: P000026
 value: true

--- a/spaces/S000103/properties/P000028.md
+++ b/spaces/S000103/properties/P000028.md
@@ -1,5 +1,4 @@
 ---
-uid: T015065
 space: S000103
 property: P000028
 value: false

--- a/spaces/S000103/properties/P000036.md
+++ b/spaces/S000103/properties/P000036.md
@@ -1,5 +1,4 @@
 ---
-uid: T014749
 space: S000103
 property: P000036
 value: true

--- a/spaces/S000103/properties/P000049.md
+++ b/spaces/S000103/properties/P000049.md
@@ -1,5 +1,4 @@
 ---
-uid: T001277
 space: S000103
 property: P000049
 value: false

--- a/spaces/S000103/properties/P000051.md
+++ b/spaces/S000103/properties/P000051.md
@@ -1,5 +1,4 @@
 ---
-uid: T001268
 space: S000103
 property: P000051
 value: false

--- a/spaces/S000103/properties/P000056.md
+++ b/spaces/S000103/properties/P000056.md
@@ -1,5 +1,4 @@
 ---
-uid: T001273
 space: S000103
 property: P000056
 value: false

--- a/spaces/S000103/properties/P000058.md
+++ b/spaces/S000103/properties/P000058.md
@@ -1,5 +1,4 @@
 ---
-uid: T001279
 space: S000103
 property: P000058
 value: false

--- a/spaces/S000103/properties/P000059.md
+++ b/spaces/S000103/properties/P000059.md
@@ -1,5 +1,4 @@
 ---
-uid: T001281
 space: S000103
 property: P000059
 value: true

--- a/spaces/S000104/properties/P000006.md
+++ b/spaces/S000104/properties/P000006.md
@@ -1,5 +1,4 @@
 ---
-uid: T015093
 space: S000104
 property: P000006
 value: true

--- a/spaces/S000104/properties/P000013.md
+++ b/spaces/S000104/properties/P000013.md
@@ -1,5 +1,4 @@
 ---
-uid: T024333
 space: S000104
 property: P000013
 value: false

--- a/spaces/S000104/properties/P000016.md
+++ b/spaces/S000104/properties/P000016.md
@@ -1,5 +1,4 @@
 ---
-uid: T015110
 space: S000104
 property: P000016
 value: false

--- a/spaces/S000104/properties/P000019.md
+++ b/spaces/S000104/properties/P000019.md
@@ -1,5 +1,4 @@
 ---
-uid: T015104
 space: S000104
 property: P000019
 value: true

--- a/spaces/S000104/properties/P000023.md
+++ b/spaces/S000104/properties/P000023.md
@@ -1,5 +1,4 @@
 ---
-uid: T015118
 space: S000104
 property: P000023
 value: true

--- a/spaces/S000104/properties/P000028.md
+++ b/spaces/S000104/properties/P000028.md
@@ -1,5 +1,4 @@
 ---
-uid: T001201
 space: S000104
 property: P000028
 value: false

--- a/spaces/S000104/properties/P000029.md
+++ b/spaces/S000104/properties/P000029.md
@@ -1,5 +1,4 @@
 ---
-uid: T001107
 space: S000104
 property: P000029
 value: false

--- a/spaces/S000104/properties/P000036.md
+++ b/spaces/S000104/properties/P000036.md
@@ -1,5 +1,4 @@
 ---
-uid: T001189
 space: S000104
 property: P000036
 value: false

--- a/spaces/S000104/properties/P000041.md
+++ b/spaces/S000104/properties/P000041.md
@@ -1,5 +1,4 @@
 ---
-uid: T001206
 space: S000104
 property: P000041
 value: false

--- a/spaces/S000104/properties/P000056.md
+++ b/spaces/S000104/properties/P000056.md
@@ -1,5 +1,4 @@
 ---
-uid: T001214
 space: S000104
 property: P000056
 value: false

--- a/spaces/S000104/properties/P000058.md
+++ b/spaces/S000104/properties/P000058.md
@@ -1,5 +1,4 @@
 ---
-uid: T001218
 space: S000104
 property: P000058
 value: false

--- a/spaces/S000104/properties/P000059.md
+++ b/spaces/S000104/properties/P000059.md
@@ -1,5 +1,4 @@
 ---
-uid: T001226
 space: S000104
 property: P000059
 value: true

--- a/spaces/S000105/properties/P000008.md
+++ b/spaces/S000105/properties/P000008.md
@@ -1,5 +1,4 @@
 ---
-uid: T000309
 space: S000105
 property: P000008
 value: false

--- a/spaces/S000105/properties/P000015.md
+++ b/spaces/S000105/properties/P000015.md
@@ -1,5 +1,4 @@
 ---
-uid: T001093
 space: S000105
 property: P000015
 value: false

--- a/spaces/S000105/properties/P000016.md
+++ b/spaces/S000105/properties/P000016.md
@@ -1,5 +1,4 @@
 ---
-uid: T000314
 space: S000105
 property: P000016
 value: true

--- a/spaces/S000105/properties/P000026.md
+++ b/spaces/S000105/properties/P000026.md
@@ -1,5 +1,4 @@
 ---
-uid: T000321
 space: S000105
 property: P000026
 value: true

--- a/spaces/S000105/properties/P000027.md
+++ b/spaces/S000105/properties/P000027.md
@@ -1,5 +1,4 @@
 ---
-uid: T000322
 space: S000105
 property: P000027
 value: false

--- a/spaces/S000105/properties/P000028.md
+++ b/spaces/S000105/properties/P000028.md
@@ -1,5 +1,4 @@
 ---
-uid: T000320
 space: S000105
 property: P000028
 value: true

--- a/spaces/S000105/properties/P000038.md
+++ b/spaces/S000105/properties/P000038.md
@@ -1,5 +1,4 @@
 ---
-uid: T026175
 space: S000105
 property: P000038
 value: true

--- a/spaces/S000105/properties/P000049.md
+++ b/spaces/S000105/properties/P000049.md
@@ -1,5 +1,4 @@
 ---
-uid: T000326
 space: S000105
 property: P000049
 value: false

--- a/spaces/S000105/properties/P000051.md
+++ b/spaces/S000105/properties/P000051.md
@@ -1,5 +1,4 @@
 ---
-uid: T000324
 space: S000105
 property: P000051
 value: false

--- a/spaces/S000105/properties/P000058.md
+++ b/spaces/S000105/properties/P000058.md
@@ -1,5 +1,4 @@
 ---
-uid: T001219
 space: S000105
 property: P000058
 value: false

--- a/spaces/S000106/properties/P000017.md
+++ b/spaces/S000106/properties/P000017.md
@@ -1,5 +1,4 @@
 ---
-uid: T000398
 space: S000106
 property: P000017
 value: false

--- a/spaces/S000106/properties/P000023.md
+++ b/spaces/S000106/properties/P000023.md
@@ -1,5 +1,4 @@
 ---
-uid: T000397
 space: S000106
 property: P000023
 value: false

--- a/spaces/S000106/properties/P000026.md
+++ b/spaces/S000106/properties/P000026.md
@@ -1,5 +1,4 @@
 ---
-uid: T000396
 space: S000106
 property: P000026
 value: true

--- a/spaces/S000106/properties/P000038.md
+++ b/spaces/S000106/properties/P000038.md
@@ -1,5 +1,4 @@
 ---
-uid: T000400
 space: S000106
 property: P000038
 value: true

--- a/spaces/S000106/properties/P000043.md
+++ b/spaces/S000106/properties/P000043.md
@@ -1,5 +1,4 @@
 ---
-uid: T000399
 space: S000106
 property: P000043
 value: true

--- a/spaces/S000106/properties/P000053.md
+++ b/spaces/S000106/properties/P000053.md
@@ -1,5 +1,4 @@
 ---
-uid: T000395
 space: S000106
 property: P000053
 value: true

--- a/spaces/S000106/properties/P000055.md
+++ b/spaces/S000106/properties/P000055.md
@@ -1,5 +1,4 @@
 ---
-uid: T001149
 space: S000106
 property: P000055
 value: true

--- a/spaces/S000107/properties/P000006.md
+++ b/spaces/S000107/properties/P000006.md
@@ -1,5 +1,4 @@
 ---
-uid: T000401
 space: S000107
 property: P000006
 value: true

--- a/spaces/S000107/properties/P000008.md
+++ b/spaces/S000107/properties/P000008.md
@@ -1,5 +1,4 @@
 ---
-uid: T001134
 space: S000107
 property: P000008
 value: false

--- a/spaces/S000107/properties/P000017.md
+++ b/spaces/S000107/properties/P000017.md
@@ -1,5 +1,4 @@
 ---
-uid: T000402
 space: S000107
 property: P000017
 value: false

--- a/spaces/S000107/properties/P000018.md
+++ b/spaces/S000107/properties/P000018.md
@@ -1,5 +1,4 @@
 ---
-uid: T001165
 space: S000107
 property: P000018
 value: false

--- a/spaces/S000107/properties/P000022.md
+++ b/spaces/S000107/properties/P000022.md
@@ -1,5 +1,4 @@
 ---
-uid: T001159
 space: S000107
 property: P000022
 value: false

--- a/spaces/S000107/properties/P000023.md
+++ b/spaces/S000107/properties/P000023.md
@@ -1,5 +1,4 @@
 ---
-uid: T000403
 space: S000107
 property: P000023
 value: false

--- a/spaces/S000107/properties/P000026.md
+++ b/spaces/S000107/properties/P000026.md
@@ -1,5 +1,4 @@
 ---
-uid: T000405
 space: S000107
 property: P000026
 value: false

--- a/spaces/S000107/properties/P000028.md
+++ b/spaces/S000107/properties/P000028.md
@@ -1,5 +1,4 @@
 ---
-uid: T000404
 space: S000107
 property: P000028
 value: false

--- a/spaces/S000107/properties/P000029.md
+++ b/spaces/S000107/properties/P000029.md
@@ -1,5 +1,4 @@
 ---
-uid: T000406
 space: S000107
 property: P000029
 value: false

--- a/spaces/S000107/properties/P000036.md
+++ b/spaces/S000107/properties/P000036.md
@@ -1,5 +1,4 @@
 ---
-uid: T000914
 space: S000107
 property: P000036
 value: false

--- a/spaces/S000107/properties/P000059.md
+++ b/spaces/S000107/properties/P000059.md
@@ -1,5 +1,4 @@
 ---
-uid: T001180
 space: S000107
 property: P000059
 value: true

--- a/spaces/S000108/properties/P000008.md
+++ b/spaces/S000108/properties/P000008.md
@@ -1,5 +1,4 @@
 ---
-uid: T026706
 space: S000108
 property: P000008
 value: false

--- a/spaces/S000108/properties/P000016.md
+++ b/spaces/S000108/properties/P000016.md
@@ -1,5 +1,4 @@
 ---
-uid: T000410
 space: S000108
 property: P000016
 value: true

--- a/spaces/S000108/properties/P000020.md
+++ b/spaces/S000108/properties/P000020.md
@@ -1,5 +1,4 @@
 ---
-uid: T001162
 space: S000108
 property: P000020
 value: false

--- a/spaces/S000108/properties/P000026.md
+++ b/spaces/S000108/properties/P000026.md
@@ -1,5 +1,4 @@
 ---
-uid: T000414
 space: S000108
 property: P000026
 value: true

--- a/spaces/S000108/properties/P000028.md
+++ b/spaces/S000108/properties/P000028.md
@@ -1,5 +1,4 @@
 ---
-uid: T001160
 space: S000108
 property: P000028
 value: false

--- a/spaces/S000108/properties/P000049.md
+++ b/spaces/S000108/properties/P000049.md
@@ -1,5 +1,4 @@
 ---
-uid: T000411
 space: S000108
 property: P000049
 value: true

--- a/spaces/S000108/properties/P000050.md
+++ b/spaces/S000108/properties/P000050.md
@@ -1,5 +1,4 @@
 ---
-uid: T000412
 space: S000108
 property: P000050
 value: true

--- a/spaces/S000108/properties/P000051.md
+++ b/spaces/S000108/properties/P000051.md
@@ -1,5 +1,4 @@
 ---
-uid: T000413
 space: S000108
 property: P000051
 value: false

--- a/spaces/S000108/properties/P000058.md
+++ b/spaces/S000108/properties/P000058.md
@@ -1,5 +1,4 @@
 ---
-uid: T001161
 space: S000108
 property: P000058
 value: false

--- a/spaces/S000108/properties/P000059.md
+++ b/spaces/S000108/properties/P000059.md
@@ -1,5 +1,4 @@
 ---
-uid: T000409
 space: S000108
 property: P000059
 value: true

--- a/spaces/S000109/properties/P000006.md
+++ b/spaces/S000109/properties/P000006.md
@@ -1,5 +1,4 @@
 ---
-uid: T000417
 space: S000109
 property: P000006
 value: true

--- a/spaces/S000109/properties/P000018.md
+++ b/spaces/S000109/properties/P000018.md
@@ -1,5 +1,4 @@
 ---
-uid: T001139
 space: S000109
 property: P000018
 value: false

--- a/spaces/S000109/properties/P000019.md
+++ b/spaces/S000109/properties/P000019.md
@@ -1,5 +1,4 @@
 ---
-uid: T000415
 space: S000109
 property: P000019
 value: true

--- a/spaces/S000109/properties/P000026.md
+++ b/spaces/S000109/properties/P000026.md
@@ -1,5 +1,4 @@
 ---
-uid: T000416
 space: S000109
 property: P000026
 value: true

--- a/spaces/S000109/properties/P000056.md
+++ b/spaces/S000109/properties/P000056.md
@@ -1,5 +1,4 @@
 ---
-uid: T001148
 space: S000109
 property: P000056
 value: false

--- a/spaces/S000110/properties/P000003.md
+++ b/spaces/S000110/properties/P000003.md
@@ -1,5 +1,4 @@
 ---
-uid: T000418
 space: S000110
 property: P000003
 value: true

--- a/spaces/S000110/properties/P000011.md
+++ b/spaces/S000110/properties/P000011.md
@@ -1,5 +1,4 @@
 ---
-uid: T000420
 space: S000110
 property: P000011
 value: false

--- a/spaces/S000110/properties/P000018.md
+++ b/spaces/S000110/properties/P000018.md
@@ -1,5 +1,4 @@
 ---
-uid: T000424
 space: S000110
 property: P000018
 value: false

--- a/spaces/S000110/properties/P000019.md
+++ b/spaces/S000110/properties/P000019.md
@@ -1,5 +1,4 @@
 ---
-uid: T000422
 space: S000110
 property: P000019
 value: false

--- a/spaces/S000110/properties/P000022.md
+++ b/spaces/S000110/properties/P000022.md
@@ -1,5 +1,4 @@
 ---
-uid: T024163
 space: S000110
 property: P000022
 value: true

--- a/spaces/S000110/properties/P000026.md
+++ b/spaces/S000110/properties/P000026.md
@@ -1,5 +1,4 @@
 ---
-uid: T000423
 space: S000110
 property: P000026
 value: true

--- a/spaces/S000110/properties/P000028.md
+++ b/spaces/S000110/properties/P000028.md
@@ -1,5 +1,4 @@
 ---
-uid: T001163
 space: S000110
 property: P000028
 value: false

--- a/spaces/S000110/properties/P000049.md
+++ b/spaces/S000110/properties/P000049.md
@@ -1,5 +1,4 @@
 ---
-uid: T000419
 space: S000110
 property: P000049
 value: true

--- a/spaces/S000110/properties/P000051.md
+++ b/spaces/S000110/properties/P000051.md
@@ -1,5 +1,4 @@
 ---
-uid: T000421
 space: S000110
 property: P000051
 value: true

--- a/spaces/S000111/properties/P000003.md
+++ b/spaces/S000111/properties/P000003.md
@@ -1,5 +1,4 @@
 ---
-uid: T000425
 space: S000111
 property: P000003
 value: true

--- a/spaces/S000111/properties/P000016.md
+++ b/spaces/S000111/properties/P000016.md
@@ -1,5 +1,4 @@
 ---
-uid: T000942
 space: S000111
 property: P000016
 value: false

--- a/spaces/S000111/properties/P000022.md
+++ b/spaces/S000111/properties/P000022.md
@@ -1,5 +1,4 @@
 ---
-uid: T000943
 space: S000111
 property: P000022
 value: false

--- a/spaces/S000111/properties/P000023.md
+++ b/spaces/S000111/properties/P000023.md
@@ -1,5 +1,4 @@
 ---
-uid: T001132
 space: S000111
 property: P000023
 value: false

--- a/spaces/S000111/properties/P000028.md
+++ b/spaces/S000111/properties/P000028.md
@@ -1,5 +1,4 @@
 ---
-uid: T001164
 space: S000111
 property: P000028
 value: false

--- a/spaces/S000111/properties/P000031.md
+++ b/spaces/S000111/properties/P000031.md
@@ -1,5 +1,4 @@
 ---
-uid: T001136
 space: S000111
 property: P000031
 value: true

--- a/spaces/S000111/properties/P000032.md
+++ b/spaces/S000111/properties/P000032.md
@@ -1,5 +1,4 @@
 ---
-uid: T001137
 space: S000111
 property: P000032
 value: true

--- a/spaces/S000111/properties/P000049.md
+++ b/spaces/S000111/properties/P000049.md
@@ -1,5 +1,4 @@
 ---
-uid: T000426
 space: S000111
 property: P000049
 value: true

--- a/spaces/S000111/properties/P000050.md
+++ b/spaces/S000111/properties/P000050.md
@@ -1,5 +1,4 @@
 ---
-uid: T000427
 space: S000111
 property: P000050
 value: true

--- a/spaces/S000111/properties/P000051.md
+++ b/spaces/S000111/properties/P000051.md
@@ -1,5 +1,4 @@
 ---
-uid: T000428
 space: S000111
 property: P000051
 value: true

--- a/spaces/S000111/properties/P000052.md
+++ b/spaces/S000111/properties/P000052.md
@@ -1,5 +1,4 @@
 ---
-uid: T000429
 space: S000111
 property: P000052
 value: false

--- a/spaces/S000111/properties/P000056.md
+++ b/spaces/S000111/properties/P000056.md
@@ -1,5 +1,4 @@
 ---
-uid: T001147
 space: S000111
 property: P000056
 value: false

--- a/spaces/S000111/properties/P000057.md
+++ b/spaces/S000111/properties/P000057.md
@@ -1,5 +1,4 @@
 ---
-uid: T000941
 space: S000111
 property: P000057
 value: true

--- a/spaces/S000112/properties/P000017.md
+++ b/spaces/S000112/properties/P000017.md
@@ -1,5 +1,4 @@
 ---
-uid: T000955
 space: S000112
 property: P000017
 value: true

--- a/spaces/S000112/properties/P000022.md
+++ b/spaces/S000112/properties/P000022.md
@@ -1,5 +1,4 @@
 ---
-uid: T000956
 space: S000112
 property: P000022
 value: false

--- a/spaces/S000112/properties/P000023.md
+++ b/spaces/S000112/properties/P000023.md
@@ -1,5 +1,4 @@
 ---
-uid: T001133
 space: S000112
 property: P000023
 value: false

--- a/spaces/S000112/properties/P000036.md
+++ b/spaces/S000112/properties/P000036.md
@@ -1,5 +1,4 @@
 ---
-uid: T001153
 space: S000112
 property: P000036
 value: false

--- a/spaces/S000112/properties/P000041.md
+++ b/spaces/S000112/properties/P000041.md
@@ -1,5 +1,4 @@
 ---
-uid: T000430
 space: S000112
 property: P000041
 value: false

--- a/spaces/S000112/properties/P000044.md
+++ b/spaces/S000112/properties/P000044.md
@@ -1,5 +1,4 @@
 ---
-uid: T001126
 space: S000112
 property: P000044
 value: false

--- a/spaces/S000112/properties/P000046.md
+++ b/spaces/S000112/properties/P000046.md
@@ -1,5 +1,4 @@
 ---
-uid: T001182
 space: S000112
 property: P000046
 value: false

--- a/spaces/S000112/properties/P000053.md
+++ b/spaces/S000112/properties/P000053.md
@@ -1,5 +1,4 @@
 ---
-uid: T000947
 space: S000112
 property: P000053
 value: true

--- a/spaces/S000112/properties/P000055.md
+++ b/spaces/S000112/properties/P000055.md
@@ -1,5 +1,4 @@
 ---
-uid: T001146
 space: S000112
 property: P000055
 value: true

--- a/spaces/S000112/properties/P000058.md
+++ b/spaces/S000112/properties/P000058.md
@@ -1,5 +1,4 @@
 ---
-uid: T001176
 space: S000112
 property: P000058
 value: false

--- a/spaces/S000113/properties/P000017.md
+++ b/spaces/S000113/properties/P000017.md
@@ -1,5 +1,4 @@
 ---
-uid: T001138
 space: S000113
 property: P000017
 value: true

--- a/spaces/S000113/properties/P000023.md
+++ b/spaces/S000113/properties/P000023.md
@@ -1,5 +1,4 @@
 ---
-uid: T000431
 space: S000113
 property: P000023
 value: false

--- a/spaces/S000113/properties/P000027.md
+++ b/spaces/S000113/properties/P000027.md
@@ -1,5 +1,4 @@
 ---
-uid: T001078
 space: S000113
 property: P000027
 value: true

--- a/spaces/S000113/properties/P000036.md
+++ b/spaces/S000113/properties/P000036.md
@@ -1,5 +1,4 @@
 ---
-uid: T000434
 space: S000113
 property: P000036
 value: true

--- a/spaces/S000113/properties/P000037.md
+++ b/spaces/S000113/properties/P000037.md
@@ -1,5 +1,4 @@
 ---
-uid: T000438
 space: S000113
 property: P000037
 value: false

--- a/spaces/S000113/properties/P000041.md
+++ b/spaces/S000113/properties/P000041.md
@@ -1,5 +1,4 @@
 ---
-uid: T000435
 space: S000113
 property: P000041
 value: false

--- a/spaces/S000113/properties/P000044.md
+++ b/spaces/S000113/properties/P000044.md
@@ -1,5 +1,4 @@
 ---
-uid: T001127
 space: S000113
 property: P000044
 value: false

--- a/spaces/S000113/properties/P000046.md
+++ b/spaces/S000113/properties/P000046.md
@@ -1,5 +1,4 @@
 ---
-uid: T001143
 space: S000113
 property: P000046
 value: false

--- a/spaces/S000113/properties/P000053.md
+++ b/spaces/S000113/properties/P000053.md
@@ -1,5 +1,4 @@
 ---
-uid: T000944
 space: S000113
 property: P000053
 value: true

--- a/spaces/S000113/properties/P000056.md
+++ b/spaces/S000113/properties/P000056.md
@@ -1,5 +1,4 @@
 ---
-uid: T001145
 space: S000113
 property: P000056
 value: false

--- a/spaces/S000114/properties/P000016.md
+++ b/spaces/S000114/properties/P000016.md
@@ -1,5 +1,4 @@
 ---
-uid: T000432
 space: S000114
 property: P000016
 value: true

--- a/spaces/S000114/properties/P000036.md
+++ b/spaces/S000114/properties/P000036.md
@@ -1,5 +1,4 @@
 ---
-uid: T000433
 space: S000114
 property: P000036
 value: true

--- a/spaces/S000114/properties/P000037.md
+++ b/spaces/S000114/properties/P000037.md
@@ -1,5 +1,4 @@
 ---
-uid: T000437
 space: S000114
 property: P000037
 value: false

--- a/spaces/S000114/properties/P000041.md
+++ b/spaces/S000114/properties/P000041.md
@@ -1,5 +1,4 @@
 ---
-uid: T000436
 space: S000114
 property: P000041
 value: false

--- a/spaces/S000114/properties/P000044.md
+++ b/spaces/S000114/properties/P000044.md
@@ -1,5 +1,4 @@
 ---
-uid: T001128
 space: S000114
 property: P000044
 value: false

--- a/spaces/S000114/properties/P000046.md
+++ b/spaces/S000114/properties/P000046.md
@@ -1,5 +1,4 @@
 ---
-uid: T001144
 space: S000114
 property: P000046
 value: false

--- a/spaces/S000114/properties/P000053.md
+++ b/spaces/S000114/properties/P000053.md
@@ -1,5 +1,4 @@
 ---
-uid: T000945
 space: S000114
 property: P000053
 value: true

--- a/spaces/S000115/properties/P000016.md
+++ b/spaces/S000115/properties/P000016.md
@@ -1,5 +1,4 @@
 ---
-uid: T000951
 space: S000115
 property: P000016
 value: true

--- a/spaces/S000115/properties/P000038.md
+++ b/spaces/S000115/properties/P000038.md
@@ -1,5 +1,4 @@
 ---
-uid: T000439
 space: S000115
 property: P000038
 value: true

--- a/spaces/S000115/properties/P000041.md
+++ b/spaces/S000115/properties/P000041.md
@@ -1,5 +1,4 @@
 ---
-uid: T000440
 space: S000115
 property: P000041
 value: false

--- a/spaces/S000115/properties/P000044.md
+++ b/spaces/S000115/properties/P000044.md
@@ -1,5 +1,4 @@
 ---
-uid: T001129
 space: S000115
 property: P000044
 value: false

--- a/spaces/S000115/properties/P000053.md
+++ b/spaces/S000115/properties/P000053.md
@@ -1,5 +1,4 @@
 ---
-uid: T000946
 space: S000115
 property: P000053
 value: true

--- a/spaces/S000116/properties/P000017.md
+++ b/spaces/S000116/properties/P000017.md
@@ -1,5 +1,4 @@
 ---
-uid: T000953
 space: S000116
 property: P000017
 value: true

--- a/spaces/S000116/properties/P000021.md
+++ b/spaces/S000116/properties/P000021.md
@@ -1,5 +1,4 @@
 ---
-uid: T000954
 space: S000116
 property: P000021
 value: false

--- a/spaces/S000116/properties/P000024.md
+++ b/spaces/S000116/properties/P000024.md
@@ -1,5 +1,4 @@
 ---
-uid: T001131
 space: S000116
 property: P000024
 value: true

--- a/spaces/S000116/properties/P000036.md
+++ b/spaces/S000116/properties/P000036.md
@@ -1,5 +1,4 @@
 ---
-uid: T000441
 space: S000116
 property: P000036
 value: true

--- a/spaces/S000116/properties/P000037.md
+++ b/spaces/S000116/properties/P000037.md
@@ -1,5 +1,4 @@
 ---
-uid: T000446
 space: S000116
 property: P000037
 value: false

--- a/spaces/S000116/properties/P000041.md
+++ b/spaces/S000116/properties/P000041.md
@@ -1,5 +1,4 @@
 ---
-uid: T000443
 space: S000116
 property: P000041
 value: false

--- a/spaces/S000116/properties/P000044.md
+++ b/spaces/S000116/properties/P000044.md
@@ -1,5 +1,4 @@
 ---
-uid: T001130
 space: S000116
 property: P000044
 value: false

--- a/spaces/S000116/properties/P000046.md
+++ b/spaces/S000116/properties/P000046.md
@@ -1,5 +1,4 @@
 ---
-uid: T001142
 space: S000116
 property: P000046
 value: false

--- a/spaces/S000116/properties/P000053.md
+++ b/spaces/S000116/properties/P000053.md
@@ -1,5 +1,4 @@
 ---
-uid: T000949
 space: S000116
 property: P000053
 value: true

--- a/spaces/S000117/properties/P000016.md
+++ b/spaces/S000117/properties/P000016.md
@@ -1,5 +1,4 @@
 ---
-uid: T000952
 space: S000117
 property: P000016
 value: true

--- a/spaces/S000117/properties/P000036.md
+++ b/spaces/S000117/properties/P000036.md
@@ -1,5 +1,4 @@
 ---
-uid: T000442
 space: S000117
 property: P000036
 value: true

--- a/spaces/S000117/properties/P000038.md
+++ b/spaces/S000117/properties/P000038.md
@@ -1,5 +1,4 @@
 ---
-uid: T000445
 space: S000117
 property: P000038
 value: true

--- a/spaces/S000117/properties/P000041.md
+++ b/spaces/S000117/properties/P000041.md
@@ -1,5 +1,4 @@
 ---
-uid: T000444
 space: S000117
 property: P000041
 value: false

--- a/spaces/S000117/properties/P000044.md
+++ b/spaces/S000117/properties/P000044.md
@@ -1,5 +1,4 @@
 ---
-uid: T001112
 space: S000117
 property: P000044
 value: false

--- a/spaces/S000117/properties/P000053.md
+++ b/spaces/S000117/properties/P000053.md
@@ -1,5 +1,4 @@
 ---
-uid: T000948
 space: S000117
 property: P000053
 value: true

--- a/spaces/S000118/properties/P000001.md
+++ b/spaces/S000118/properties/P000001.md
@@ -1,5 +1,4 @@
 ---
-uid: T000447
 space: S000118
 property: P000001
 value: true

--- a/spaces/S000118/properties/P000002.md
+++ b/spaces/S000118/properties/P000002.md
@@ -1,5 +1,4 @@
 ---
-uid: T000448
 space: S000118
 property: P000002
 value: false

--- a/spaces/S000118/properties/P000014.md
+++ b/spaces/S000118/properties/P000014.md
@@ -1,5 +1,4 @@
 ---
-uid: T001116
 space: S000118
 property: P000014
 value: true

--- a/spaces/S000118/properties/P000016.md
+++ b/spaces/S000118/properties/P000016.md
@@ -1,5 +1,4 @@
 ---
-uid: T000449
 space: S000118
 property: P000016
 value: true

--- a/spaces/S000118/properties/P000037.md
+++ b/spaces/S000118/properties/P000037.md
@@ -1,5 +1,4 @@
 ---
-uid: T000452
 space: S000118
 property: P000037
 value: true

--- a/spaces/S000118/properties/P000040.md
+++ b/spaces/S000118/properties/P000040.md
@@ -1,5 +1,4 @@
 ---
-uid: T001115
 space: S000118
 property: P000040
 value: true

--- a/spaces/S000118/properties/P000041.md
+++ b/spaces/S000118/properties/P000041.md
@@ -1,5 +1,4 @@
 ---
-uid: T000450
 space: S000118
 property: P000041
 value: false

--- a/spaces/S000118/properties/P000044.md
+++ b/spaces/S000118/properties/P000044.md
@@ -1,5 +1,4 @@
 ---
-uid: T001113
 space: S000118
 property: P000044
 value: false

--- a/spaces/S000118/properties/P000056.md
+++ b/spaces/S000118/properties/P000056.md
@@ -1,5 +1,4 @@
 ---
-uid: T001114
 space: S000118
 property: P000056
 value: true

--- a/spaces/S000118/properties/P000057.md
+++ b/spaces/S000118/properties/P000057.md
@@ -1,5 +1,4 @@
 ---
-uid: T000451
 space: S000118
 property: P000057
 value: true

--- a/spaces/S000119/properties/P000016.md
+++ b/spaces/S000119/properties/P000016.md
@@ -1,5 +1,4 @@
 ---
-uid: T000455
 space: S000119
 property: P000016
 value: false

--- a/spaces/S000119/properties/P000023.md
+++ b/spaces/S000119/properties/P000023.md
@@ -1,5 +1,4 @@
 ---
-uid: T000454
 space: S000119
 property: P000023
 value: true

--- a/spaces/S000119/properties/P000024.md
+++ b/spaces/S000119/properties/P000024.md
@@ -1,5 +1,4 @@
 ---
-uid: T001073
 space: S000119
 property: P000024
 value: true

--- a/spaces/S000119/properties/P000027.md
+++ b/spaces/S000119/properties/P000027.md
@@ -1,5 +1,4 @@
 ---
-uid: T001072
 space: S000119
 property: P000027
 value: true

--- a/spaces/S000119/properties/P000036.md
+++ b/spaces/S000119/properties/P000036.md
@@ -1,5 +1,4 @@
 ---
-uid: T000453
 space: S000119
 property: P000036
 value: true

--- a/spaces/S000119/properties/P000037.md
+++ b/spaces/S000119/properties/P000037.md
@@ -1,5 +1,4 @@
 ---
-uid: T001074
 space: S000119
 property: P000037
 value: false

--- a/spaces/S000119/properties/P000041.md
+++ b/spaces/S000119/properties/P000041.md
@@ -1,5 +1,4 @@
 ---
-uid: T000456
 space: S000119
 property: P000041
 value: false

--- a/spaces/S000119/properties/P000044.md
+++ b/spaces/S000119/properties/P000044.md
@@ -1,5 +1,4 @@
 ---
-uid: T001075
 space: S000119
 property: P000044
 value: false

--- a/spaces/S000119/properties/P000046.md
+++ b/spaces/S000119/properties/P000046.md
@@ -1,5 +1,4 @@
 ---
-uid: T001076
 space: S000119
 property: P000046
 value: false

--- a/spaces/S000119/properties/P000053.md
+++ b/spaces/S000119/properties/P000053.md
@@ -1,5 +1,4 @@
 ---
-uid: T000950
 space: S000119
 property: P000053
 value: true

--- a/spaces/S000120/properties/P000022.md
+++ b/spaces/S000120/properties/P000022.md
@@ -1,5 +1,4 @@
 ---
-uid: T001044
 space: S000120
 property: P000022
 value: false

--- a/spaces/S000120/properties/P000024.md
+++ b/spaces/S000120/properties/P000024.md
@@ -1,5 +1,4 @@
 ---
-uid: T001050
 space: S000120
 property: P000024
 value: true

--- a/spaces/S000120/properties/P000027.md
+++ b/spaces/S000120/properties/P000027.md
@@ -1,5 +1,4 @@
 ---
-uid: T001045
 space: S000120
 property: P000027
 value: true

--- a/spaces/S000120/properties/P000036.md
+++ b/spaces/S000120/properties/P000036.md
@@ -1,5 +1,4 @@
 ---
-uid: T000457
 space: S000120
 property: P000036
 value: true

--- a/spaces/S000120/properties/P000037.md
+++ b/spaces/S000120/properties/P000037.md
@@ -1,5 +1,4 @@
 ---
-uid: T001067
 space: S000120
 property: P000037
 value: false

--- a/spaces/S000120/properties/P000041.md
+++ b/spaces/S000120/properties/P000041.md
@@ -1,5 +1,4 @@
 ---
-uid: T001065
 space: S000120
 property: P000041
 value: false

--- a/spaces/S000120/properties/P000044.md
+++ b/spaces/S000120/properties/P000044.md
@@ -1,5 +1,4 @@
 ---
-uid: T001070
 space: S000120
 property: P000044
 value: false

--- a/spaces/S000120/properties/P000046.md
+++ b/spaces/S000120/properties/P000046.md
@@ -1,5 +1,4 @@
 ---
-uid: T001071
 space: S000120
 property: P000046
 value: false

--- a/spaces/S000120/properties/P000053.md
+++ b/spaces/S000120/properties/P000053.md
@@ -1,5 +1,4 @@
 ---
-uid: T000964
 space: S000120
 property: P000053
 value: true

--- a/spaces/S000121/properties/P000036.md
+++ b/spaces/S000121/properties/P000036.md
@@ -1,5 +1,4 @@
 ---
-uid: T015424
 space: S000121
 property: P000036
 value: true

--- a/spaces/S000122/properties/P000003.md
+++ b/spaces/S000122/properties/P000003.md
@@ -1,5 +1,4 @@
 ---
-uid: T000458
 space: S000122
 property: P000003
 value: true

--- a/spaces/S000122/properties/P000036.md
+++ b/spaces/S000122/properties/P000036.md
@@ -1,5 +1,4 @@
 ---
-uid: T000459
 space: S000122
 property: P000036
 value: true

--- a/spaces/S000122/properties/P000046.md
+++ b/spaces/S000122/properties/P000046.md
@@ -1,5 +1,4 @@
 ---
-uid: T001055
 space: S000122
 property: P000046
 value: true

--- a/spaces/S000122/properties/P000057.md
+++ b/spaces/S000122/properties/P000057.md
@@ -1,5 +1,4 @@
 ---
-uid: T000958
 space: S000122
 property: P000057
 value: true

--- a/spaces/S000123/properties/P000004.md
+++ b/spaces/S000123/properties/P000004.md
@@ -1,5 +1,4 @@
 ---
-uid: T000463
 space: S000123
 property: P000004
 value: true

--- a/spaces/S000123/properties/P000010.md
+++ b/spaces/S000123/properties/P000010.md
@@ -1,5 +1,4 @@
 ---
-uid: T000915
 space: S000123
 property: P000010
 value: false

--- a/spaces/S000123/properties/P000027.md
+++ b/spaces/S000123/properties/P000027.md
@@ -1,5 +1,4 @@
 ---
-uid: T001046
 space: S000123
 property: P000027
 value: true

--- a/spaces/S000123/properties/P000036.md
+++ b/spaces/S000123/properties/P000036.md
@@ -1,5 +1,4 @@
 ---
-uid: T000460
 space: S000123
 property: P000036
 value: true

--- a/spaces/S000123/properties/P000041.md
+++ b/spaces/S000123/properties/P000041.md
@@ -1,5 +1,4 @@
 ---
-uid: T001064
 space: S000123
 property: P000041
 value: false

--- a/spaces/S000123/properties/P000045.md
+++ b/spaces/S000123/properties/P000045.md
@@ -1,5 +1,4 @@
 ---
-uid: T000461
 space: S000123
 property: P000045
 value: true

--- a/spaces/S000123/properties/P000046.md
+++ b/spaces/S000123/properties/P000046.md
@@ -1,5 +1,4 @@
 ---
-uid: T001056
 space: S000123
 property: P000046
 value: true

--- a/spaces/S000123/properties/P000056.md
+++ b/spaces/S000123/properties/P000056.md
@@ -1,5 +1,4 @@
 ---
-uid: T001051
 space: S000123
 property: P000056
 value: true

--- a/spaces/S000123/properties/P000057.md
+++ b/spaces/S000123/properties/P000057.md
@@ -1,5 +1,4 @@
 ---
-uid: T000462
 space: S000123
 property: P000057
 value: true

--- a/spaces/S000124/properties/P000005.md
+++ b/spaces/S000124/properties/P000005.md
@@ -1,5 +1,4 @@
 ---
-uid: T000465
 space: S000124
 property: P000005
 value: false

--- a/spaces/S000124/properties/P000027.md
+++ b/spaces/S000124/properties/P000027.md
@@ -1,5 +1,4 @@
 ---
-uid: T001047
 space: S000124
 property: P000027
 value: true

--- a/spaces/S000124/properties/P000048.md
+++ b/spaces/S000124/properties/P000048.md
@@ -1,5 +1,4 @@
 ---
-uid: T000464
 space: S000124
 property: P000048
 value: true

--- a/spaces/S000124/properties/P000049.md
+++ b/spaces/S000124/properties/P000049.md
@@ -1,5 +1,4 @@
 ---
-uid: T000467
 space: S000124
 property: P000049
 value: false

--- a/spaces/S000124/properties/P000051.md
+++ b/spaces/S000124/properties/P000051.md
@@ -1,5 +1,4 @@
 ---
-uid: T000466
 space: S000124
 property: P000051
 value: false

--- a/spaces/S000124/properties/P000056.md
+++ b/spaces/S000124/properties/P000056.md
@@ -1,5 +1,4 @@
 ---
-uid: T001052
 space: S000124
 property: P000056
 value: true

--- a/spaces/S000124/properties/P000057.md
+++ b/spaces/S000124/properties/P000057.md
@@ -1,5 +1,4 @@
 ---
-uid: T000992
 space: S000124
 property: P000057
 value: true

--- a/spaces/S000125/properties/P000022.md
+++ b/spaces/S000125/properties/P000022.md
@@ -1,5 +1,4 @@
 ---
-uid: T001043
 space: S000125
 property: P000022
 value: false

--- a/spaces/S000125/properties/P000023.md
+++ b/spaces/S000125/properties/P000023.md
@@ -1,5 +1,4 @@
 ---
-uid: T024392
 space: S000125
 property: P000023
 value: false

--- a/spaces/S000125/properties/P000027.md
+++ b/spaces/S000125/properties/P000027.md
@@ -1,5 +1,4 @@
 ---
-uid: T001048
 space: S000125
 property: P000027
 value: true

--- a/spaces/S000125/properties/P000036.md
+++ b/spaces/S000125/properties/P000036.md
@@ -1,5 +1,4 @@
 ---
-uid: T001059
 space: S000125
 property: P000036
 value: true

--- a/spaces/S000125/properties/P000037.md
+++ b/spaces/S000125/properties/P000037.md
@@ -1,5 +1,4 @@
 ---
-uid: T001068
 space: S000125
 property: P000037
 value: false

--- a/spaces/S000125/properties/P000041.md
+++ b/spaces/S000125/properties/P000041.md
@@ -1,5 +1,4 @@
 ---
-uid: T001063
 space: S000125
 property: P000041
 value: false

--- a/spaces/S000125/properties/P000045.md
+++ b/spaces/S000125/properties/P000045.md
@@ -1,5 +1,4 @@
 ---
-uid: T001060
 space: S000125
 property: P000045
 value: true

--- a/spaces/S000125/properties/P000053.md
+++ b/spaces/S000125/properties/P000053.md
@@ -1,5 +1,4 @@
 ---
-uid: T000965
 space: S000125
 property: P000053
 value: true

--- a/spaces/S000125/properties/P000058.md
+++ b/spaces/S000125/properties/P000058.md
@@ -1,5 +1,4 @@
 ---
-uid: T001053
 space: S000125
 property: P000058
 value: false

--- a/spaces/S000126/properties/P000027.md
+++ b/spaces/S000126/properties/P000027.md
@@ -1,5 +1,4 @@
 ---
-uid: T001049
 space: S000126
 property: P000027
 value: true

--- a/spaces/S000126/properties/P000051.md
+++ b/spaces/S000126/properties/P000051.md
@@ -1,5 +1,4 @@
 ---
-uid: T001066
 space: S000126
 property: P000051
 value: false

--- a/spaces/S000126/properties/P000053.md
+++ b/spaces/S000126/properties/P000053.md
@@ -1,5 +1,4 @@
 ---
-uid: T000966
 space: S000126
 property: P000053
 value: true

--- a/spaces/S000127/properties/P000016.md
+++ b/spaces/S000127/properties/P000016.md
@@ -1,5 +1,4 @@
 ---
-uid: T000468
 space: S000127
 property: P000016
 value: true

--- a/spaces/S000127/properties/P000036.md
+++ b/spaces/S000127/properties/P000036.md
@@ -1,5 +1,4 @@
 ---
-uid: T000469
 space: S000127
 property: P000036
 value: true

--- a/spaces/S000127/properties/P000046.md
+++ b/spaces/S000127/properties/P000046.md
@@ -1,5 +1,4 @@
 ---
-uid: T001058
 space: S000127
 property: P000046
 value: true

--- a/spaces/S000127/properties/P000053.md
+++ b/spaces/S000127/properties/P000053.md
@@ -1,5 +1,4 @@
 ---
-uid: T000957
 space: S000127
 property: P000053
 value: true

--- a/spaces/S000128/properties/P000029.md
+++ b/spaces/S000128/properties/P000029.md
@@ -1,5 +1,4 @@
 ---
-uid: T001009
 space: S000128
 property: P000029
 value: true

--- a/spaces/S000128/properties/P000044.md
+++ b/spaces/S000128/properties/P000044.md
@@ -1,5 +1,4 @@
 ---
-uid: T001023
 space: S000128
 property: P000044
 value: true

--- a/spaces/S000128/properties/P000053.md
+++ b/spaces/S000128/properties/P000053.md
@@ -1,5 +1,4 @@
 ---
-uid: T001007
 space: S000128
 property: P000053
 value: true

--- a/spaces/S000128/properties/P000059.md
+++ b/spaces/S000128/properties/P000059.md
@@ -1,5 +1,4 @@
 ---
-uid: T001036
 space: S000128
 property: P000059
 value: true

--- a/spaces/S000129/properties/P000023.md
+++ b/spaces/S000129/properties/P000023.md
@@ -1,5 +1,4 @@
 ---
-uid: T024406
 space: S000129
 property: P000023
 value: false

--- a/spaces/S000129/properties/P000038.md
+++ b/spaces/S000129/properties/P000038.md
@@ -1,5 +1,4 @@
 ---
-uid: T015434
 space: S000129
 property: P000038
 value: true

--- a/spaces/S000129/properties/P000053.md
+++ b/spaces/S000129/properties/P000053.md
@@ -1,5 +1,4 @@
 ---
-uid: T024410
 space: S000129
 property: P000053
 value: true

--- a/spaces/S000130/properties/P000036.md
+++ b/spaces/S000130/properties/P000036.md
@@ -1,5 +1,4 @@
 ---
-uid: T015444
 space: S000130
 property: P000036
 value: true

--- a/spaces/S000132/properties/P000017.md
+++ b/spaces/S000132/properties/P000017.md
@@ -1,5 +1,4 @@
 ---
-uid: T000481
 space: S000132
 property: P000017
 value: false

--- a/spaces/S000132/properties/P000023.md
+++ b/spaces/S000132/properties/P000023.md
@@ -1,5 +1,4 @@
 ---
-uid: T000480
 space: S000132
 property: P000023
 value: false

--- a/spaces/S000132/properties/P000026.md
+++ b/spaces/S000132/properties/P000026.md
@@ -1,5 +1,4 @@
 ---
-uid: T000482
 space: S000132
 property: P000026
 value: true

--- a/spaces/S000132/properties/P000048.md
+++ b/spaces/S000132/properties/P000048.md
@@ -1,5 +1,4 @@
 ---
-uid: T000483
 space: S000132
 property: P000048
 value: true

--- a/spaces/S000132/properties/P000051.md
+++ b/spaces/S000132/properties/P000051.md
@@ -1,5 +1,4 @@
 ---
-uid: T000484
 space: S000132
 property: P000051
 value: false

--- a/spaces/S000132/properties/P000053.md
+++ b/spaces/S000132/properties/P000053.md
@@ -1,5 +1,4 @@
 ---
-uid: T000479
 space: S000132
 property: P000053
 value: true

--- a/spaces/S000132/properties/P000058.md
+++ b/spaces/S000132/properties/P000058.md
@@ -1,5 +1,4 @@
 ---
-uid: T001041
 space: S000132
 property: P000058
 value: false

--- a/spaces/S000133/properties/P000023.md
+++ b/spaces/S000133/properties/P000023.md
@@ -1,5 +1,4 @@
 ---
-uid: T000489
 space: S000133
 property: P000023
 value: false

--- a/spaces/S000133/properties/P000026.md
+++ b/spaces/S000133/properties/P000026.md
@@ -1,5 +1,4 @@
 ---
-uid: T000488
 space: S000133
 property: P000026
 value: false

--- a/spaces/S000133/properties/P000029.md
+++ b/spaces/S000133/properties/P000029.md
@@ -1,5 +1,4 @@
 ---
-uid: T001018
 space: S000133
 property: P000029
 value: false

--- a/spaces/S000133/properties/P000049.md
+++ b/spaces/S000133/properties/P000049.md
@@ -1,5 +1,4 @@
 ---
-uid: T000491
 space: S000133
 property: P000049
 value: false

--- a/spaces/S000133/properties/P000050.md
+++ b/spaces/S000133/properties/P000050.md
@@ -1,5 +1,4 @@
 ---
-uid: T000490
 space: S000133
 property: P000050
 value: true

--- a/spaces/S000133/properties/P000051.md
+++ b/spaces/S000133/properties/P000051.md
@@ -1,5 +1,4 @@
 ---
-uid: T000492
 space: S000133
 property: P000051
 value: true

--- a/spaces/S000133/properties/P000053.md
+++ b/spaces/S000133/properties/P000053.md
@@ -1,5 +1,4 @@
 ---
-uid: T000487
 space: S000133
 property: P000053
 value: true

--- a/spaces/S000133/properties/P000055.md
+++ b/spaces/S000133/properties/P000055.md
@@ -1,5 +1,4 @@
 ---
-uid: T001033
 space: S000133
 property: P000055
 value: true

--- a/spaces/S000133/properties/P000058.md
+++ b/spaces/S000133/properties/P000058.md
@@ -1,5 +1,4 @@
 ---
-uid: T001040
 space: S000133
 property: P000058
 value: false

--- a/spaces/S000133/properties/P000059.md
+++ b/spaces/S000133/properties/P000059.md
@@ -1,5 +1,4 @@
 ---
-uid: T001037
 space: S000133
 property: P000059
 value: true

--- a/spaces/S000133/properties/P000065.md
+++ b/spaces/S000133/properties/P000065.md
@@ -1,5 +1,4 @@
 ---
-uid: T024723
 space: S000133
 property: P000065
 value: true

--- a/spaces/S000134/properties/P000023.md
+++ b/spaces/S000134/properties/P000023.md
@@ -1,5 +1,4 @@
 ---
-uid: T001027
 space: S000134
 property: P000023
 value: false

--- a/spaces/S000134/properties/P000026.md
+++ b/spaces/S000134/properties/P000026.md
@@ -1,5 +1,4 @@
 ---
-uid: T000494
 space: S000134
 property: P000026
 value: false

--- a/spaces/S000134/properties/P000029.md
+++ b/spaces/S000134/properties/P000029.md
@@ -1,5 +1,4 @@
 ---
-uid: T001019
 space: S000134
 property: P000029
 value: false

--- a/spaces/S000134/properties/P000038.md
+++ b/spaces/S000134/properties/P000038.md
@@ -1,5 +1,4 @@
 ---
-uid: T001016
 space: S000134
 property: P000038
 value: true

--- a/spaces/S000134/properties/P000043.md
+++ b/spaces/S000134/properties/P000043.md
@@ -1,5 +1,4 @@
 ---
-uid: T001014
 space: S000134
 property: P000043
 value: true

--- a/spaces/S000134/properties/P000044.md
+++ b/spaces/S000134/properties/P000044.md
@@ -1,5 +1,4 @@
 ---
-uid: T001021
 space: S000134
 property: P000044
 value: false

--- a/spaces/S000134/properties/P000053.md
+++ b/spaces/S000134/properties/P000053.md
@@ -1,5 +1,4 @@
 ---
-uid: T000493
 space: S000134
 property: P000053
 value: true

--- a/spaces/S000134/properties/P000055.md
+++ b/spaces/S000134/properties/P000055.md
@@ -1,5 +1,4 @@
 ---
-uid: T001034
 space: S000134
 property: P000055
 value: true

--- a/spaces/S000134/properties/P000059.md
+++ b/spaces/S000134/properties/P000059.md
@@ -1,5 +1,4 @@
 ---
-uid: T001038
 space: S000134
 property: P000059
 value: true

--- a/spaces/S000135/properties/P000008.md
+++ b/spaces/S000135/properties/P000008.md
@@ -1,5 +1,4 @@
 ---
-uid: T000495
 space: S000135
 property: P000008
 value: true

--- a/spaces/S000135/properties/P000018.md
+++ b/spaces/S000135/properties/P000018.md
@@ -1,5 +1,4 @@
 ---
-uid: T000497
 space: S000135
 property: P000018
 value: false

--- a/spaces/S000135/properties/P000023.md
+++ b/spaces/S000135/properties/P000023.md
@@ -1,5 +1,4 @@
 ---
-uid: T000498
 space: S000135
 property: P000023
 value: false

--- a/spaces/S000135/properties/P000026.md
+++ b/spaces/S000135/properties/P000026.md
@@ -1,5 +1,4 @@
 ---
-uid: T000499
 space: S000135
 property: P000026
 value: false

--- a/spaces/S000135/properties/P000028.md
+++ b/spaces/S000135/properties/P000028.md
@@ -1,5 +1,4 @@
 ---
-uid: T000496
 space: S000135
 property: P000028
 value: false

--- a/spaces/S000135/properties/P000029.md
+++ b/spaces/S000135/properties/P000029.md
@@ -1,5 +1,4 @@
 ---
-uid: T001020
 space: S000135
 property: P000029
 value: false

--- a/spaces/S000135/properties/P000030.md
+++ b/spaces/S000135/properties/P000030.md
@@ -1,5 +1,4 @@
 ---
-uid: T000500
 space: S000135
 property: P000030
 value: true

--- a/spaces/S000135/properties/P000034.md
+++ b/spaces/S000135/properties/P000034.md
@@ -1,5 +1,4 @@
 ---
-uid: T001031
 space: S000135
 property: P000034
 value: true

--- a/spaces/S000135/properties/P000038.md
+++ b/spaces/S000135/properties/P000038.md
@@ -1,5 +1,4 @@
 ---
-uid: T001017
 space: S000135
 property: P000038
 value: true

--- a/spaces/S000135/properties/P000043.md
+++ b/spaces/S000135/properties/P000043.md
@@ -1,5 +1,4 @@
 ---
-uid: T001015
 space: S000135
 property: P000043
 value: true

--- a/spaces/S000135/properties/P000044.md
+++ b/spaces/S000135/properties/P000044.md
@@ -1,5 +1,4 @@
 ---
-uid: T001022
 space: S000135
 property: P000044
 value: false

--- a/spaces/S000135/properties/P000056.md
+++ b/spaces/S000135/properties/P000056.md
@@ -1,5 +1,4 @@
 ---
-uid: T001035
 space: S000135
 property: P000056
 value: false

--- a/spaces/S000135/properties/P000059.md
+++ b/spaces/S000135/properties/P000059.md
@@ -1,5 +1,4 @@
 ---
-uid: T001039
 space: S000135
 property: P000059
 value: true

--- a/spaces/S000136/properties/P000003.md
+++ b/spaces/S000136/properties/P000003.md
@@ -1,5 +1,4 @@
 ---
-uid: T000501
 space: S000136
 property: P000003
 value: true

--- a/spaces/S000136/properties/P000007.md
+++ b/spaces/S000136/properties/P000007.md
@@ -1,5 +1,4 @@
 ---
-uid: T000502
 space: S000136
 property: P000007
 value: true

--- a/spaces/S000136/properties/P000018.md
+++ b/spaces/S000136/properties/P000018.md
@@ -1,5 +1,4 @@
 ---
-uid: T001012
 space: S000136
 property: P000018
 value: false

--- a/spaces/S000136/properties/P000030.md
+++ b/spaces/S000136/properties/P000030.md
@@ -1,5 +1,4 @@
 ---
-uid: T000504
 space: S000136
 property: P000030
 value: false

--- a/spaces/S000136/properties/P000031.md
+++ b/spaces/S000136/properties/P000031.md
@@ -1,5 +1,4 @@
 ---
-uid: T000506
 space: S000136
 property: P000031
 value: false

--- a/spaces/S000136/properties/P000056.md
+++ b/spaces/S000136/properties/P000056.md
@@ -1,5 +1,4 @@
 ---
-uid: T001111
 space: S000136
 property: P000056
 value: false

--- a/spaces/S000136/properties/P000059.md
+++ b/spaces/S000136/properties/P000059.md
@@ -1,5 +1,4 @@
 ---
-uid: T001011
 space: S000136
 property: P000059
 value: false

--- a/spaces/S000137/properties/P000007.md
+++ b/spaces/S000137/properties/P000007.md
@@ -1,5 +1,4 @@
 ---
-uid: T000503
 space: S000137
 property: P000007
 value: true

--- a/spaces/S000137/properties/P000030.md
+++ b/spaces/S000137/properties/P000030.md
@@ -1,5 +1,4 @@
 ---
-uid: T000505
 space: S000137
 property: P000030
 value: false

--- a/spaces/S000137/properties/P000031.md
+++ b/spaces/S000137/properties/P000031.md
@@ -1,5 +1,4 @@
 ---
-uid: T000507
 space: S000137
 property: P000031
 value: true

--- a/spaces/S000137/properties/P000032.md
+++ b/spaces/S000137/properties/P000032.md
@@ -1,5 +1,4 @@
 ---
-uid: T000508
 space: S000137
 property: P000032
 value: true

--- a/spaces/S000137/properties/P000059.md
+++ b/spaces/S000137/properties/P000059.md
@@ -1,5 +1,4 @@
 ---
-uid: T001010
 space: S000137
 property: P000059
 value: false

--- a/spaces/S000138/properties/P000007.md
+++ b/spaces/S000138/properties/P000007.md
@@ -1,5 +1,4 @@
 ---
-uid: T000177
 space: S000138
 property: P000007
 value: true

--- a/spaces/S000147/properties/P000053.md
+++ b/spaces/S000147/properties/P000053.md
@@ -1,5 +1,4 @@
 ---
-uid: T023627
 space: S000147
 property: P000053
 value: true

--- a/spaces/S000147/properties/P000066.md
+++ b/spaces/S000147/properties/P000066.md
@@ -1,5 +1,4 @@
 ---
-uid: T023622
 space: S000147
 property: P000066
 value: true

--- a/spaces/S000147/properties/P000069.md
+++ b/spaces/S000147/properties/P000069.md
@@ -1,5 +1,4 @@
 ---
-uid: T023625
 space: S000147
 property: P000069
 value: false

--- a/spaces/S000154/properties/P000002.md
+++ b/spaces/S000154/properties/P000002.md
@@ -1,5 +1,4 @@
 ---
-uid: T000607
 space: S000154
 property: P000002
 value: true

--- a/spaces/S000154/properties/P000008.md
+++ b/spaces/S000154/properties/P000008.md
@@ -1,5 +1,4 @@
 ---
-uid: T000608
 space: S000154
 property: P000008
 value: true

--- a/spaces/S000154/properties/P000015.md
+++ b/spaces/S000154/properties/P000015.md
@@ -1,5 +1,4 @@
 ---
-uid: T000609
 space: S000154
 property: P000015
 value: false

--- a/spaces/S000154/properties/P000016.md
+++ b/spaces/S000154/properties/P000016.md
@@ -1,5 +1,4 @@
 ---
-uid: T000610
 space: S000154
 property: P000016
 value: true

--- a/spaces/S000154/properties/P000020.md
+++ b/spaces/S000154/properties/P000020.md
@@ -1,5 +1,4 @@
 ---
-uid: T000611
 space: S000154
 property: P000020
 value: true

--- a/spaces/S000154/properties/P000026.md
+++ b/spaces/S000154/properties/P000026.md
@@ -1,5 +1,4 @@
 ---
-uid: T000612
 space: S000154
 property: P000026
 value: false

--- a/spaces/S000154/properties/P000028.md
+++ b/spaces/S000154/properties/P000028.md
@@ -1,5 +1,4 @@
 ---
-uid: T000613
 space: S000154
 property: P000028
 value: false

--- a/spaces/S000154/properties/P000048.md
+++ b/spaces/S000154/properties/P000048.md
@@ -1,5 +1,4 @@
 ---
-uid: T000614
 space: S000154
 property: P000048
 value: true

--- a/spaces/S000154/properties/P000049.md
+++ b/spaces/S000154/properties/P000049.md
@@ -1,5 +1,4 @@
 ---
-uid: T000615
 space: S000154
 property: P000049
 value: false

--- a/spaces/S000154/properties/P000050.md
+++ b/spaces/S000154/properties/P000050.md
@@ -1,5 +1,4 @@
 ---
-uid: T000617
 space: S000154
 property: P000050
 value: true

--- a/spaces/S000154/properties/P000051.md
+++ b/spaces/S000154/properties/P000051.md
@@ -1,5 +1,4 @@
 ---
-uid: T000616
 space: S000154
 property: P000051
 value: true

--- a/spaces/S000154/properties/P000080.md
+++ b/spaces/S000154/properties/P000080.md
@@ -1,5 +1,4 @@
 ---
-uid: T025511
 space: S000154
 property: P000080
 value: true

--- a/spaces/S000156/properties/P000057.md
+++ b/spaces/S000156/properties/P000057.md
@@ -1,5 +1,4 @@
 ---
-uid: T026148
 space: S000156
 property: P000057
 value: true

--- a/spaces/S000156/properties/P000080.md
+++ b/spaces/S000156/properties/P000080.md
@@ -1,5 +1,4 @@
 ---
-uid: T026163
 space: S000156
 property: P000080
 value: false

--- a/spaces/S000158/properties/P000016.md
+++ b/spaces/S000158/properties/P000016.md
@@ -1,5 +1,4 @@
 ---
-uid: T026433
 space: S000158
 property: P000016
 value: true

--- a/spaces/S000158/properties/P000038.md
+++ b/spaces/S000158/properties/P000038.md
@@ -1,5 +1,4 @@
 ---
-uid: T026383
 space: S000158
 property: P000038
 value: true

--- a/spaces/S000158/properties/P000053.md
+++ b/spaces/S000158/properties/P000053.md
@@ -1,5 +1,4 @@
 ---
-uid: T026394
 space: S000158
 property: P000053
 value: true

--- a/spaces/S001103/properties/P000006.md
+++ b/spaces/S001103/properties/P000006.md
@@ -1,5 +1,4 @@
 ---
-uid: T115181
 space: S001103
 property: P000006
 value: true

--- a/spaces/S001103/properties/P000013.md
+++ b/spaces/S001103/properties/P000013.md
@@ -1,5 +1,4 @@
 ---
-uid: T115218
 space: S001103
 property: P000013
 value: false

--- a/spaces/S001103/properties/P000017.md
+++ b/spaces/S001103/properties/P000017.md
@@ -1,5 +1,4 @@
 ---
-uid: T115202
 space: S001103
 property: P000017
 value: false

--- a/spaces/S001103/properties/P000023.md
+++ b/spaces/S001103/properties/P000023.md
@@ -1,5 +1,4 @@
 ---
-uid: T115205
 space: S001103
 property: P000023
 value: false

--- a/spaces/S001103/properties/P000026.md
+++ b/spaces/S001103/properties/P000026.md
@@ -1,5 +1,4 @@
 ---
-uid: T115200
 space: S001103
 property: P000026
 value: false

--- a/spaces/S001103/properties/P000028.md
+++ b/spaces/S001103/properties/P000028.md
@@ -1,5 +1,4 @@
 ---
-uid: T115190
 space: S001103
 property: P000028
 value: false

--- a/spaces/S001103/properties/P000044.md
+++ b/spaces/S001103/properties/P000044.md
@@ -1,5 +1,4 @@
 ---
-uid: T101125
 space: S001103
 property: P000044
 value: false

--- a/spaces/S001103/properties/P000050.md
+++ b/spaces/S001103/properties/P000050.md
@@ -1,5 +1,4 @@
 ---
-uid: T115207
 space: S001103
 property: P000050
 value: true

--- a/spaces/S001103/properties/P000051.md
+++ b/spaces/S001103/properties/P000051.md
@@ -1,5 +1,4 @@
 ---
-uid: T115217
 space: S001103
 property: P000051
 value: false


### PR DESCRIPTION
Last batch of the cleanup for issue #58.  Command used:

`sed -b -i '/^uid: /d' S*/properties/*.md`