### PR TITLE
fix parse errors

### DIFF
--- a/theorems/T000165.md
+++ b/theorems/T000165.md
@@ -12,7 +12,7 @@ refs:
 Let $\sigma(\mathcal{U}, n)$ be a winning Markov strategy for $F$ in the Menger
 game, and let $\mathfrak{C}$ be the collection of all open covers of $X$. Then for
 
-$$R_n = \bigcap_{\mathcal{U}\in\mathfrak{C}} \bigcup\sigma(\mathcal{U},n)$$
+$R_n = \bigcap_{\mathcal{U}\in\mathfrak{C}} \bigcup\sigma(\mathcal{U},n)$
 
 it follows that $R_n$ is relatively compact to $X$, and
 $\bigcup_{n<\omega} R_n = X$.

--- a/theorems/T000167.md
+++ b/theorems/T000167.md
@@ -14,10 +14,9 @@ refs:
 Let $\sigma(\mathcal{U}_0,\dots,\mathcal{U}_{n-1})$ be a winning strategy for $F$, and observe that since $X$ is second-countable, we may assume all covers are countable. Let $\mathfrak{C}$ be the collection of all countable covers of $X$. We define $R_s,\mathcal{U}_s$ for $s\in\omega^{<\omega}$ as follows:
 
 * $R_\emptyset = \bigcap_{\mathcal{U}\in\mathfrak{C}} \left(\bigcup \sigma(\mathcal{U})\right)$
-* Note that there are only countably many distinct finite subsets $\sigma(\mathcal{U})$ of the countable collection $\mathcal U$. Thus define each $\mathcal U_{\langle n\rangle}$ so that
-$$ R_\emptyset = \bigcap_{n<\omega}\left(\bigcup\sigma(\mathcal{U}_{\langle n\rangle})\right) $$
+* Note that there are only countably many distinct finite subsets $\sigma(\mathcal{U})$ of the countable collection $\mathcal U$. Thus define each $\mathcal U_{\langle n\rangle}$ so that $R_\emptyset =\bigcap_{n\lt\omega}\left(\bigcup\sigma(\mathcal{U}_{\langle n\rangle})\right)$
 * $R_s = \bigcap_{\mathcal{U}\in\mathfrak{C}} \left(\bigcup \sigma(\mathcal{U}_{s\restriction 1},\mathcal{U}_{s\restriction 2},\dots,\mathcal{U}_s,\mathcal{U})\right)$
 * Again, note that there are only countably many distinct finite subsets $\sigma(\mathcal{U}_{s\restriction 1},\mathcal{U}_{s\restriction 2},\dots,\mathcal{U}_s,\mathcal{U})$ of the countable collection $\mathcal U$. Thus define each $\mathcal U_{s{^\frown}\langle n\rangle}$ so that
-$$R_s = \bigcap_{n<\omega} \left(\bigcup \sigma(\mathcal{U}_{s\restriction 1}, \mathcal{U}_{s\restriction 2}, \dots, \mathcal{U}_s, \mathcal{U}_{s{^\frown}\langle n\rangle})\right)$$
+$R_s = \bigcap_{n<\omega} \left(\bigcup \sigma(\mathcal{U}_{s\restriction 1}, \mathcal{U}_{s\restriction 2}, \dots, \mathcal{U}_s, \mathcal{U}_{s{^\frown}\langle n\rangle})\right)$
 
 See Lemma 4.10 of {{doi:10.14712/1213-7243.2015.201}}.


### PR DESCRIPTION
Fixes the parsing errors I allowed to slip in with #342. It's not clear to me why the parsing broke with `$$` but not `$` but this seems to be the best solution for today.