### PR TITLE
R0 property

### DIFF
--- a/properties/P000134.md
+++ b/properties/P000134.md
@@ -1,9 +1,9 @@
 ---
 uid: P000134
 slug: preregular
-name: Preregular
+name: $R_1$
 aliases:
-  - "$R_1$"
+  - Preregular
 refs:
   - mr: MR1417259
     name: Handbook of Analysis and its Foundations (Schechter)

--- a/properties/P000135.md
+++ b/properties/P000135.md
@@ -1,0 +1,14 @@
+---
+uid: P000135
+slug: R0
+name: $R_0$
+refs:
+  - wikipedia: T1_space
+    name: T1 space on Wikipedia
+  - mr: MR1417259
+    name: Handbook of Analysis and its Foundations (Schechter)
+---
+
+A space such that given any two topologically distinguishable points each has a neighborhood not including the other point.  (Two points are topologically distinguishable if there is an open set containing one of the points and not the other.)  Equivalently, a space whose Kolmogorov quotient is $T_1$.
+
+Defined in {{wikipedia:T1_space}}, which also lists many equivalent characterizations.  Also in definition 16.6, p. 438 of {{mr:1417259}} as "symmetric space".  The $R_0$ terminology seems preferable to avoid confusion with symmetric spaces from Riemannian geometry.

--- a/theorems/T000037.md
+++ b/theorems/T000037.md
@@ -2,17 +2,13 @@
 uid: T000037
 if:
   and:
-  - P000011: true
   - P000013: true
+  - P000135: true
 then:
   P000012: true
 refs:
-- doi: 10.1007/978-1-4612-6290-9
-  name: Counterexamples in Topology
+  - mathse: 3990826
+    name: $R_0$ and normal implies completely regular
 ---
 
-If $X$ is regular and normal, given any $a \in X$ and $B \subset X$ closed with $a \notin B$, by regularity there is some open set $U$ containing $a$ with $cl(U)$ disjoint from $B$. By Urysohn's Lemma, there is a continuous function $f:X \rightarrow [0,1]$ with $f(cl(U))=\{0\}$ and $f(B)=\{1\}$. Then clearly $f(a)=0$.
-
-Asserted in Figure 1 of {{doi:10.1007/978-1-4612-6290-9}}
-(where T_3 means regular, T_{3.5} means completely regular, and
-T_4 means normal).
+See {{mathse:3990826}}.

--- a/theorems/T000286.md
+++ b/theorems/T000286.md
@@ -1,0 +1,12 @@
+---
+uid: T000286
+if:
+  P000134: true
+then:
+  P000135: true
+refs:
+  - wikipedia: Separation_axiom
+    name: Separation axiom on Wikipedia
+---
+
+Follows directly from the definitions, and stated in {{wikipedia:Separation_axiom}}.

--- a/theorems/T000287.md
+++ b/theorems/T000287.md
@@ -1,0 +1,12 @@
+---
+uid: T000287
+if:
+  P000002: true
+then:
+  P000135: true
+refs:
+  - wikipedia: T1_space
+    name: $T_1$ space on Wikipedia
+---
+
+Follows directly from the definitions, and stated in {{wikipedia:T1_space}}.

--- a/theorems/T000288.md
+++ b/theorems/T000288.md
@@ -1,0 +1,17 @@
+---
+uid: T000288
+if:
+  and:
+  - P000135: true
+  - P000001: true
+then:
+  P000002: true
+converse:
+- T000287
+- T000119
+refs:
+  - wikipedia: T1_space
+    name: $T_1$ space on Wikipedia
+---
+
+Follows directly from the definitions.  See {{wikipedia:T1_space}}.

--- a/theorems/T000289.md
+++ b/theorems/T000289.md
@@ -1,0 +1,12 @@
+---
+uid: T000289
+if:
+  P000132: true
+then:
+  P000135: true
+refs:
+  - mathse: 4547643
+    name: $G_\delta$ spaces are $R_0$
+---
+
+See {{mathse:4547643}}.


### PR DESCRIPTION
Adding the R0 property (P135), as discussed in issue #164.

With related theorems:
- (T286) R1 ==> R0
- (T287) T1 ==> R0
- (T288) R0 + T0 ==> T1
- (T289) G_delta ==> R0

Generalized one theorem:
- (old T37) normal + regular ==> completely regular
- (new T37) normal + R0 ==> completely regular

Also made R1 the primary name for Preregular (P134).  I don't have strong feelings about that one, so we can revert that if you think it's better.
