### PR TITLE
mark S147 as requiring CH

### DIFF
--- a/spaces/S000147/README.md
+++ b/spaces/S000147/README.md
@@ -4,8 +4,12 @@ name: Luzin subset of the reals
 aliases:
   - Lusin subset of the reals
 ambiguous_construction: true
+# additional_axioms: CH
 refs:
   - mr: MR0450063
     name: Luzin spaces
 ---
+
 An uncountable subset of the reals such that every nowhere dense subset is countable.
+
+Note that the construction of such a set requires additional axioms beyond $ZFC$, such as $CH$.


### PR DESCRIPTION
As discussed in today's meeting, we will allow spaces that require more than ZFC, but we want to mark up their descriptions and add a (commented for now) attribute to their frontmatter.