### PR TITLE
reject wlc in rationals

### DIFF
--- a/spaces/S000027/properties/P000023.md
+++ b/spaces/S000027/properties/P000023.md
@@ -1,0 +1,11 @@
+---
+space: S000027
+property: P000023
+value: false
+refs:
+- mathse: 4209303
+  name: A σ-compact but not hemicompact space?
+---
+
+Open neighborhoods are disjoint unions of copies of $\mathbb Q$ and therefore
+contain a closed copy of the infinite discrete set $\mathbb Z$, and thus cannot be compact.


### PR DESCRIPTION
In particular, shows the rationals are not hemicompact as noted in https://math.stackexchange.com/questions/4209303/a-sigma-compact-but-not-hemicompact-space (based on my fall 2022 comment, we must have known this in the pi-Base previously, but perhaps this was lost during cleaning at some point?)