### PR TITLE
more inclusive choice of default terminology

### DIFF
--- a/spaces/S000125/README.md
+++ b/spaces/S000125/README.md
@@ -11,7 +11,7 @@ refs:
 - wikipedia: Knaster-Kuratowski_fan
   name: Knaster-Kuratowski fan
 ---
-For any $a \in [0,1]$, let $L(a)$ be the line segment from $(a,0)$ to $p = (\frac{1}{2}, \frac{1}{2})$. Let $\mathcal{C}$ be the middle-thirds Cantor set in the unit interval, $\mathcal{E}$ the endpoints of the removed intervals and $\mathcal{F} = \mathcal{C} \setminus \mathcal{E}$. Define $A = \{(x,y) \in L(c)\ |\ c \in \mathcal{E}, y \in \mathbb{Q}\}$ and $B = \{(x,y) \in L(c)\ |\ c \in \mathcal{F}, y \not\in \mathbb{Q}\}$. This space is $X = A \cup B \subset \mathbb{R}^2$ with the subspace topology.
+For any $a \in [0,1]$, let $L(a)$ be the line segment from $(a,0)$ to $p = (\frac{1}{2}, \frac{1}{2})$. Let $\mathcal{C}$ be the middle-thirds Cantor set in the unit interval, $\mathcal{E}$ the endpoints of the removed intervals and $\mathcal{F} = \mathcal{C} \setminus \mathcal{E}$. Define $A = \{(x,y) \in L(c)\ |\ c \in \mathcal{E}, y \in \mathbb{Q}\}$ and $B = \{(x,y) \in L(c)\ |\ c \in \mathcal{F}, y \not\in \mathbb{Q}\}$. This space is $X = (A \cup B) \subset \mathbb{R}^2$ with the subspace topology.
 
 Defined as counterexample #128 ("Cantor's Leaky Tent")
 in {{doi:10.1007/978-1-4612-6290-9}}.

--- a/spaces/S000125/README.md
+++ b/spaces/S000125/README.md
@@ -1,9 +1,9 @@
 ---
 uid: S000125
-slug: cantor's-leaky-tent
-name: Cantor's leaky tent
+slug: kn-fan
+name: Knaster-Kuratowski fan
 aliases:
-  - Knaster-Kuratowski fan
+  - Cantor's leaky tent
 counterexamples_id: 128
 refs:
 - doi: 10.1007/978-1-4612-6290-9
@@ -11,7 +11,7 @@ refs:
 - wikipedia: Knaster-Kuratowski_fan
   name: Knaster-Kuratowski fan
 ---
-For any $a \in [0,1]$, let $L(a)$ be the line segment from $(a,0)$ to $p = (\frac{1}{2}, \frac{1}{2})$. Let $\mathcal{C}$ be the middle-thirds Cantor set in the unit interval, $\mathcal{E}$ the endpoints of the removed intervals and $\mathcal{F} = \mathcal{C} \setminus \mathcal{E}$. Define $A = \{(x,y) \in L(c)\ |\ c \in \mathcal{E}, y \in \mathbb{Q}\}$ and $B = \{(x,y) \in L(c)\ |\ c \in \mathcal{F}, y \not\in \mathbb{Q}\}$. Cantor's Leaky Tent is $X = A \cup B \subset \mathbb{R}^2$ with the subspace topology.
+For any $a \in [0,1]$, let $L(a)$ be the line segment from $(a,0)$ to $p = (\frac{1}{2}, \frac{1}{2})$. Let $\mathcal{C}$ be the middle-thirds Cantor set in the unit interval, $\mathcal{E}$ the endpoints of the removed intervals and $\mathcal{F} = \mathcal{C} \setminus \mathcal{E}$. Define $A = \{(x,y) \in L(c)\ |\ c \in \mathcal{E}, y \in \mathbb{Q}\}$ and $B = \{(x,y) \in L(c)\ |\ c \in \mathcal{F}, y \not\in \mathbb{Q}\}$. This space is $X = A \cup B \subset \mathbb{R}^2$ with the subspace topology.
 
 Defined as counterexample #128 ("Cantor's Leaky Tent")
 in {{doi:10.1007/978-1-4612-6290-9}}.

--- a/spaces/S000125/README.md
+++ b/spaces/S000125/README.md
@@ -11,7 +11,7 @@ refs:
 - wikipedia: Knaster-Kuratowski_fan
   name: Knaster-Kuratowski fan
 ---
-For any $a \in [0,1]$, let $L(a)$ be the line segment from $(a,0)$ to $p = (\frac{1}{2}, \frac{1}{2})$. Let $\mathcal{C}$ be the middle-thirds Cantor set in the unit interval, $\mathcal{E}$ the endpoints of the removed intervals and $\mathcal{F} = \mathcal{C} \setminus \mathcal{E}$. Define $A = \{(x,y) \in L(c)\ |\ c \in \mathcal{E}, y \in \mathbb{Q}\}$ and $B = \{(x,y) \in L(c)\ |\ c \in \mathcal{F}, y \not\in \mathbb{Q}\}$. This space is $X = (A \cup B) \subset \mathbb{R}^2$ with the subspace topology.
+For any $a \in [0,1]$, let $L(a)$ be the line segment from $(a,0)$ to $p = (\frac{1}{2}, \frac{1}{2})$. Let $\mathcal{C}$ be the middle-thirds Cantor set in the unit interval, $\mathcal{E}$ the endpoints of the removed intervals and $\mathcal{F} = \mathcal{C} \setminus \mathcal{E}$. Define $A = \{(x,y) \in L(c)\ |\ c \in \mathcal{E}, y \in \mathbb{Q}\}$ and $B = \{(x,y) \in L(c)\ |\ c \in \mathcal{F}, y \not\in \mathbb{Q}\}$. This space is $X = A \cup B \subset \mathbb{R}^2$ with the subspace topology.
 
 Defined as counterexample #128 ("Cantor's Leaky Tent")
 in {{doi:10.1007/978-1-4612-6290-9}}.

--- a/spaces/S000126/README.md
+++ b/spaces/S000126/README.md
@@ -11,7 +11,7 @@ refs:
 - wikipedia: Knaster-Kuratowski_fan
   name: Knaster-Kuratowski fan
 ---
-{S000125} with the apex removed. Specifically: For any $a \in [0,1]$, let $L(a)$ be the line segment from $(a,0)$ to $p = (\frac{1}{2}, \frac{1}{2})$. Let $\mathcal{C}$ be the middle-thirds Cantor set in the unit interval, $\mathcal{E}$ the endpoints of the removed intervals and $\mathcal{F} = \mathcal{C} \setminus \mathcal{E}$. Define $A = \{(x,y) \in L(c)\ |\ c \in \mathcal{E}, y \in \mathbb{Q}\}$ and $B = \{(x,y) \in L(c)\ |\ c \in \mathcal{F}, y \not\in \mathbb{Q}\}$. This space is $X = A \cup B \setminus\{p\} \subset \mathbb{R}^2$ with the subspace topology.
+{S000125} with the apex removed. Specifically: For any $a \in [0,1]$, let $L(a)$ be the line segment from $(a,0)$ to $p = (\frac{1}{2}, \frac{1}{2})$. Let $\mathcal{C}$ be the middle-thirds Cantor set in the unit interval, $\mathcal{E}$ the endpoints of the removed intervals and $\mathcal{F} = \mathcal{C} \setminus \mathcal{E}$. Define $A = \{(x,y) \in L(c)\ |\ c \in \mathcal{E}, y \in \mathbb{Q}\}$ and $B = \{(x,y) \in L(c)\ |\ c \in \mathcal{F}, y \not\in \mathbb{Q}\}$. This space is $X = (A \cup B) \setminus\{p\} \subset \mathbb{R}^2$ with the subspace topology.
 
 Defined as counterexample #129 ("Cantor's Teepee")
 in {{doi:10.1007/978-1-4612-6290-9}}.

--- a/spaces/S000126/README.md
+++ b/spaces/S000126/README.md
@@ -1,9 +1,9 @@
 ---
 uid: S000126
-slug: cantor's-teepee
-name: Cantor's Teepee
+slug: punctured-kn-fan
+name: Punctured Knaster-Kuratowski fan
 aliases:
-  - Punctured Knaster-Kuratowski fan
+  - Cantor's Teepee
 counterexamples_id: 129
 refs:
 - doi: 10.1007/978-1-4612-6290-9
@@ -11,7 +11,7 @@ refs:
 - wikipedia: Knaster-Kuratowski_fan
   name: Knaster-Kuratowski fan
 ---
-Cantor's Teepee is Cantor's Leaky Tent with the apex removed. Specifically: For any $a \in [0,1]$, let $L(a)$ be the line segment from $(a,0)$ to $p = (\frac{1}{2}, \frac{1}{2})$. Let $\mathcal{C}$ be the middle-thirds Cantor set in the unit interval, $\mathcal{E}$ the endpoints of the removed intervals and $\mathcal{F} = \mathcal{C} \setminus \mathcal{E}$. Define $A = \{(x,y) \in L(c)\ |\ c \in \mathcal{E}, y \in \mathbb{Q}\}$ and $B = \{(x,y) \in L(c)\ |\ c \in \mathcal{F}, y \not\in \mathbb{Q}\}$. Cantor's Teepee is $X = A \cup B \setminus\{p\} \subset \mathbb{R}^2$ with the subspace topology.
+{S000125} with the apex removed. Specifically: For any $a \in [0,1]$, let $L(a)$ be the line segment from $(a,0)$ to $p = (\frac{1}{2}, \frac{1}{2})$. Let $\mathcal{C}$ be the middle-thirds Cantor set in the unit interval, $\mathcal{E}$ the endpoints of the removed intervals and $\mathcal{F} = \mathcal{C} \setminus \mathcal{E}$. Define $A = \{(x,y) \in L(c)\ |\ c \in \mathcal{E}, y \in \mathbb{Q}\}$ and $B = \{(x,y) \in L(c)\ |\ c \in \mathcal{F}, y \not\in \mathbb{Q}\}$. This space is $X = A \cup B \setminus\{p\} \subset \mathbb{R}^2$ with the subspace topology.
 
 Defined as counterexample #129 ("Cantor's Teepee")
 in {{doi:10.1007/978-1-4612-6290-9}}.


### PR DESCRIPTION
I won't delete "Cantor's teepee" so the space can still be found via search, but we definitely don't want that to be the default name we promote.