### PR TITLE
Update theorems showing relationships between all locally compact related properties

### DIFF
--- a/properties/P000024.md
+++ b/properties/P000024.md
@@ -8,7 +8,7 @@ refs:
   - doi: 10.1007/978-1-4612-6290-9
     name: Counterexamples in Topology
   - wikipedia: Locally_compact_space
-    name: Locally compact space
+    name: Locally compact space on Wikipedia
 ---
 
 Each point has a basis of neighborhoods relatively compact to the space.
@@ -16,4 +16,4 @@ Each point has a basis of neighborhoods relatively compact to the space.
 Equivalently (see {{wikipedia:Locally_compact_space}}), every point in $X$ has
 a closed and compact neighborhood.
 
-Defined on page 20 of {{doi:10.1007/978-1-4612-6290-9}} as "strongly locally compact". Contrast with [P000130](/properties/P000130).
+Defined on page 20 of {{doi:10.1007/978-1-4612-6290-9}} as "strongly locally compact". Contrast with {P130}.

--- a/properties/P000130.md
+++ b/properties/P000130.md
@@ -3,13 +3,9 @@ uid: P000130
 slug: locally-compact
 name: Locally Compact
 refs:
-  - doi: 10.2307/24340250
-    name: What is Locally Compact?
   - wikipedia: Locally_compact_space
-    name: Locally compact space
+    name: Locally compact space on Wikipedia
 ---
 Each point has a local basis of compact neighborhoods.
 
-Defined as strongly locally compact in {{doi:10.2307/24340250}}, discussing various kinds of
-local compactness.
-Given as (3) in {{wikipedia:Locally_compact_space}}.
+Given as condition (3) in {{wikipedia:Locally_compact_space}}.  See also the article "What is locally compact?" on p. 390 [here](http://www.pme-math.org/journal/issues/PMEJ.Vol.9.No.6.pdf), which discusses various kinds of local compactness.

--- a/properties/P000134.md
+++ b/properties/P000134.md
@@ -3,7 +3,7 @@ uid: P000134
 slug: preregular
 name: Preregular
 aliases:
-  - $R_1$
+  - "$R_1$"
 refs:
   - mr: MR1417259
     name: Handbook of Analysis and its Foundations (Schechter)

--- a/theorems/T000027.md
+++ b/theorems/T000027.md
@@ -2,15 +2,15 @@
 uid: T000027
 if:
   and:
-  - P000003: true
   - P000023: true
+  - P000134: true
 then:
-  P000006: true
+  P000012: true
 refs:
-- doi: 10.1007/978-1-4612-6290-9
-  name: Counterexamples in Topology
+  - mr: MR2048350
+    name: General Topology (Willard)
+  - mathse: 4503299
+    name: Locally compact preregular spaces are completely regular
 ---
 
-If $X$ is locally compact $T_2$, then it has a one-point compactification which is $T_4$ and thus $T_{3 \frac{1}{2}}$. Then $X$ is a subspace of its one-point compactification and so is also $T_{3 \frac{1}{2}}$.
-
-Asserted in Figure 7 of {{doi:10.1007/978-1-4612-6290-9}}.
+By Theorem 19.3 in {{mr:2048350}} locally compact Hausdorff spaces are completely regular.  The general case follows by passing to the Kolmogorov quotient, as explained for example in {{mathse:4503299}}.

--- a/theorems/T000224.md
+++ b/theorems/T000224.md
@@ -3,12 +3,12 @@ uid: T000224
 if:
   and:
   - P000023: true
-  - P000003: true
+  - P000011: true
 then:
   P000024: true
 refs:
-- doi: 10.1007/978-1-4612-6290-9
-  name: Counterexamples in Topology
+- mr: MR0370454
+  name: General Topology (Kelley)
 ---
 
-Asserted on the bottom of page 20 in {{doi:10.1007/978-1-4612-6290-9}}.
+By Theorem 17 in chapter 5, p. 146, of {{mr:0370454}} every point in a weakly locally compact regular space has a local base of closed compact neighborhoods (which obviously have compact closure).

--- a/theorems/T000224.md
+++ b/theorems/T000224.md
@@ -13,6 +13,6 @@ refs:
     name: Locally compact space on Wikipedia
 ---
 
-By Theorem 17 in chapter 5, p. 146, of {{mr:0370454}} every point in a weakly locally compact regular space has a local base of closed compact neighborhoods (which obviously have compact closure).
+By Theorem 17 in chapter 5, p. 146, of {{mr:0370454}} every point in a weakly locally compact regular space has a local base of closed compact neighborhoods.
 
 See also {{wikipedia:Locally_compact_space}}.

--- a/theorems/T000224.md
+++ b/theorems/T000224.md
@@ -7,8 +7,12 @@ if:
 then:
   P000024: true
 refs:
-- mr: MR0370454
-  name: General Topology (Kelley)
+  - mr: MR0370454
+    name: General Topology (Kelley)
+  - wikipedia: Locally_compact_space
+    name: Locally compact space on Wikipedia
 ---
 
 By Theorem 17 in chapter 5, p. 146, of {{mr:0370454}} every point in a weakly locally compact regular space has a local base of closed compact neighborhoods (which obviously have compact closure).
+
+See also {{wikipedia:Locally_compact_space}}.

--- a/theorems/T000245.md
+++ b/theorems/T000245.md
@@ -5,8 +5,8 @@ if:
 then:
   P000023: true
 refs:
-  - doi: 10.2307/24340250
-    name: What is Locally Compact?
+  - wikipedia: Locally_compact_space
+    name: Locally compact space on Wikipedia
 ---
 
-See {{doi:10.2307/24340250}}. Having a basis of compact neighborhoods implies at least one compact neighborhood.
+Having a local base of compact neighborhoods implies at least one compact neighborhood.  See {{wikipedia:Locally_compact_space}}.

--- a/theorems/T000246.md
+++ b/theorems/T000246.md
@@ -2,17 +2,19 @@
 uid: T000246
 if:
   and:
-  - P000003: true
   - P000023: true
+  - P000011: true
 then:
   P000130: true
 refs:
+  - mr: MR0370454
+    name: General Topology (Kelley)
   - mathse: 3812324
     name: Weakly locally compact vs. locally compact
+  - wikipedia: Locally_compact_space
+    name: Locally compact space on Wikipedia
 ---
 
-As shown in {{mathse:3812324}}.
+By Theorem 17 in chapter 5, p. 146, of {{mr:0370454}} every point in a weakly locally compact regular space has a local base of closed compact neighborhoods.
 
-Note first that any closed subspace of a compact is itself compact. If the space is Hausdorff, then every compact set $K$ in the space is closed, see <https://math.stackexchange.com/q/83355>.
-
-So then let $K$ be the given compact neighborhood of a point $x$ in a weakly locally compact Hausdorff space, and let $\mathcal B$ be a basis of open neighborhoods of $x$. Then $\mathcal B'=\{cl(B\cap K):B\in\mathcal B\}$ is a basis of closed neighborhoods of $x$. Since each $cl(B\cap K)\subseteq cl(K)=K$ , $\mathcal B'$ is a basis of compact neighborhoods, showing that a weakly locally compact Hausdorff space is strongly locally compact.
+See also {{mathse:3812324}} and {{wikipedia:Locally_compact_space}}.


### PR DESCRIPTION
(see issue #157)

Some cosmetic changes:
- P24
- P130: removed "What is locally compact?" article from the references, as the doi was not usable.  Added url to the corresponding pdf instead.
- P134: hoping the double quotes will do something
- T245: removed ref to "What is locally compact?", replaced by wikipedia

Substantial changes:
- T27: (Weakly locally compact (WLC) + T2 --> Tychonoff) replaced by (WLC + preregular --> completely regular)
- T224: (WLC + T2 --> locally relatively compact) replaced by (WLC + regular --> locally relatively compact)
- T246: (WLC + T2 --> locally compact) replaced by (WLC + regular --> locally compact)
This does not lose anything, as WLC + T2 implies regular via the new T27.