### PR TITLE
Minor fixes

### DIFF
--- a/spaces/S000134/README.md
+++ b/spaces/S000134/README.md
@@ -12,12 +12,12 @@ refs:
     name: Hedgehog space
 ---
 If $d$ is the usual metric on $\mathbb{R}^2$, the radial metric $r$ is defined by:
-$$
+\[
 r(x,y) = \begin{cases}
-    d(x,y), & \text{$x$ and $y$ lie on the same line through the origin} \\\\
+    d(x,y), & x \text{ and } y \text{ lie on the same line through the origin} \\\\
     d(x,(0,0)) + d(y,(0,0)), & \text{otherwise.}
 \end{cases}
-$$
+\]
 
 Defined as counterexample #140 ("The Radial Metric")
 in {{doi:10.1007/978-1-4612-6290-9}}.

--- a/spaces/S000134/README.md
+++ b/spaces/S000134/README.md
@@ -12,12 +12,13 @@ refs:
     name: Hedgehog space
 ---
 If $d$ is the usual metric on $\mathbb{R}^2$, the radial metric $r$ is defined by:
-\[
+
+$$
 r(x,y) = \begin{cases}
     d(x,y), & x \text{ and } y \text{ lie on the same line through the origin} \\\\
     d(x,(0,0)) + d(y,(0,0)), & \text{otherwise.}
 \end{cases}
-\]
+$$
 
 Defined as counterexample #140 ("The Radial Metric")
 in {{doi:10.1007/978-1-4612-6290-9}}.

--- a/spaces/S000134/README.md
+++ b/spaces/S000134/README.md
@@ -13,12 +13,10 @@ refs:
 ---
 If $d$ is the usual metric on $\mathbb{R}^2$, the radial metric $r$ is defined by:
 
-$$
-r(x,y) = \\begin{cases}
-    d(x,y), & x \\text{ and } y \\text{ lie on the same line through the origin} \\\\
-    d(x,(0,0)) + d(y,(0,0)), & \\text{otherwise.}
-\\end{cases}
-$$
+$$r(x,y) = \\begin{cases}
+d(x,y), & x \\text{ and } y \\text{ lie on the same line through the origin} \\\\
+d(x,(0,0)) + d(y,(0,0)), & \\text{otherwise.}
+\\end{cases}$$
 
 Defined as counterexample #140 ("The Radial Metric")
 in {{doi:10.1007/978-1-4612-6290-9}}.

--- a/spaces/S000134/README.md
+++ b/spaces/S000134/README.md
@@ -12,12 +12,12 @@ refs:
     name: Hedgehog space
 ---
 If $d$ is the usual metric on $\mathbb{R}^2$, the radial metric $r$ is defined by:
-\[
+$$
 r(x,y) = \begin{cases}
     d(x,y), & \text{$x$ and $y$ lie on the same line through the origin} \\\\
     d(x,(0,0)) + d(y,(0,0)), & \text{otherwise.}
 \end{cases}
-\]
+$$
 
 Defined as counterexample #140 ("The Radial Metric")
 in {{doi:10.1007/978-1-4612-6290-9}}.

--- a/spaces/S000134/README.md
+++ b/spaces/S000134/README.md
@@ -13,12 +13,12 @@ refs:
 ---
 If $d$ is the usual metric on $\mathbb{R}^2$, the radial metric $r$ is defined by:
 
-$$
-r(x,y) = \begin{cases}
-    d(x,y), & x \text{ and } y \text{ lie on the same line through the origin} \\\\
-    d(x,(0,0)) + d(y,(0,0)), & \text{otherwise.}
-\end{cases}
-$$
+\\[
+r(x,y) = \\begin{cases}
+    d(x,y), & x \\text{ and } y \\text{ lie on the same line through the origin} \\\\
+    d(x,(0,0)) + d(y,(0,0)), & \\text{otherwise.}
+\\end{cases}
+\\]
 
 Defined as counterexample #140 ("The Radial Metric")
 in {{doi:10.1007/978-1-4612-6290-9}}.

--- a/spaces/S000134/README.md
+++ b/spaces/S000134/README.md
@@ -13,10 +13,10 @@ refs:
 ---
 If $d$ is the usual metric on $\mathbb{R}^2$, the radial metric $r$ is defined by:
 
-$$r(x,y) = \\begin{cases}
-d(x,y), & x \\text{ and } y \\text{ lie on the same line through the origin} \\\\
-d(x,(0,0)) + d(y,(0,0)), & \\text{otherwise.}
-\\end{cases}$$
+$r(x,y) = \begin{cases}
+d(x,y), & x \text{ and } y \text{ colinear with } \vec 0\\
+d(x,\vec 0) + d(y,\vec 0), & \text{otherwise.}
+\end{cases}$
 
 Defined as counterexample #140 ("The Radial Metric")
 in {{doi:10.1007/978-1-4612-6290-9}}.

--- a/spaces/S000134/README.md
+++ b/spaces/S000134/README.md
@@ -13,12 +13,12 @@ refs:
 ---
 If $d$ is the usual metric on $\mathbb{R}^2$, the radial metric $r$ is defined by:
 
-\\[
+$$
 r(x,y) = \\begin{cases}
     d(x,y), & x \\text{ and } y \\text{ lie on the same line through the origin} \\\\
     d(x,(0,0)) + d(y,(0,0)), & \\text{otherwise.}
 \\end{cases}
-\\]
+$$
 
 Defined as counterexample #140 ("The Radial Metric")
 in {{doi:10.1007/978-1-4612-6290-9}}.

--- a/spaces/S000171/README.md
+++ b/spaces/S000171/README.md
@@ -7,5 +7,5 @@ refs:
     name: Example of an uncountable scattered space with some properties
 ---
 
-In [[mo:416331]] Will Brian provides an example in ZFC for an uncountable, Hausdorff,
+In {{mo:416331}} Will Brian provides an example in ZFC for an uncountable, Hausdorff,
 first-countable, scattered, Lindelöf space.

--- a/theorems/T000151.md
+++ b/theorems/T000151.md
@@ -9,6 +9,10 @@ then:
 converse:
 - T000149
 - T000115
+- T000033
+- T000032
+- T000118
+- T000119
 refs:
 - doi: 10.1007/978-1-4612-6290-9
   name: Counterexamples in Topology


### PR DESCRIPTION
Fixed the mo ref in Brian's example, the math mode delimiter in the radial plane, and completed some converse references for Theorem 151.

Upon further inspection, the piece-wise definition in the radial plane (space 134) still doesn't render correctly. I'm not sure how to address this.