### PR TITLE
Size of Michael's closed subspace

### DIFF
--- a/spaces/S000136/properties/P000164.md
+++ b/spaces/S000136/properties/P000164.md
@@ -1,0 +1,7 @@
+---
+space: S000136
+property: P000164
+value: true
+---
+
+$|X| = 2^{2^\mathfrak{c}}$ is non-measurable

--- a/spaces/S000137/README.md
+++ b/spaces/S000137/README.md
@@ -6,7 +6,7 @@ refs:
 - doi: 10.1007/978-1-4612-6290-9
   name: Counterexamples in Topology
 ---
-Michael's Closed Subspace is the subspace $Y = M \cup F$ of Bing's Discrete Extension Space $X$ where
+Michael's Closed Subspace is the subspace $Y = M \cup F$ of {S000136} $X$ where
 $F=\{x\in X\setminus M: x(\lambda)=1 \text{ for only finitely many }\lambda\in 2^{\Bbb{R}}\}$.
 
 Defined as counterexample #143 ("Michael's Closed Subspace")

--- a/spaces/S000137/properties/P000059.md
+++ b/spaces/S000137/properties/P000059.md
@@ -1,13 +1,10 @@
 ---
 space: S000137
 property: P000059
-value: false
+value: true
 refs:
 - doi: 10.1007/978-1-4612-6290-9_6
   name: Counterexamples in Topology
 ---
 
-By definition, the space has cardinality $2^{2^\mathfrak{c}}$.
-
-Asserted in the General Reference Chart for space #143 in
-{{doi:10.1007/978-1-4612-6290-9_6}}.
+Let $S = \{x\in X : x(\lambda) = 1\text{ for finitely many }\lambda\in 2^{\mathbb{R}}\}$, then $|S| = |[2^{\mathbb{R}}]^{<\omega}| = |2^{\mathbb{R}}| = 2^\mathfrak{c}$ where $[A]^{<\omega}$ denotes the set of all finite subsets of $A$. Also $|M| = \mathfrak{c}$. Thus $|F| = |S\setminus M| = 2^\mathfrak{c}$, and so $|Y| = 2^\mathfrak{c}$.

--- a/spaces/S000137/properties/P000163.md
+++ b/spaces/S000137/properties/P000163.md
@@ -1,0 +1,10 @@
+---
+space: S000137
+property: P000163
+value: false
+refs:
+- doi: 10.1007/978-1-4612-6290-9_6
+  name: Counterexamples in Topology
+---
+
+Let $S = \{x\in X : x(\lambda) = 1\text{ for finitely many }\lambda\in 2^{\mathbb{R}}\}$, then $|S| = |[2^{\mathbb{R}}]^{<\omega}| = |2^{\mathbb{R}}| = 2^\mathfrak{c}$ where $[A]^{<\omega}$ denotes the set of all finite subsets of $A$. Also $|M| = \mathfrak{c}$. Thus $|F| = |S\setminus M| = 2^\mathfrak{c}$, and so $|Y| = 2^\mathfrak{c} > \mathfrak{c}$.


### PR DESCRIPTION
While trying to check which spaces wouldn't be automatically of non-measurable size, I've tried checking which spaces don't have the property "size $\leq 2^\mathfrak{c}$. 

Those were Bing's space and its Michael subspace. By definition, $|X| = 2^{2^\mathfrak{c}}$ where $X$ is Bing's space. 
But $Y\subseteq X$, $Y = F\cup M$ is a subspace. The justification given was that $Y$ is of size $> 2^\mathfrak{c}$ by definition.
$M$ is of size $\mathfrak{c}$ since its a set of elements $x_r$ for $r\in\mathbb{R}$, all of them distinct
$F$ is obtained by removing $M$ from a set bijective to the collection of all finite subsets of $2^\mathbb{R}$. 
Therefore $F$ and $2^\mathbb{R}$ have the same cardinality

Note that in Counterexamples in Topology chart, they say that Michael's subspace is not of size $\leq 2^\mathfrak{c}$ as well.