### PR TITLE
discrete + realcompact => non-measurable

### DIFF
--- a/theorems/T000394.md
+++ b/theorems/T000394.md
@@ -13,4 +13,4 @@ refs:
   name: Rings of Continuous Functions (Gillman and Jerison)
 ---
 
-See theorem 12.2 in {{10.1007/978-1-4615-7819-2}} or exercise 3.11.D of {{MR1039321}}.
+See theorem 12.2 in {{doi:10.1007/978-1-4615-7819-2}} or exercise 3.11.D of {{mr:MR1039321}}.

--- a/theorems/T000394.md
+++ b/theorems/T000394.md
@@ -1,0 +1,16 @@
+---
+uid: T000394
+if:
+  and:
+    - P000052: true
+    - P000162: true
+then:
+  P000164: true
+refs:
+- mr: MR1039321
+  name: General Topology (Engelking, 1989)
+- doi: 10.1007/978-1-4615-7819-2
+  name: Rings of Continuous Functions (Gillman and Jerison)
+---
+
+See theorem 12.2 in {{10.1007/978-1-4615-7819-2}} or exercise 3.11.D of {{MR1039321}}.


### PR DESCRIPTION
I've added discrete + realcompact => non-measurable since the two properties are equivalent for discrete spaces (the other implication follows from other theorem).
This theorem is useless in practice but I added it for completeness.