### PR TITLE
T136 generalization

### DIFF
--- a/theorems/T000136.md
+++ b/theorems/T000136.md
@@ -3,12 +3,14 @@ uid: T000136
 if:
   and:
   - P000023: true
-  - P000003: true
+  - P000011: true
 then:
   P000064: true
 refs:
-- mr: MR2048350
-  name: General Topology (Willard)
+  - mr: MR0370454
+    name: General Topology (Kelley)
+  - mr: MR1417259
+    name: Handbook of Analysis and its Foundations (Schechter)
 ---
 
-By the Baire Category Theorem, see 25.4b of {{mr:MR2048350}}.
+See Theorem 34, p. 200 of {{mr:MR0370454}}, or Proposition 20.18, p. 538 of {{mr:MR1417259}}.


### PR DESCRIPTION
Generalization of T136 (see issue #157).

- (old T136) Weakly locally compact + T2 ==> Baire
- (new T136) Weakly locally compact + regular ==> Baire
