### PR TITLE
T307 generalization

### DIFF
--- a/theorems/T000307.md
+++ b/theorems/T000307.md
@@ -2,16 +2,15 @@
 uid: T000307
 if:
   and:
-    - P000001: true
     - P000078: true
-    - P000137: false
+    - P000001: true
 then:
-  P000139: true
+  P000051: true
 refs:
   - mathse: 4583879
     name: Answer to "How many T0 topologies are possible for a set of 3 elements?"
 ---
 
-Suppose not. Then suppose $F$ is an open set with $|F|>1$ minimal. 
-Choose $x,y\in F$. There must be some open $U$ containing exactly one of $x,y$. 
-Then $U\cap F$ is open and $|U\cap F|<|F|$, contradiction.
+First assume $X$ is nonempty and show it has an isolated point.  Take a nonempty open set $U\subseteq X$ that is minimal under inclusion.  It cannot contain more than one point, otherwise intersecting with another open set that contains one point and not another in $U$ would give a strictly smaller open set, which is not possible.  So $U$ consists of one isolated point.
+
+Now given any nonempty subspace $A\subseteq X$, it is itself finite and $T_0$ and hence contains a point isolated in $A$.  This shows that $X$ is scattered.


### PR DESCRIPTION
- (old T307) T_0 + finite + not empty ==> has isolated point
- (new T307) finite + T_0 ==> scattered

By itself it is not a generalization of the old T307, but it is in combination with T306 (scattered + not empty ==> has isolated point).  And the new T307 provides a useful building block that can be used in current and future deductions.

This will also allow to clean up various trait files (tell me if I should do it in the same PR or separately is better).
