### PR TITLE
T182: locally metrizable ==> first countable

### DIFF
--- a/theorems/T000182.md
+++ b/theorems/T000182.md
@@ -1,0 +1,12 @@
+---
+uid: T000182
+if:
+  P000082: true
+then:
+  P000028: true
+refs:
+- mr: MR0464128
+  name: Topology (Munkres)
+---
+
+Being {P28} is a local property.  So given a point $x\in X$ with a {P53} open neighborhood $V$ in $X$, take a countable local base at $x$ in $V$.  That collection of sets will also be a countable local base at $x$ in $X$.


### PR DESCRIPTION
The contrapositive will then automatically deduce that a lot more spaces are not locally metrizable.
