### PR TITLE
Some theorems and traits involving local metrizability

### DIFF
--- a/spaces/S000025/properties/P000123.md
+++ b/spaces/S000025/properties/P000123.md
@@ -1,0 +1,10 @@
+---
+space: S000025
+property: P000123
+value: true
+refs:
+- mr: 3728284
+  name: Topology (Munkres)
+---
+
+Evident from the definition of {P123}.

--- a/spaces/S000065/properties/P000082.md
+++ b/spaces/S000065/properties/P000082.md
@@ -1,0 +1,10 @@
+---
+space: S000065
+property: P000082
+value: true
+refs:
+- doi: 10.1007/978-1-4612-6290-9_6
+  name: Counterexamples in Topology
+---
+
+Every point has an open neighborhood homeomorphic to the interval $[0,1]$.

--- a/spaces/S000065/properties/P000099.md
+++ b/spaces/S000065/properties/P000099.md
@@ -1,0 +1,10 @@
+---
+space: S000065
+property: P000099
+value: false
+refs:
+- doi: 10.1007/978-1-4612-6290-9_6
+  name: Counterexamples in Topology
+---
+
+The sequence $(1-1/n)_{n\ge 1}$ converges to both $1$ and $1^*$.

--- a/spaces/S000170/properties/P000123.md
+++ b/spaces/S000170/properties/P000123.md
@@ -1,0 +1,10 @@
+---
+space: S000170
+property: P000123
+value: true
+refs:
+- wikipedia: Manifold
+  name: Manifold on Wikipedia
+---
+
+See {{wikipedia:Manifold}}.

--- a/theorems/T000328.md
+++ b/theorems/T000328.md
@@ -1,0 +1,12 @@
+---
+uid: T000328
+if:
+  P000082: true
+then:
+  P000002: true
+refs:
+  - mathse: 3142975
+    name: Locally Euclidean space implies T1 space
+---
+
+Around every point there is a neighborhood that is {P53}, hence $T_1$.  And a space that is "locally $T_1$" is $T_1$, as shown in {{mathse:3142975}}.

--- a/theorems/T000329.md
+++ b/theorems/T000329.md
@@ -1,0 +1,12 @@
+---
+uid: T000329
+if:
+  P000123: true
+then:
+  P000082: true
+refs:
+- mr: 3728284
+  name: Topology (Munkres)
+---
+
+Every point has a neighborhood that is homeomorphic to an open subset of some $\mathbb R^n$, hence {P53}.  See Exercise 1 on p. 317 of {{mr:3728284}}.


### PR DESCRIPTION
As discussed in #244, added theorems:
- T328: locally metrizable ==> T1
- T329: locally Euclidean ==> locally metrizable

Added trait of locally Euclidean for the real line and the circle.  That gives examples of manifold (P124), of which there were none before.

Telophase topology is now an example of locally metrizable but not metrizable.  Also added US (P99) = false for that space.
