### PR TITLE
B. Scott's modified Arens square

### DIFF
--- a/spaces/S000072/properties/P000051.md
+++ b/spaces/S000072/properties/P000051.md
@@ -1,0 +1,10 @@
+---
+space: S000072
+property: P000051
+value: false
+refs:
+- doi: 10.1007/978-1-4612-6290-9_6
+  name: Counterexamples in Topology
+---
+
+See item #7 for space #80 in {{doi:10.1007/978-1-4612-6290-9_6}}.

--- a/spaces/S000072/properties/P000139.md
+++ b/spaces/S000072/properties/P000139.md
@@ -1,7 +1,7 @@
 ---
 space: S000072
-property: P000057
-value: true
+property: P000139
+value: false
 refs:
 - doi: 10.1007/978-1-4612-6290-9_6
   name: Counterexamples in Topology

--- a/spaces/S000080/README.md
+++ b/spaces/S000080/README.md
@@ -12,7 +12,7 @@ The authors of {{doi:10.1007/978-1-4612-6290-9}} intended the {S72} space (count
 
 Let $Q$ be the set of rational points in the interval $(0,1)$ and let $\{Q_q:q\in Q\}$ be a partition of $Q$ into countably many dense subsets. Let
 
-$S=\bigcup_{q\in Q}(\{q\}\times Q\_q)$
+$S=\bigcup_{q\in Q}(\{q\}\times Q_q)$
 
 and take the space to be $X=\{(0,0),(1,0)\}\cup S$.
 

--- a/spaces/S000080/README.md
+++ b/spaces/S000080/README.md
@@ -12,7 +12,7 @@ The authors of {{doi:10.1007/978-1-4612-6290-9}} intended the {S72} space (count
 
 Let $Q$ be the set of rational points in the interval $(0,1)$ and let $\{Q_q:q\in Q\}$ be a partition of $Q$ into countably many dense subsets. Let
 
-$$S=\bigcup_{q\in Q}(\{q\}\times Q_q)$$
+$S=\bigcup_{q\in Q}(\{q\}\times Q\_q)$
 
 and take the space to be $X=\{(0,0),(1,0)\}\cup S$.
 

--- a/spaces/S000080/README.md
+++ b/spaces/S000080/README.md
@@ -1,0 +1,24 @@
+---
+uid: S000080
+name: B. Scott's modified Arens square
+refs:
+  - mathse: 1716095
+    name: Answer to "Is Arens Square a Urysohn space?"
+  - doi: 10.1007/978-1-4612-6290-9
+    name: Counterexamples in Topology
+---
+
+The authors of {{doi:10.1007/978-1-4612-6290-9}} intended the {S72} space (counterexample #80) to be an example of a space that is {P4} and {P10}, but not {P5} and not {P9}.  It turns out {S72} was erroneously claimed as {P4} in their book.  Brian Scott constructed the modification below in {{mathse:1716095}} to provide an example with the desired properties.
+
+Let $Q$ be the set of rational points in the interval $(0,1)$ and let $\{Q_q:q\in Q\}$ be a partition of $Q$ into countably many dense subsets. Let
+
+$$S=\bigcup_{q\in Q}(\{q\}\times Q_q)$$
+
+and take the space to be $X=\{(0,0),(1,0)\}\cup S$.
+
+Let $M=\{1/2\}\times Q_{1/2}$. Points of $S\setminus M$ have the neighborhoods that they inherit from the Euclidean topology.  Local bases at the points $(0,0)$, $(1,0)$ and $(1/2,q)\in M$ are given respectively by the collections of sets
+- $U_n(0,0) = \{(0,0)\} \cup \{(x,y)\in S: 0<x<\frac14, \; 0<y<\frac1n\}$,
+- $U_n(1,0) = \{(1,0)\} \cup \{(x,y)\in S: \frac34<x<1, \; 0<y<\frac1n\}$,
+- $U_n(1/2,q) = \{(x,y)\in S: \frac{1}{4}<x<\frac34, \; q-\frac1n < y < q+\frac1n\}.$
+
+The properties and justifications given for counterexample #80 in {{doi:10.1007/978-1-4612-6290-9}} are valid for this space with minimal modifications.

--- a/spaces/S000080/properties/P000004.md
+++ b/spaces/S000080/properties/P000004.md
@@ -1,0 +1,12 @@
+---
+space: S000080
+property: P000004
+value: true
+refs:
+- mathse: 1715435
+  name: Is Arens Square a Urysohn space?
+- doi: 10.1007/978-1-4612-6290-9_6
+  name: Counterexamples in Topology
+---
+
+See discussion at {{mathse:1715435}}, using the fact that no two points of $S$ have the same $y$-coordinate.

--- a/spaces/S000080/properties/P000009.md
+++ b/spaces/S000080/properties/P000009.md
@@ -1,0 +1,10 @@
+---
+space: S000080
+property: P000009
+value: false
+refs:
+- doi: 10.1007/978-1-4612-6290-9_6
+  name: Counterexamples in Topology
+---
+
+See item #3 for space #80 in {{doi:10.1007/978-1-4612-6290-9_6}}.

--- a/spaces/S000080/properties/P000010.md
+++ b/spaces/S000080/properties/P000010.md
@@ -1,0 +1,10 @@
+---
+space: S000080
+property: P000010
+value: true
+refs:
+- doi: 10.1007/978-1-4612-6290-9_6
+  name: Counterexamples in Topology
+---
+
+See item #4 for space #80 in {{doi:10.1007/978-1-4612-6290-9_6}}.

--- a/spaces/S000080/properties/P000011.md
+++ b/spaces/S000080/properties/P000011.md
@@ -1,10 +1,10 @@
 ---
-space: S000072
-property: P000051
+space: S000080
+property: P000011
 value: false
 refs:
 - doi: 10.1007/978-1-4612-6290-9_6
   name: Counterexamples in Topology
 ---
 
-See item #7 for space #80 in {{doi:10.1007/978-1-4612-6290-9_6}}.
+See item #2 for space #80 in {{doi:10.1007/978-1-4612-6290-9_6}}.

--- a/spaces/S000080/properties/P000022.md
+++ b/spaces/S000080/properties/P000022.md
@@ -1,0 +1,11 @@
+---
+space: S000080
+property: P000022
+value: false
+refs:
+- doi: 10.1007/978-1-4612-6290-9_6
+  name: Counterexamples in Topology
+---
+
+Asserted in the General Reference Chart for space #80 in
+{{doi:10.1007/978-1-4612-6290-9_6}}.

--- a/spaces/S000080/properties/P000028.md
+++ b/spaces/S000080/properties/P000028.md
@@ -1,0 +1,10 @@
+---
+space: S000080
+property: P000028
+value: true
+refs:
+- mathse: 1716095
+  name: Answer to "Is Arens Square a Urysohn space?"
+---
+
+By construction.

--- a/spaces/S000080/properties/P000031.md
+++ b/spaces/S000080/properties/P000031.md
@@ -1,0 +1,11 @@
+---
+space: S000080
+property: P000031
+value: true
+refs:
+- doi: 10.1007/978-1-4612-6290-9_6
+  name: Counterexamples in Topology
+---
+
+Asserted in the General Reference Chart for space #80 in
+{{doi:10.1007/978-1-4612-6290-9_6}}.

--- a/spaces/S000080/properties/P000047.md
+++ b/spaces/S000080/properties/P000047.md
@@ -1,0 +1,10 @@
+---
+space: S000080
+property: P000047
+value: true
+refs:
+- doi: 10.1007/978-1-4612-6290-9_6
+  name: Counterexamples in Topology
+---
+
+See item #6 for space #80 in {{doi:10.1007/978-1-4612-6290-9_6}}.

--- a/spaces/S000080/properties/P000057.md
+++ b/spaces/S000080/properties/P000057.md
@@ -1,0 +1,10 @@
+---
+space: S000080
+property: P000057
+value: true
+refs:
+- mathse: 1716095
+  name: Answer to "Is Arens Square a Urysohn space?"
+---
+
+By construction.

--- a/spaces/S000080/properties/P000139.md
+++ b/spaces/S000080/properties/P000139.md
@@ -1,0 +1,10 @@
+---
+space: S000080
+property: P000139
+value: false
+refs:
+- mathse: 1716095
+  name: Answer to "Is Arens Square a Urysohn space?"
+---
+
+By construction.


### PR DESCRIPTION
This is adding Brian Scott's modification to the Arens square (https://math.stackexchange.com/a/1716095) to regain an example of space that is T2.5, semiregular, not T3, not completely Hausdorff:

https://topology.pi-base.org/spaces?q=T2.5%2Bsemi%2B~T3%2B~Completely%20Hausdorff

Also for the Arens space, replaced the trait for scattered = false with "has an isolated point" = false.  This gives us meager for free.

@StevenClontz There is a build problem (mismatch of double quote in a certain generated script).  Not sure what it is, maybe you would have an idea.

