### PR TITLE
T328 update

### DIFF
--- a/theorems/T000195.md
+++ b/theorems/T000195.md
@@ -5,8 +5,12 @@ if:
 then:
   P000002: true
 refs:
-- mr: MR3084709
-  name: The equivalence relations of local homeomorphisms and Fell algebras
+  - mr: MR3084709
+    name: The equivalence relations of local homeomorphisms and Fell algebras
+  - mathse: 3142975
+    name: Locally Euclidean space implies T1 space
 ---
 
 Given $a,b\in X$ with $a\neq b$. We want to show that $a$ has a neighborhood that does not contain $b$. Since $X$ is locally $T_2$, there is an open neighborhood $U\subseteq X$ of $a$ which is Hausdorff. If $b\notin U$, the claim is proved. Assume now $b\in U$. Then $a$ und $b$ have disjoint open neighborhoods in $U$ which are also open in $X$.
+
+See also {{mathse:3142975}}.

--- a/theorems/T000328.md
+++ b/theorems/T000328.md
@@ -3,10 +3,10 @@ uid: T000328
 if:
   P000082: true
 then:
-  P000002: true
+  P000084: true
 refs:
-  - mathse: 3142975
-    name: Locally Euclidean space implies T1 space
+  - wikipedia: Metric_space
+    name: Metric space on Wikipedia
 ---
 
-Around every point there is a neighborhood that is {P53}, hence $T_1$.  And a space that is "locally $T_1$" is $T_1$, as shown in {{mathse:3142975}}.
+Around every point there is a neighborhood that is {P53}, hence {P3}.


### PR DESCRIPTION
One more generalization:
- (old T328) locally metrizable ==> T1
- (new T328) locally metrizable ==> locally Hausdorff

We don't lose anything, thanks to (T195) locally Hausdorff ==> T1.
