### PR TITLE
T000393: fix typo

### DIFF
--- a/theorems/T000393.md
+++ b/theorems/T000393.md
@@ -8,7 +8,7 @@ then:
   P000050: true
 refs:
 - mr: MR0785749
-  name: "Fundamentals of general topology: Problems and exercises" (Arkhangel′skii & Ponomarev)
+  name: "Fundamentals of general topology: Problems and exercises (Arkhangel′skii & Ponomarev)"
 ---
 
 Let $X$ be regular and extremally disconnected. If $p\in X$ and $U$ is an open neighbourhood of $p$, from {P000011} there exists an open $V$ with $p\in V\subseteq \overline{V}\subseteq U$. From {P000049}, $\overline{V}$ is clopen. Thus clopen sets in $X$ form a basis, that is $X$ is {P000050}.


### PR DESCRIPTION
Misplaced a double quote.  Fixes #357.

@StevenClontz, @ccaruvana or @lyengulalp : would you mind approving this, as it's blocking T393?
