### PR TITLE
Misc spaces: more precise position between T1 and T2

### DIFF
--- a/spaces/S000019/properties/P000099.md
+++ b/spaces/S000019/properties/P000099.md
@@ -1,0 +1,10 @@
+---
+space: S000019
+property: P000099
+value: false
+refs:
+- doi: 10.1007/978-1-4612-6290-9_6
+  name: Counterexamples in Topology
+---
+
+The sequence $(n)_{n\in\omega}$ is eventually outside of every compact subset of $\mathbb R$, that is, inside of every nonempty open set in $X$.  So it converges to every point of $X$.

--- a/spaces/S000024/properties/P000099.md
+++ b/spaces/S000024/properties/P000099.md
@@ -1,0 +1,10 @@
+---
+space: S000024
+property: P000099
+value: false
+refs:
+- doi: 10.1007/978-1-4612-6290-9_6
+  name: Counterexamples in Topology
+---
+
+An infinite sequence of distinct points of $\mathbb R$ converges to both $\infty_1$ and $\infty_2$.

--- a/spaces/S000097/README.md
+++ b/spaces/S000097/README.md
@@ -7,7 +7,7 @@ refs:
   - doi: 10.1007/978-1-4612-6290-9
     name: Counterexamples in Topology
 ---
-Let $X$ be the set of all lattice points $(i,j) \in \omega^2$ along with two extra points $x$ and $y$. Let each $(i,j)$ be open. Neighborhoods of $x$ have the form $X \setminus A$ where $A$ is any set of lattice points with at most finitely many points on each row. Neighborhoods of $y$ have the form $X \setminus B$ where $B$ is any set of lattice points selected from at most finitely many rows.
+Let $X$ be the set of all lattice points $(i,j) \in \omega^2$ together with two extra points $x$ and $y$. Let each $(i,j)$ be open. Basic neighborhoods of $x$ have the form $X \setminus (A\cup\{y\})$ where $A$ is any set of lattice points with at most finitely many points on each row. Basic neighborhoods of $y$ have the form $X \setminus (B\cup\{x\})$ where $B$ is any set of lattice points selected from at most finitely many rows.
 
 Defined as counterexample #99 ("Maximal Compact Topology")
 in {{doi:10.1007/978-1-4612-6290-9}}.

--- a/spaces/S000097/properties/P000100.md
+++ b/spaces/S000097/properties/P000100.md
@@ -1,0 +1,10 @@
+---
+space: S000097
+property: P000100
+value: true
+refs:
+- doi: 10.1007/978-1-4612-6290-9_6
+  name: Counterexamples in Topology
+---
+
+See item #3 for space #99 in {{doi:10.1007/978-1-4612-6290-9_6}}.

--- a/spaces/S000165/README.md
+++ b/spaces/S000165/README.md
@@ -7,4 +7,4 @@ refs:
     name: Answer to ""All retracts are closed" and "all compacts are closed""
 ---
 
-The one-point compactification of {S23}, see {{mo:435257}}.
+The one-point compactification $X$ of {S23}.  See [this answer](https://mathoverflow.net/a/435257) to {{mo:435257}}.

--- a/spaces/S000165/properties/P000143.md
+++ b/spaces/S000165/properties/P000143.md
@@ -1,0 +1,12 @@
+---
+space: S000165
+property: P000143
+value: false
+refs:
+  - mo: 435257
+    name: Answer to ""All retracts are closed" and "all compacts are closed""
+---
+
+Let $0$ be the non-isolated point of the Arens-Fort space.  The subspace $A=X\setminus\{0\}$ is homeomorphic to the one-point compactification of a discrete space (i.e., {S20}), which is compact and Hausdorff.  But $A$ is not closed in $X$.
+
+See [this answer](https://mathoverflow.net/a/435257) to {{mo:435257}}.


### PR DESCRIPTION
Checked the various spaces that are T1 and not T2.  Where necessary, added traits to pinpoint their position in the chain of implications: T2 ==> KC ==> weak Hausdorff ==> US ==> T1.

Also small fix for the description of space S97 (it was phrased such that each nbhd of x would contain y and vice versa, which is not what was meant).
