### PR TITLE
New theorem: Smaller than continuum + completely regular ==> zero dim

### DIFF
--- a/theorems/T000054.md
+++ b/theorems/T000054.md
@@ -3,12 +3,12 @@ uid: T000054
 if:
   P000050: true
 then:
-  P000011: true
+  P000012: true
 refs:
 - doi: 10.1007/978-1-4612-6290-9
   name: Counterexamples in Topology
 ---
 
-If $X$ is zero dimensional, given any open $U \subset X$ and $x \in U$ then there is a clopen $x \in V \subset U$.
+If $X$ is zero dimensional, then given any open $U \subset X$ and $x \in U$ there is a clopen $V$ with $x \in V \subset U$.  The function equal to $0$ on $V$ and $1$ outside of $V$ is continuous and separates $x$ from the complement of $U$.
 
-Asserted on page 33 of {{doi:10.1007/978-1-4612-6290-9}}.
+Asserted on page 33 of {{doi:10.1007/978-1-4612-6290-9}} for the regularity property.  Completely regularity is the simple modification above.

--- a/theorems/T000300.md
+++ b/theorems/T000300.md
@@ -1,0 +1,14 @@
+---
+uid: T000300
+if:
+  and:
+    - P000058: true
+    - P000007: true
+then:
+  P000050: true
+refs:
+  - mathse: 4528918
+    name: Prove that a countable completely regular space is zero dimensional
+---
+
+Shown in {{mathse:4528918}} for countable spaces.  The same argument works for any cardinality less than the continuum.


### PR DESCRIPTION
Something like this came up in the conversation for issue #189.  This is slightly more general.

(T300) Smaller than the continuum + completely regular ==> zero dimensional

Also generalized (T54) slightly, as it involved the same properties:
- (old T54) zero dimensional ==> regular
- (new T54) zero dimensional ==> completely regular

(tracking in #188)
