### PR TITLE
Justification fixes for hyperconnected in various spaces

### DIFF
--- a/spaces/S000007/properties/P000039.md
+++ b/spaces/S000007/properties/P000039.md
@@ -7,6 +7,6 @@ refs:
   name: Counterexamples in Topology
 ---
 
-Every open set in $X$ contains $p$, so there are no disjoint open sets.
+Any two nonempty open sets intersect since they must contain $p$.
 
 See item #10 for space #8 in {{doi:10.1007/978-1-4612-6290-9_6}}.

--- a/spaces/S000008/properties/P000039.md
+++ b/spaces/S000008/properties/P000039.md
@@ -7,6 +7,6 @@ refs:
   name: Counterexamples in Topology
 ---
 
-Every open set in $X$ contains $p$, so there are no disjoint open sets.
+Any two nonempty open sets intersect since they must contain $p$.
 
 See item #10 for space #9 in {{doi:10.1007/978-1-4612-6290-9_6}}.

--- a/spaces/S000009/properties/P000039.md
+++ b/spaces/S000009/properties/P000039.md
@@ -7,6 +7,6 @@ refs:
   name: Counterexamples in Topology
 ---
 
-Every open set in $X$ contains $p$, so there are no disjoint open sets.
+Any two nonempty open sets intersect since they must contain $p$.
 
 See item #10 for space #10 in {{doi:10.1007/978-1-4612-6290-9_6}}.

--- a/spaces/S000010/properties/P000039.md
+++ b/spaces/S000010/properties/P000039.md
@@ -7,6 +7,6 @@ refs:
   name: Counterexamples in Topology
 ---
 
-No two open sets are disjoint since every open set contains the element $0$.
+No two nonempty open sets are disjoint since they all contain the element $0$.
 
 See item #18 for space #11 in {{doi:10.1007/978-1-4612-6290-9_6}}.

--- a/spaces/S000015/properties/P000039.md
+++ b/spaces/S000015/properties/P000039.md
@@ -7,6 +7,6 @@ refs:
   name: Counterexamples in Topology
 ---
 
-Since open sets are co-finite.
+Since nonempty open sets are co-finite.
 
 See item #6 for space #18 in {{doi:10.1007/978-1-4612-6290-9_6}}.

--- a/spaces/S000016/properties/P000039.md
+++ b/spaces/S000016/properties/P000039.md
@@ -7,6 +7,6 @@ refs:
   name: Counterexamples in Topology
 ---
 
-Let $\tau$ denote the Finite Complement Topology on an Uncountable Space. Let us be given any two open sets $U_i,U_n \in \tau$. Note that $U_i$ and $U_n$ are uncountable, since they both miss finitely many things. Let $U_j = U_i \cap U_n $ thus by definition $U_j = X - (U_i {}^c \cup U_n {}^c)$. Note that $U_i {}^c \cup U_n {}^c$ is finite since it is a finite union of finite sets, therefore $U_j$ is open. Thus $U_i$ and $U_n$ have uncountably many thins in common thus they are not disjoint, hence $\tau$ is hyper-connected.
+The intersection of two cofinite sets in $X$ is cofinite, hence not empty.
 
 See item #6 for space #19 in {{doi:10.1007/978-1-4612-6290-9_6}}.

--- a/spaces/S000017/properties/P000039.md
+++ b/spaces/S000017/properties/P000039.md
@@ -7,6 +7,6 @@ refs:
   name: Counterexamples in Topology
 ---
 
-If $A$ and $B$ are two open sets, then $X \setminus A$ and $X \setminus B$ are countable. Thus $X \setminus A \cup X \setminus B$ = $X \setminus (A \cap B)$ is countable and so $A \cap B$ is uncountable (and in particular, non-empty).
+If $A$ and $B$ are two nonempty open sets, then $X \setminus A$ and $X \setminus B$ are countable. Thus $X \setminus A \cup X \setminus B$ = $X \setminus (A \cap B)$ is countable and so $A \cap B$ is uncountable (and in particular, non-empty).
 
 See item #4 for space #20 in {{doi:10.1007/978-1-4612-6290-9_6}}.

--- a/spaces/S000019/properties/P000039.md
+++ b/spaces/S000019/properties/P000039.md
@@ -7,12 +7,6 @@ refs:
   name: Counterexamples in Topology
 ---
 
-Let $U_1$, $U_2 \in \tau$ where $U_1$, $U_2 \neq \emptyset$.
-Let $V_1 = \mathbb{R} / U_1$ and $V_2 = \mathbb{R} / U_2$.
-$V_1$ and $V_2$ are compact by definition.
-So, $V = V_1 \cup V_2$ are compact and thus bounded.
-Since $V$ is bounded, $V \neq \mathbb{R}$, and since $U_1$, $U_2 \neq \emptyset$, $v \neq \emptyset$.
-Thus, $V = (\mathbb{R} / U_1) \cup (\mathbb{R} / U_2) = R / (U_1 \cap U_2) \neq \emptyset$.
-This implies $U_1 \cap U_2 \neq \emptyset$.
+Let $U_1$ and $U_2$ be nonempty open sets in $X$.  Their complements $C_1$ and $C_2$ are compact in the Euclidean topology, and so is their union $C_1\cup C_2$, which cannot be the whole of $X$ since $\mathbb{R}$ is not compact in the Euclidean topology.  This shows that the intersection of $U_1$ and $U_2$ is not empty.
 
 See item #3 for space #22 in {{doi:10.1007/978-1-4612-6290-9_6}}.

--- a/spaces/S000044/properties/P000039.md
+++ b/spaces/S000044/properties/P000039.md
@@ -7,10 +7,4 @@ refs:
   name: Counterexamples in Topology
 ---
 
-Given that $U_n$ denotes sets in the nested interval topology we can see that
-\begin{align*}
-U_n \subset U_{n+1}
-\end{align*}
-for all $n \in \mathbb{N}$. Therefore for any two sets in the Nested Interval Topology one is a subset of the other which implies there are no disjoint open sets thus the Nested Interval Topology is Hyper-connected.
-
 See item #4 for space #52 in {{doi:10.1007/978-1-4612-6290-9_6}}.

--- a/spaces/S000045/properties/P000039.md
+++ b/spaces/S000045/properties/P000039.md
@@ -7,6 +7,6 @@ refs:
   name: Counterexamples in Topology
 ---
 
-Any open set must contain 0 so any two open sets must intersect.
+Any two nonempty open sets intersect since they must contain $0$.
 
 See item #3 for space #53 in {{doi:10.1007/978-1-4612-6290-9_6}}.

--- a/theorems/T000252.md
+++ b/theorems/T000252.md
@@ -9,4 +9,4 @@ refs:
     name: What topological properties are trivially/vacuously satisfied by any indiscrete space?
 ---
 
-No disjoint pair of nonempty closed sets exists.
+No disjoint nonempty closed sets exist, so the space is {P13}.  It is also a {P132}.


### PR DESCRIPTION
Cleaning up the justifications for the hyperconnected property of various spaces, especially sloppy language where "open set" was used to mean "nonempty open set".

Also fixed something in the justification for T252.
