### PR TITLE
S31: square of one point compactification of Q

### DIFF
--- a/spaces/S000031/README.md
+++ b/spaces/S000031/README.md
@@ -1,0 +1,10 @@
+---
+uid: S000031
+slug: sq-one-point-compactification-of-the-rationals
+name: Square of One Point Compactification of the Rationals
+refs:
+- mathse: 632320
+  name: Weak Hausdorff space not KC
+---
+
+The space $X$ is the product $\mathbb Q^*\times \mathbb Q^*$ with $\mathbb Q^*=\mathbb Q\cup\{\infty\}$ equal to {S29}.

--- a/spaces/S000031/properties/P000016.md
+++ b/spaces/S000031/properties/P000016.md
@@ -1,0 +1,10 @@
+---
+space: S000031
+property: P000016
+value: true
+refs:
+- mathse: 632320
+  name: Weak Hausdorff space not KC
+---
+
+$X$ is compact as a product of compact spaces.

--- a/spaces/S000031/properties/P000020.md
+++ b/spaces/S000031/properties/P000020.md
@@ -1,0 +1,12 @@
+---
+space: S000031
+property: P000020
+value: true
+refs:
+  - mr: 2048350
+    name: General Topology (Willard)
+  - mathse: 1288007
+    name: Countable Product of Sequentially Compact spaces is Sequentially Compact
+---
+
+The space {S29} has the {P20} property.  And the property is preserved by countable products, as mentioned in Problem 17G.5 of {{mr:2048350}}.  Or see {{mathse:1288007}}.

--- a/spaces/S000031/properties/P000036.md
+++ b/spaces/S000031/properties/P000036.md
@@ -1,0 +1,10 @@
+---
+space: S000031
+property: P000036
+value: true
+refs:
+- mr: 2048350
+  name: General Topology (Willard)
+---
+
+The space {S29} has the {P36} property.  And the property is preserved by products, as shown in Theorem 26.10 of {{mr:2048350}}.

--- a/spaces/S000031/properties/P000041.md
+++ b/spaces/S000031/properties/P000041.md
@@ -1,0 +1,10 @@
+---
+space: S000031
+property: P000041
+value: false
+refs:
+  - mr: 2048350
+    name: General Topology (Willard)
+---
+
+By Problem 27F.2 of {{mr:2048350}}, the product of two nonempty spaces is {P41} iff each factor is.  Since {S29} is not {P41}, neither is $X$.

--- a/spaces/S000031/properties/P000057.md
+++ b/spaces/S000031/properties/P000057.md
@@ -1,0 +1,10 @@
+---
+space: S000031
+property: P000057
+value: true
+refs:
+- mathse: 632320
+  name: Weak Hausdorff space not KC
+---
+
+By definition.

--- a/spaces/S000031/properties/P000100.md
+++ b/spaces/S000031/properties/P000100.md
@@ -1,0 +1,12 @@
+---
+space: S000031
+property: P000100
+value: false
+refs:
+- mathse: 632320
+  name: Weak Hausdorff space not KC
+---
+
+The diagonal $\Delta=\{(x,x):x\in\mathbb Q^*\}\subseteq X$ is homeomorphic to $\mathbb Q^*$ ({S29}), which is {P16}.  But it is not closed in $X=\mathbb Q^*\times\mathbb Q^*$ since $\mathbb Q^*$ is not {P3}.  This shows that $X$ is not {P100}.
+
+See {{mathse:632320}}.

--- a/spaces/S000031/properties/P000130.md
+++ b/spaces/S000031/properties/P000130.md
@@ -1,0 +1,10 @@
+---
+space: S000031
+property: P000130
+value: false
+refs:
+  - mr: 2048350
+    name: General Topology (Willard)
+---
+
+By Theorem 18.6 of {{mr:2048350}}, the product of two nonempty spaces is {P130} iff each factor is.  Since {S29} is not {P130}, neither is $X$.

--- a/spaces/S000031/properties/P000143.md
+++ b/spaces/S000031/properties/P000143.md
@@ -1,0 +1,10 @@
+---
+space: S000031
+property: P000143
+value: true
+refs:
+- mathse: 632320
+  name: Weak Hausdorff space not KC
+---
+
+The space {S29} has the {P143} property.  And the property is preserved by products, as shown in {{mathse:632320}}.


### PR DESCRIPTION
Adding new space S31: square of one point compactification of the rationals.  This provides an example of a weak Hausdorff space that is not KC.

For the record, space S31 was never used before, as can be checked with this command:
"git log --full-history -- S000031/README.md"

