### PR TITLE
T262 generalization

### DIFF
--- a/theorems/T000262.md
+++ b/theorems/T000262.md
@@ -2,8 +2,8 @@
 uid: T000262
 if:
   and:
-  - P000125: true
-  - P000003: true
+  - P000134: true
+  - P000129: false
 then:
   P000039: false
 refs:
@@ -11,4 +11,4 @@ refs:
     name: Hyperconnected space
 ---
 
-Distinct points have disjoint (nonempty) open neighborhoods.
+If $X$ is not indiscrete, it has a nonempty proper open subset.  A point in that subset and a point outside of it are topologically distinguishable, and therefore have disjoint neighborhoods, which shows that the space is not hyperconnected.


### PR DESCRIPTION
- (old T262)  Has distinct points + T_2 ==> not hyperconnected
- (new T262) R_1 + not indiscrete ==> not hyperconnected

The benefit is that this applies to both T_2 and regular spaces in this context without needing another theorem.  We don't lose anything as T_2 spaces with at least two points are R_1 and not indiscrete.
