### PR TITLE
Properties of long line

### DIFF
--- a/spaces/S000038/properties/P000015.md
+++ b/spaces/S000038/properties/P000015.md
@@ -1,0 +1,10 @@
+---
+space: S000038
+property: P000015
+value: true
+refs:
+- doi: 10.1007/978-1-4612-6290-9
+  name: Counterexamples in Topology
+---
+
+See item #4 for space #45 in {{doi:10.1007/978-1-4612-6290-9_6}}.

--- a/spaces/S000038/properties/P000028.md
+++ b/spaces/S000038/properties/P000028.md
@@ -7,6 +7,6 @@ refs:
   name: Counterexamples in Topology
 ---
 
-Every point has a neighborhood homeomorphic to an open interval in $\mathbb{R}$.
+Every point has a neighborhood homeomorphic to an interval in $\mathbb{R}$.
 
 See item #3 for space #45 in {{doi:10.1007/978-1-4612-6290-9_6}}.

--- a/spaces/S000038/properties/P000043.md
+++ b/spaces/S000038/properties/P000043.md
@@ -7,7 +7,7 @@ refs:
   name: Counterexamples in Topology
 ---
 
-Every point has a basis of sets homeomorphic to an open interval in $\mathbb{R}$.
+Every point has a basis of sets homeomorphic to an interval in $\mathbb{R}$.
 
 Asserted in the General Reference Chart for space #45 in
 {{doi:10.1007/978-1-4612-6290-9_6}}.

--- a/spaces/S000038/properties/P000059.md
+++ b/spaces/S000038/properties/P000059.md
@@ -7,7 +7,7 @@ refs:
   name: Counterexamples in Topology
 ---
 
-By construction (and since $|\omega_1| \leq \mathfrak{c}$), $|X| = \mathfrak{c} < 2^\mathfrak{c}$
+By construction (and since $|\omega_1| \leq \mathfrak{c}$), $|X| = \aleph_1\cdot \mathfrak{c} = \mathfrak{c}$.
 
 Asserted in the General Reference Chart for space #45 in
 {{doi:10.1007/978-1-4612-6290-9_6}}.

--- a/spaces/S000038/properties/P000059.md
+++ b/spaces/S000038/properties/P000059.md
@@ -7,7 +7,7 @@ refs:
   name: Counterexamples in Topology
 ---
 
-By construction (and since $|\omega_1| \leq \mathfrak{c}$), $|X| = \aleph_1\cdot \mathfrak{c} = \mathfrak{c}$.
+By construction (and since $|\omega_1| \leq \mathfrak{c}$), $|X| = \aleph_1\cdot \mathfrak{c} = \mathfrak{c}\leq 2^{\mathfrak c}$.
 
 Asserted in the General Reference Chart for space #45 in
 {{doi:10.1007/978-1-4612-6290-9_6}}.

--- a/spaces/S000038/properties/P000065.md
+++ b/spaces/S000038/properties/P000065.md
@@ -1,13 +1,13 @@
 ---
 space: S000038
-property: P000059
+property: P000065
 value: true
 refs:
 - doi: 10.1007/978-1-4612-6290-9_6
   name: Counterexamples in Topology
 ---
 
-By construction (and since $|\omega_1| \leq \mathfrak{c}$), $|X| = \aleph_1\cdot \mathfrak{c} = \mathfrak{c}\leq 2^{\mathfrak c}$.
+By construction (and since $|\omega_1| \leq \mathfrak{c}$), $|X| = \aleph_1\cdot \mathfrak{c} = \mathfrak{c}$.
 
 Asserted in the General Reference Chart for space #45 in
 {{doi:10.1007/978-1-4612-6290-9_6}}.

--- a/spaces/S000153/properties/P000015.md
+++ b/spaces/S000153/properties/P000015.md
@@ -1,0 +1,10 @@
+---
+space: S000153
+property: P000015
+value: true
+refs:
+  - wikipedia: Long_line_(topology)
+    name: Long line on Wikipedia
+---
+
+{S000153} is a subspace of {S000038} which has {P000015}


### PR DESCRIPTION
I've added perfectly normal property of long line as it wasn't on pi-base. I mentioned this here #348 
I've also changed three proofs, two of them mentioned neighbourhoods homeomorphic to open interval of $\mathbb{R}$, while the point $(0, 0)$ has no such neighbourhood, so I switched them to intervals.
Proof of the fourth property mentioned that $|X| < 2^\mathfrak{c}$ which I didn't really understand so I replaced it with $|X| = \aleph_1\cdot \mathfrak{c} = \mathfrak{c}$.

I've also added that the open long line is perfectly normal, since subspace of a perfectly normal space is perfectly normal.