### PR TITLE
T292 generalization

### DIFF
--- a/theorems/T000292.md
+++ b/theorems/T000292.md
@@ -2,9 +2,9 @@
 uid: T000292
 if:
   and:
-    - P000002: true
-    - P000079: true
     - P000136: true
+    - P000002: true
+    - P000140: true
 then:
   P000052: true
 converse:
@@ -13,12 +13,11 @@ converse:
 - T000285
 - T000183
 - T000184
+- T000059
 - T000294
 refs:
-  - mathse: 517411
-    name: Is a space where only finite subsets are compact sets always discrete?
+  - mo: 434451
+    name: '"All retracts are closed" and "all compacts are closed"'
 ---
 
-See {{mathse:517411}}. For each $x\in X$, $X\setminus\{x\}$ must be sequentially closed;
-otherwise we could construct an infinite sequence converging to $x$. Therefore by {P79}
-we have $X\setminus\{x\}$ is closed and $\{x\}$ is open.
+See the discussion about {S23} in [this answer](https://mathoverflow.net/a/435257/458159) to {{mo:434451}}.  Suppose $X$ satisfies the hypotheses.  Take $A\subseteq X$.  We have to show $A$ is closed.  By {P140} it's enough to show that $A\cap K$ is closed in $K$ for every compact $K\subseteq X$.  But $A\cap K$ is finite (since $K$ is finite by {P136}) and is closed as a finite union of closed points (since $X$ is $T_1$).

--- a/theorems/T000323.md
+++ b/theorems/T000323.md
@@ -1,15 +1,12 @@
 ---
 uid: T000323
 if:
-  and:
-    - P000098: true
-    - P000002: true
-    - P000136: true
+  P000098: true
 then:
-  P000052: true
+  P000140: true
 refs:
-  - mathse: 4585825
-    name: Without Hausdorff, what implications can we prove about kω related to other covering properties?
+  - mathse: 4633318
+    name: Is every kω space a k space?
 ---
 
-See the discussion of {S000023} in [this answer](https://math.stackexchange.com/a/4586575/52912) to {{mathse:4585825}}.
+See {{mathse:4633318}}.


### PR DESCRIPTION
Subsume two theorems
- (old T292) Anticompact + T1 + sequential ==> discrete
- (T323) Anticompact + T1 + $k_\omega$ ==> discrete

into the more general

- (new T292) Anticompact + T1 + compactly generated ==> discrete

provided we also add $k_\omega$ ==> compactly generated.  This latter one could be added by reusing the slot for T323.
