### PR TITLE
T209 generalization

### DIFF
--- a/properties/P000086.md
+++ b/properties/P000086.md
@@ -3,7 +3,7 @@ uid: P000086
 slug: homogenous
 name: Homogenous
 refs:
-  - mr: MR2048350
+  - mr: 2048350
     name: General Topology (Willard)
 ---
-A space $X$ is homogenous if for each $a,b\in X$ there is a homeomorphism $\phi : X \to X$ such that $\phi(a)=b$. In other words: the group of homeomorphisms acts transitively.
+A space $X$ such that for each $a,b\in X$ there is a homeomorphism $\phi : X \to X$ such that $\phi(a)=b$. In other words: the group of homeomorphisms of the space onto itself acts transitively.

--- a/properties/P000086.md
+++ b/properties/P000086.md
@@ -1,7 +1,7 @@
 ---
 uid: P000086
 slug: homogenous
-name: Homogenous
+name: Homogeneous
 refs:
   - mr: 2048350
     name: General Topology (Willard)

--- a/theorems/T000209.md
+++ b/theorems/T000209.md
@@ -2,18 +2,13 @@
 uid: T000209
 if:
   and:
-  - P000051: true
+  - P000139: true
   - P000086: true
 then:
   P000052: true
-converse:
-- T000042
-- T000204
 refs:
 - mr: MR2048350
   name: General Topology (Willard)
 ---
 
-Evident from the definitions:
-since $X$ is scattered, it has an isolated point $a$. Let $x\in X$; there
-is a homeomorphism of $X$ taking $a$ to $x$, showing that $x$ is also isolated.
+Let $a$ be an isolated point of $X$. Let $x\in X$; there is an homeomorphism of $X$ onto itself taking $a$ to $x$, showing that every point is isolated.


### PR DESCRIPTION
- (old T209) scattered + homogeneous ==> discrete
- (new T209) has an isolated point + homogeneous ==> discrete

Not quite the same as before, because the empty space is scattered but has no isolated point.  But we don't lose anything because the empty space is also discrete.

The spell checker here seems to tell me that "homogenous" should probably be "homogeneous".  Can we change that at the same time?
