### PR TITLE
Door property (P126)

### DIFF
--- a/properties/P000126.md
+++ b/properties/P000126.md
@@ -1,0 +1,15 @@
+---
+uid: P000126
+name: Door
+aliases:
+- Door space
+refs:
+  - mr: ??
+    name: Door spaces are identifiable (S. D. McCartan)
+  - wikipedia: Door_space
+    name: Door space on Wikipedia
+---
+
+Every subset of the space is open or closed (or both).
+
+See {{mr:}}, available at <https://www.jstor.org/stable/20489255>.

--- a/properties/P000126.md
+++ b/properties/P000126.md
@@ -4,7 +4,7 @@ name: Door
 aliases:
 - Door space
 refs:
-  - mr: ??
+  - mr: MR0923909
     name: Door spaces are identifiable (S. D. McCartan)
   - wikipedia: Door_space
     name: Door space on Wikipedia
@@ -12,4 +12,4 @@ refs:
 
 Every subset of the space is open or closed (or both).
 
-See {{mr:}}, available at <https://www.jstor.org/stable/20489255>.
+See {{mr:MR0923909}}, available at <https://www.jstor.org/stable/20489255>.

--- a/spaces/S000007/properties/P000126.md
+++ b/spaces/S000007/properties/P000126.md
@@ -1,0 +1,10 @@
+---
+space: S000007
+property: P000126
+value: true
+refs:
+- doi: 10.1007/978-1-4612-6290-9_6
+  name: Counterexamples in Topology
+---
+
+Every set containing $p$ is open and every set not containing $p$ is closed.

--- a/spaces/S000008/properties/P000126.md
+++ b/spaces/S000008/properties/P000126.md
@@ -1,0 +1,10 @@
+---
+space: S000008
+property: P000126
+value: true
+refs:
+- doi: 10.1007/978-1-4612-6290-9_6
+  name: Counterexamples in Topology
+---
+
+Every set containing $p$ is open and every set not containing $p$ is closed.

--- a/spaces/S000008/properties/P000129.md
+++ b/spaces/S000008/properties/P000129.md
@@ -1,7 +1,0 @@
----
-space: S000008
-property: P000129
-value: false
----
-
-The space is non-trivial by definition.

--- a/spaces/S000009/properties/P000126.md
+++ b/spaces/S000009/properties/P000126.md
@@ -1,0 +1,10 @@
+---
+space: S000009
+property: P000126
+value: true
+refs:
+- doi: 10.1007/978-1-4612-6290-9_6
+  name: Counterexamples in Topology
+---
+
+Every set containing $p$ is open and every set not containing $p$ is closed.

--- a/spaces/S000009/properties/P000129.md
+++ b/spaces/S000009/properties/P000129.md
@@ -1,7 +1,0 @@
----
-space: S000009
-property: P000129
-value: false
----
-
-The space is non-trivial by definition.

--- a/spaces/S000010/properties/P000126.md
+++ b/spaces/S000010/properties/P000126.md
@@ -1,0 +1,10 @@
+---
+space: S000010
+property: P000126
+value: true
+refs:
+- doi: 10.1007/978-1-4612-6290-9_6
+  name: Counterexamples in Topology
+---
+
+By inspection.

--- a/spaces/S000011/properties/P000126.md
+++ b/spaces/S000011/properties/P000126.md
@@ -1,0 +1,10 @@
+---
+space: S000011
+property: P000126
+value: true
+refs:
+  - wikipedia: Door_space
+    name: Door space on Wikipedia
+---
+
+A space with all but one point isolated is {P126}.

--- a/spaces/S000012/properties/P000126.md
+++ b/spaces/S000012/properties/P000126.md
@@ -1,0 +1,10 @@
+---
+space: S000012
+property: P000126
+value: true
+refs:
+  - wikipedia: Door_space
+    name: Door space on Wikipedia
+---
+
+A space with all but one point isolated is {P126}.

--- a/spaces/S000012/properties/P000129.md
+++ b/spaces/S000012/properties/P000129.md
@@ -1,7 +1,0 @@
----
-space: S000012
-property: P000129
-value: false
----
-
-The space is non-trivial by definition.

--- a/spaces/S000013/properties/P000126.md
+++ b/spaces/S000013/properties/P000126.md
@@ -1,0 +1,10 @@
+---
+space: S000013
+property: P000126
+value: true
+refs:
+  - wikipedia: Door_space
+    name: Door space on Wikipedia
+---
+
+A space with all but one point isolated is {P126}.

--- a/spaces/S000013/properties/P000129.md
+++ b/spaces/S000013/properties/P000129.md
@@ -1,7 +1,0 @@
----
-space: S000013
-property: P000129
-value: false
----
-
-The space is non-trivial by definition.

--- a/spaces/S000020/properties/P000126.md
+++ b/spaces/S000020/properties/P000126.md
@@ -1,0 +1,10 @@
+---
+space: S000020
+property: P000126
+value: true
+refs:
+  - wikipedia: Door_space
+    name: Door space on Wikipedia
+---
+
+A space with all but one point isolated is {P126}.

--- a/spaces/S000020/properties/P000129.md
+++ b/spaces/S000020/properties/P000129.md
@@ -1,7 +1,0 @@
----
-space: S000020
-property: P000129
-value: false
----
-
-The space is non-trivial by definition.

--- a/spaces/S000022/properties/P000126.md
+++ b/spaces/S000022/properties/P000126.md
@@ -1,0 +1,10 @@
+---
+space: S000022
+property: P000126
+value: true
+refs:
+  - wikipedia: Door_space
+    name: Door space on Wikipedia
+---
+
+A space with all but one point isolated is {P126}.

--- a/spaces/S000023/properties/P000126.md
+++ b/spaces/S000023/properties/P000126.md
@@ -1,0 +1,10 @@
+---
+space: S000023
+property: P000126
+value: true
+refs:
+  - wikipedia: Door_space
+    name: Door space on Wikipedia
+---
+
+A space with all but one point isolated is {P126}.

--- a/spaces/S000033/properties/P000126.md
+++ b/spaces/S000033/properties/P000126.md
@@ -1,0 +1,10 @@
+---
+space: S000033
+property: P000126
+value: true
+refs:
+  - wikipedia: Door_space
+    name: Door space on Wikipedia
+---
+
+A space with all but one point isolated is {P126}.

--- a/spaces/S000033/properties/P000129.md
+++ b/spaces/S000033/properties/P000129.md
@@ -1,7 +1,0 @@
----
-space: S000033
-property: P000129
-value: false
----
-
-The space is non-trivial by definition.

--- a/spaces/S000111/properties/P000126.md
+++ b/spaces/S000111/properties/P000126.md
@@ -1,0 +1,10 @@
+---
+space: S000111
+property: P000126
+value: true
+refs:
+  - wikipedia: Door_space
+    name: Door space on Wikipedia
+---
+
+A space with all but one point isolated is {P126}.

--- a/spaces/S000154/properties/P000126.md
+++ b/spaces/S000154/properties/P000126.md
@@ -1,0 +1,10 @@
+---
+space: S000154
+property: P000126
+value: true
+refs:
+  - wikipedia: Door_space
+    name: Door space on Wikipedia
+---
+
+A space with all but one point isolated is {P126}.

--- a/spaces/S000154/properties/P000129.md
+++ b/spaces/S000154/properties/P000129.md
@@ -1,7 +1,0 @@
----
-space: S000154
-property: P000129
-value: false
----
-
-The space is non-trivial by definition.

--- a/theorems/T000143.md
+++ b/theorems/T000143.md
@@ -9,4 +9,4 @@ refs:
   name: How do finite door spaces work?
 ---
 
-If $x$ and $y$ are two topologically indistinguishable points, the singleton $\{x\}$ is neither open nor closed.
+Given two distinct points $x$ and $y$, by the {P126} property either $\{x\}$ is open (and is a neighborhood of $x$ not containing $y$) or $X\setminus\{x\}$ is open (and is a neighborhood of $y$ not containing $x$).  Therefore the two points are topologically distinguishable.

--- a/theorems/T000143.md
+++ b/theorems/T000143.md
@@ -1,0 +1,12 @@
+---
+uid: T000143
+if:
+  P000126: true
+then:
+  P000001: true
+refs:
+- mo: 405781
+  name: How do finite door spaces work?
+---
+
+If $x$ and $y$ are two topologically indistinguishable points, the singleton $\{x\}$ is neither open nor closed.

--- a/theorems/T000144.md
+++ b/theorems/T000144.md
@@ -1,0 +1,12 @@
+---
+uid: T000144
+if:
+  P000052: true
+then:
+  P000126: true
+refs:
+- wikipedia: Door_space
+  name: Door space on Wikipedia
+---
+
+Evident from the definitions.

--- a/theorems/T000145.md
+++ b/theorems/T000145.md
@@ -1,0 +1,15 @@
+---
+uid: T000145
+if:
+  and:
+  - P000126: true
+  - P000003: true
+  - P000137: false
+then:
+  P000139: true
+refs:
+- mathse: 3789612
+  name: In a Hausdorff door space, at most one point is a limit point
+---
+
+See {{mathse:3789612}}.


### PR DESCRIPTION
Introducing the door space property (P126), but just calling it "door" for the main name for simplicity.  This matches the usage in the reference from McCartan in the README. (And "door" functions similarly to an adjective here.)

See #295.

Can someone check the MR for McCartan's paper?  This needs to be added in two places in P000126.md.
