### PR TITLE
add aliases for separation properties

### DIFF
--- a/properties/P000001.md
+++ b/properties/P000001.md
@@ -4,6 +4,7 @@ slug: t_0
 name: "$T_0$"
 aliases:
   - Kolmogorov
+  - T0
 refs:
   - doi: 10.1007/978-1-4612-6290-9
     name: Counterexamples in Topology

--- a/properties/P000002.md
+++ b/properties/P000002.md
@@ -4,6 +4,7 @@ slug: t_1
 name: "$T_1$"
 aliases:
   - Fréchet
+  - T1
 refs:
   - doi: 10.1007/978-1-4612-6290-9
     name: Counterexamples in Topology

--- a/properties/P000003.md
+++ b/properties/P000003.md
@@ -4,6 +4,7 @@ slug: t_2
 name: "$T_2$"
 aliases:
   - Hausdorff
+  - T2
 refs:
   - doi: 10.1007/978-1-4612-6290-9
     name: Counterexamples in Topology

--- a/properties/P000004.md
+++ b/properties/P000004.md
@@ -5,6 +5,7 @@ name: "$T_{2 \\frac{1}{2}}$"
 aliases:
   - Urysohn
   - Completely Hausdorff
+  - T2.5
 refs:
   - mr: MR2048350
     name: General Topology (Willard)

--- a/properties/P000005.md
+++ b/properties/P000005.md
@@ -4,6 +4,7 @@ slug: t_3
 name: "$T_3$"
 aliases:
   - Regular Hausdorff
+  - T3
 refs:
   - mr: MR2048350
     name: General Topology (Willard)

--- a/properties/P000006.md
+++ b/properties/P000006.md
@@ -5,6 +5,7 @@ name: "$T_{3 \\frac{1}{2}}$"
 aliases:
   - Tychonoff
   - Completely Regular Hausdorff
+  - T3.5
 refs:
   - mr: MR2048350
     name: General Topology (Willard)

--- a/properties/P000007.md
+++ b/properties/P000007.md
@@ -4,6 +4,7 @@ slug: t_4
 name: "$T_4$"
 aliases:
   - Normal Hausdorff
+  - T4
 refs:
   - mr: MR2048350
     name: General Topology (Willard)

--- a/properties/P000008.md
+++ b/properties/P000008.md
@@ -4,6 +4,7 @@ slug: t_5
 name: "$T_5$"
 aliases:
   - Completely normal Hausdorff
+  - T5
 refs:
   - doi: 10.1007/978-1-4612-6290-9
     name: Counterexamples in Topology

--- a/properties/P000035.md
+++ b/properties/P000035.md
@@ -2,6 +2,8 @@
 uid: P000035
 slug: fully-t_4
 name: Fully $T_4$
+aliases:
+  - Fully T4
 refs:
   - doi: 10.1007/978-1-4612-6290-9
     name: Counterexamples in Topology

--- a/properties/P000067.md
+++ b/properties/P000067.md
@@ -5,6 +5,7 @@ name: "$T_6$"
 aliases:
   - Perfectly T_4
   - Perfectly normal Hausdorff
+  - T6
 refs:
   - doi: 10.1007/978-1-4612-6290-9
     name: Counterexamples in Topology


### PR DESCRIPTION
This should make searching for e.g. `T4` much less tedious (without these the lack of underscore messes up search).