### PR TITLE
T5: Untangle the position of hemicompact between P25 and P17

### DIFF
--- a/theorems/T000005.md
+++ b/theorems/T000005.md
@@ -3,12 +3,10 @@ uid: T000005
 if:
   P000025: true
 then:
-  P000017: true
+  P000111: true
 refs:
-- doi: 10.1007/978-1-4612-6290-9
-  name: Counterexamples in Topology
+- mathse: 4492531
+  name: Does locally compact and σ-compact non-Hausdorff space imply hemicompact?
 ---
 
-By definition.
-
-Asserted on page 22 of {{doi:10.1007/978-1-4612-6290-9}}.
+See the proof of the theorem in [this answer](https://math.stackexchange.com/a/4569500) to {{mathse:4492531}}.


### PR DESCRIPTION
Context: https://en.wikipedia.org/wiki/Exhaustion_by_compact_sets

The hemicompact property (P111) is right in between Exhaustible by compacts (P25) and sigma-compact (P17).  There should be a direct implication between P25 and P111 (we already have T237 to go from P111 to P17).  But it used to be a tangled mess to deduce this.  Simplify all this by changing the target of T5.

Hopefully that should also be useful in preparation for the changes in #208.
