### PR TITLE
Converse for T292

### DIFF
--- a/theorems/T000292.md
+++ b/theorems/T000292.md
@@ -21,4 +21,4 @@ refs:
 
 See {{mathse:517411}}. For each $x\in X$, $X\setminus\{x\}$ must be sequentially closed;
 otherwise we could construct an infinite sequence converging to $x$. Therefore by {P79}
-we have $X\setminus\{x\}$ is closed and $\{x\}$ is open.
+we have $X\setminus\{x\}$ is closed and $\{x\}$ is open. 

--- a/theorems/T000292.md
+++ b/theorems/T000292.md
@@ -7,6 +7,13 @@ if:
     - P000136: true
 then:
   P000052: true
+converse:
+- T000042
+- T000218
+- T000285
+- T000183
+- T000184
+- T000294
 refs:
   - mathse: 517411
     name: Is a space where only finite subsets are compact sets always discrete?


### PR DESCRIPTION
I only added the lines for "converse:", but the diff shows all the lines as different.  Not exactly sure, but it seems it has to do with crlf versus lf in the repo itself?  (checked with "git diff ... |od -c")  Did something weird happen in your previous commit involving this file?  To confirm, I modified some files not involved in that commit and the problem does not happen there.

If needed to fix the git repo, feel free to discard this commit.  We can easily recreate it.
