### PR TITLE
New theorem: Countable + compact + R1 ==> pseudometrizable

### DIFF
--- a/theorems/T000302.md
+++ b/theorems/T000302.md
@@ -1,0 +1,15 @@
+---
+uid: T000302
+if:
+  and:
+    - P000057: true
+    - P000016: true
+    - P000134: true
+then:
+  P000121: true
+refs:
+  - mathse: 3705764
+    name: Every countable compact Hausdorff space is metrizable?
+---
+
+It is shown in {{mathse:3705764}} that countable compact Hausdorff spaces are metrizable.  The case of countable compact $R_1$ spaces being pseudometrizable follows by passing to the Kolmogorov quotient.


### PR DESCRIPTION
This came up in the conversation for #189 for countable compact $T_2$ spaces.  Slightly generalizing here to the equivalent with $R_1$.