### PR TITLE
Add "converse" attributes to multiple theorems

### DIFF
--- a/theorems/T000031.md
+++ b/theorems/T000031.md
@@ -4,7 +4,6 @@ if:
   - P000123: true
   - P000003: true
   - P000027: true
-converse: null
 uid: T000031
 then:
   P000124: true

--- a/theorems/T000055.md
+++ b/theorems/T000055.md
@@ -3,7 +3,6 @@ if:
   and:
   - P000005: true
   - P000018: true
-converse: null
 uid: T000055
 then:
   P000035: true

--- a/theorems/T000148.md
+++ b/theorems/T000148.md
@@ -6,6 +6,10 @@ if:
   - P000001: true
 then:
   P000005: true
+converse:
+- T000146
+- T000033
+- T000032
 refs:
 - doi: 10.1007/978-1-4612-6290-9
   name: Counterexamples in Topology

--- a/theorems/T000151.md
+++ b/theorems/T000151.md
@@ -6,6 +6,9 @@ if:
   - P000001: true
 then:
   P000006: true
+converse:
+- T000149
+- T000115
 refs:
 - doi: 10.1007/978-1-4612-6290-9
   name: Counterexamples in Topology

--- a/theorems/T000209.md
+++ b/theorems/T000209.md
@@ -6,6 +6,9 @@ if:
   - P000086: true
 then:
   P000052: true
+converse:
+- T000042
+- T000204
 refs:
 - mr: MR2048350
   name: General Topology (Willard)

--- a/theorems/T000237.md
+++ b/theorems/T000237.md
@@ -1,7 +1,6 @@
 ---
 if:
   P000111: true
-converse: null
 uid: T000237
 then:
   P000017: true

--- a/theorems/T000247.md
+++ b/theorems/T000247.md
@@ -6,6 +6,9 @@ if:
   - P000129: true
 then:
   P000125: false
+converse:
+- T000248
+- T000249
 refs:
   - wikipedia: Finite_topological_space
     name: Finite Topological space

--- a/theorems/T000257.md
+++ b/theorems/T000257.md
@@ -6,6 +6,10 @@ if:
   - P000132: true
 then:
   P000015: true
+converse:
+- T000156
+- T000036
+- T000256
 refs:
   - doi: 10.1007/978-1-4612-6290-9
     name: Counterexamples in Topology


### PR DESCRIPTION
Add "converse" attribute to these theorems:
- https://topology.pi-base.org/theorems/T000148
- https://topology.pi-base.org/theorems/T000151
- https://topology.pi-base.org/theorems/T000209
- https://topology.pi-base.org/theorems/T000247
- https://topology.pi-base.org/theorems/T000257

Also remove unnecessary "converse: null" from a few places.