### PR TITLE
Selection principles minor cleanup

### DIFF
--- a/properties/P000066.md
+++ b/properties/P000066.md
@@ -3,12 +3,12 @@ uid: P000066
 name: Menger
 refs:
   - doi: 10.1016/0166-8641(95)00067-4
-    name: "Combinatorics of open covers I: Ramsey theory"
+    name: "Combinatorics of open covers I: Ramsey theory (M. Scheepers)"
 ---
-A space $X$ is **Menger** if it satisfies the selection principle
+A space that satisfies the selection principle
 \(S_{fin}(\mathcal{O},\mathcal{O})\): for every sequence of open covers
 \(\mathcal{U}_n\) for \(n<\omega\), there exist finite subcollections
-\(\mathcal{F}_n\) such that \(\bigcup_{n<\omega}\mathcal{F}_n\) is
+$\mathcal{F}_n\subseteq\mathcal{U}_n$ such that \(\bigcup_{n<\omega}\mathcal{F}_n\) is
 also an open cover.
 
 See section 5 of {{doi:10.1016/0166-8641(95)00067-4}}.

--- a/properties/P000068.md
+++ b/properties/P000068.md
@@ -1,11 +1,13 @@
 ---
 uid: P000068
 name: Rothberger
+aliases:
+  - Property C''
 refs:
   - doi: 10.1016/0166-8641(95)00067-4
-    name: "Combinatorics of open covers I: Ramsey theory"
+    name: "Combinatorics of open covers I: Ramsey theory (M. Scheepers)"
 ---
-A space $X$ is **Rothberger** if it satisfies the selection principle
+A space that satisfies the selection principle
 \(S_{1}(\mathcal{O},\mathcal{O})\): for every sequence of open covers
 \(\mathcal{U}_n\) for \(n<\omega\), there exist choices
 \(V_n\in\mathcal{U}_n\) such that \(\{V_n:n<\omega\}\) is

--- a/properties/P000071.md
+++ b/properties/P000071.md
@@ -3,6 +3,8 @@ uid: P000071
 name: "$\\sigma$-relatively-compact"
 refs:
   - doi: 10.14712/1213-7243.2015.201
-    name: Applications of limited information strategies in Menger's game
+    name: Applications of limited information strategies in Menger's game (S. Clontz)
 ---
-$X=\bigcup_{n<\omega}R_n$, where $R_n$ is relatively compact to $X$, that is, for every cover of $X$, there exists a finite subcollection which covers $R_n$.
+$X=\bigcup_{n<\omega}R_n$, where $R_n$ is relatively compact to $X$.  Here, a set $A\subseteq X$ is called *relatively compact to* $X$ if every open cover of $X$ has a finite subcollection which covers $A$.
+
+See Definition 4.2 in {{doi:10.14712/1213-7243.2015.201}}.

--- a/theorems/T000140.md
+++ b/theorems/T000140.md
@@ -6,9 +6,9 @@ then:
   P000018: true
 refs:
 - doi: 10.14712/1213-7243.2015.201
-  name: Applications of limited information strategies in Menger's game
+  name: Applications of limited information strategies in Menger's game (S. Clontz)
 ---
 
-For any open cover $\mathcal U$, apply Menger to $\langle\mathcal U,\mathcal U,\dots\rangle$ to produce $\langle\mathcal F_0,\mathcal F_1,\dots\rangle$ such that $\bigcup_{n<\omega} \mathcal F_n$ is a countable subcover of $X$.
+For any open cover $\mathcal U$, apply Menger to $\langle\mathcal U,\mathcal U,\dots\rangle$ to produce $\langle\mathcal F_0,\mathcal F_1,\dots\rangle$ with each $\mathcal F_n$ a finite subset of $\mathcal U$ such that $\bigcup_{n<\omega} \mathcal F_n$ is a countable subcover of $\mathcal U$.
 
-See proposition 1.2 of {{10.14712/1213-7243.2015.201}}.
+See proposition 1.2 of {{doi:10.14712/1213-7243.2015.201}}.

--- a/theorems/T000160.md
+++ b/theorems/T000160.md
@@ -6,7 +6,7 @@ then:
   P000066: true
 refs:
 - doi: 10.1016/j.topol.2015.12.059
-  name: A note on the Menger (Rothberger) property and topological games
+  name: A note on the Menger (Rothberger) property and topological games (Peng & Shen)
 ---
 
-By definition, see e.g. {{10.14712/1213-7243.2015.201}}.
+By definition, see e.g. {{doi:10.14712/1213-7243.2015.201}}.

--- a/theorems/T000161.md
+++ b/theorems/T000161.md
@@ -6,7 +6,7 @@ then:
   P000066: true
 refs:
 - doi: 10.14712/1213-7243.2015.201
-  name: Applications of limited information strategies in Menger's game
+  name: Applications of limited information strategies in Menger's game (S. Clontz)
 ---
 
-See Figure 3 of {{10.14712/1213-7243.2015.201}}.
+See Figure 3 of {{doi:10.14712/1213-7243.2015.201}}.

--- a/theorems/T000162.md
+++ b/theorems/T000162.md
@@ -6,7 +6,7 @@ then:
   P000072: true
 refs:
 - doi: 10.14712/1213-7243.2015.201
-  name: Applications of limited information strategies in Menger's game
+  name: Applications of limited information strategies in Menger's game (S. Clontz)
 ---
 
-See Figure 3 of {{10.14712/1213-7243.2015.201}}.
+See Figure 3 of {{doi:10.14712/1213-7243.2015.201}}.

--- a/theorems/T000163.md
+++ b/theorems/T000163.md
@@ -6,8 +6,9 @@ then:
   P000071: true
 refs:
 - doi: 10.14712/1213-7243.2015.201
-  name: Applications of limited information strategies in Menger's game
+  name: Applications of limited information strategies in Menger's game (S. Clontz)
+- mathse: 4702452
+  name: Definitions of relatively compact
 ---
 
-All compact subsets are relatively compact. See
-{{10.14712/1213-7243.2015.201}}.
+All compact subsets are relatively compact. See {{mathse:4702452}}.

--- a/theorems/T000164.md
+++ b/theorems/T000164.md
@@ -8,8 +8,7 @@ then:
   P000017: true
 refs:
 - doi: 10.14712/1213-7243.2015.201
-  name: Applications of limited information strategies in Menger's game
+  name: Applications of limited information strategies in Menger's game (S. Clontz)
 ---
 
-The closure of a relatively-compact set in a T_3 space is compact. See
-{{10.14712/1213-7243.2015.201}}.
+The closure of a relatively-compact set in a {P11} space is compact. See Proposition 4.4 in {{doi:10.14712/1213-7243.2015.201}}.

--- a/theorems/T000165.md
+++ b/theorems/T000165.md
@@ -6,16 +6,15 @@ then:
   P000071: true
 refs:
 - doi: 10.14712/1213-7243.2015.201
-  name: Applications of limited information strategies in Menger's game
+  name: Applications of limited information strategies in Menger's game (S. Clontz)
 ---
 
 Let $\sigma(\mathcal{U}, n)$ be a winning Markov strategy for $F$ in the Menger
-game, and $\mathfrak{C}$ collect all open covers of $X$. Then for
-\[
-  R_n = \bigcap_{\mathcal{U}\in\mathfrak{C}} \bigcup\sigma(\mathcal{U},n)
-\]
+game, and let $\mathfrak{C}$ be the collection of all open covers of $X$. Then for
+
+$$R_n = \bigcap_{\mathcal{U}\in\mathfrak{C}} \bigcup\sigma(\mathcal{U},n)$$
+
 it follows that $R_n$ is relatively compact to $X$, and
 $\bigcup_{n<\omega} R_n = X$.
 
-See Corollary 4.7 of
-{{10.14712/1213-7243.2015.201}}.
+See Corollary 4.7 of {{doi:10.14712/1213-7243.2015.201}}.

--- a/theorems/T000166.md
+++ b/theorems/T000166.md
@@ -11,5 +11,4 @@ refs:
 
 The second player may cover the nth relatively compact subset during the nth round of the game.
 
-See Corollary 4.7 of
-{{10.14712/1213-7243.2015.201}}.
+See Corollary 4.7 of {{doi:10.14712/1213-7243.2015.201}}.

--- a/theorems/T000167.md
+++ b/theorems/T000167.md
@@ -8,20 +8,16 @@ then:
   P000070: true
 refs:
 - doi: 10.14712/1213-7243.2015.201
-  name: Applications of limited information strategies in Menger's game
+  name: Applications of limited information strategies in Menger's game (S. Clontz)
 ---
 
 Let $\sigma(\mathcal{U}_0,\dots,\mathcal{U}_{n-1})$ be a winning strategy for $F$, and observe that since $X$ is second-countable, we may assume all covers are countable. Let $\mathfrak{C}$ be the collection of all countable covers of $X$. We define $R_s,\mathcal{U}_s$ for $s\in\omega^{<\omega}$ as follows:
 
-
 * $R_\emptyset = \bigcap_{\mathcal{U}\in\mathfrak{C}} \left(\bigcup \sigma(\mathcal{U})\right)$
 * Note that there are only countably many distinct finite subsets $\sigma(\mathcal{U})$ of the countable collection $\mathcal U$. Thus define each $\mathcal U_{\langle n\rangle}$ so that
-  $$ R_\emptyset = \bigcap_{n<\omega}\left(\bigcup\sigma(\mathcal{U}_{\langle n\rangle})\right) $$
+$$ R_\emptyset = \bigcap_{n<\omega}\left(\bigcup\sigma(\mathcal{U}_{\langle n\rangle})\right) $$
 * $R_s = \bigcap_{\mathcal{U}\in\mathfrak{C}} \left(\bigcup \sigma(\mathcal{U}_{s\restriction 1},\mathcal{U}_{s\restriction 2},\dots,\mathcal{U}_s,\mathcal{U})\right)$
 * Again, note that there are only countably many distinct finite subsets $\sigma(\mathcal{U}_{s\restriction 1},\mathcal{U}_{s\restriction 2},\dots,\mathcal{U}_s,\mathcal{U})$ of the countable collection $\mathcal U$. Thus define each $\mathcal U_{s{^\frown}\langle n\rangle}$ so that
-  $$R_s = \bigcap_{n<\omega} \left(\bigcup \sigma(\mathcal{U}_{s\restriction 1}, \mathcal{U}_{s\restriction 2}, \dots, \mathcal{U}_s, \mathcal{U}_{s{^\frown}\langle n\rangle})\right)$$
+$$R_s = \bigcap_{n<\omega} \left(\bigcup \sigma(\mathcal{U}_{s\restriction 1}, \mathcal{U}_{s\restriction 2}, \dots, \mathcal{U}_s, \mathcal{U}_{s{^\frown}\langle n\rangle})\right)$$
 
-
-
-See Lemma 4.10 of
-{{10.14712/1213-7243.2015.201}}.
+See Lemma 4.10 of {{doi:10.14712/1213-7243.2015.201}}.a

--- a/theorems/T000167.md
+++ b/theorems/T000167.md
@@ -20,4 +20,4 @@ $$ R_\emptyset = \bigcap_{n<\omega}\left(\bigcup\sigma(\mathcal{U}_{\langle n\ra
 * Again, note that there are only countably many distinct finite subsets $\sigma(\mathcal{U}_{s\restriction 1},\mathcal{U}_{s\restriction 2},\dots,\mathcal{U}_s,\mathcal{U})$ of the countable collection $\mathcal U$. Thus define each $\mathcal U_{s{^\frown}\langle n\rangle}$ so that
 $$R_s = \bigcap_{n<\omega} \left(\bigcup \sigma(\mathcal{U}_{s\restriction 1}, \mathcal{U}_{s\restriction 2}, \dots, \mathcal{U}_s, \mathcal{U}_{s{^\frown}\langle n\rangle})\right)$$
 
-See Lemma 4.10 of {{doi:10.14712/1213-7243.2015.201}}.a
+See Lemma 4.10 of {{doi:10.14712/1213-7243.2015.201}}.

--- a/theorems/T000168.md
+++ b/theorems/T000168.md
@@ -6,7 +6,7 @@ then:
   P000069: true
 refs:
 - doi: 10.14712/1213-7243.2015.201
-  name: Applications of limited information strategies in Menger's game
+  name: Applications of limited information strategies in Menger's game (S. Clontz)
 ---
 
-See Figure 3 of {{10.14712/1213-7243.2015.201}}.
+See Figure 3 of {{doi:10.14712/1213-7243.2015.201}}.


### PR DESCRIPTION
Mainly formatting fixes (missing "doi").  Also added Property C'' as an alias for Rothberger.

I tried but was unable to fix the parse errors in
- https://topology.pi-base.org/theorems/T000165
- https://topology.pi-base.org/theorems/T000167

Wasn't there a pi-base test url to be able to experiment with the formatting of things?
