### PR TITLE
Adding realcompact property to some spaces

### DIFF
--- a/spaces/S000057/properties/P000162.md
+++ b/spaces/S000057/properties/P000162.md
@@ -7,4 +7,4 @@ refs:
   name: Rings of Continuous Functions (Gillman and Jerison)
 ---
 
-The identity function $\text{Id}:\mathbb{R}\to \mathbb{R}$, $\text{Id}(x) = x$ from {S000057} to {S000025} is a continuous bijection. Since every subspace of {S000025} is realcompact, {S000057} is realcompact from corollary 8.18 in {{doi:10.1007/978-1-4615-7819-2}}.
+The identity function $\text{Id}:\mathbb{R}\to \mathbb{R}$, $\text{Id}(x) = x$ from {S57} to {S25} is a continuous bijection. Since every subspace of {S25} is realcompact, {S57} is realcompact from corollary 8.18 in {{doi:10.1007/978-1-4615-7819-2}}.

--- a/spaces/S000057/properties/P000162.md
+++ b/spaces/S000057/properties/P000162.md
@@ -7,4 +7,4 @@ refs:
   name: Rings of Continuous Functions (Gillman and Jerison)
 ---
 
-The identity function $\text{Id}:\mathbb{R}\to \mathbb{R}$, $\text{Id}(x) = x$ from {S57} to {S25} is a continuous bijection. Since every subspace of {S25} is realcompact, {S57} is realcompact from corollary 8.18 in {{doi:10.1007/978-1-4615-7819-2}}.
+The identity function $\text{Id}:\mathbb{R}\to \mathbb{R}$, $\text{Id}(x) = x$ from {S57} to {S25} is a continuous bijection. Since every subspace of {S25} is realcompact ({S25} is hereditarily Lindelof, and $T_{3.5}$ Lindelof space is realcompact), {S57} is realcompact from corollary 8.18 in {{doi:10.1007/978-1-4615-7819-2}}.

--- a/spaces/S000057/properties/P000162.md
+++ b/spaces/S000057/properties/P000162.md
@@ -1,0 +1,10 @@
+---
+space: S000057
+property: P000162
+value: true
+refs:
+- doi: 10.1007/978-1-4615-7819-2
+  name: Rings of Continuous Functions (Gillman and Jerison)
+---
+
+The identity function $\text{Id}:\mathbb{R}\to \mathbb{R}$, $\text{Id}(x) = x$ from {S000057} to {S000025} is a continuous bijection. Since every subspace of {S000025} is realcompact, {S000057} is realcompact from corollary 8.18 in {{doi:10.1007/978-1-4615-7819-2}}.

--- a/spaces/S000057/properties/P000162.md
+++ b/spaces/S000057/properties/P000162.md
@@ -7,4 +7,4 @@ refs:
   name: Rings of Continuous Functions (Gillman and Jerison)
 ---
 
-The identity function $\text{Id}:\mathbb{R}\to \mathbb{R}$, $\text{Id}(x) = x$ from {S57} to {S25} is a continuous bijection. Since every subspace of {S25} is realcompact ({S25} is hereditarily Lindelof, and $T_{3.5}$ Lindelof space is realcompact), {S57} is realcompact from corollary 8.18 in {{doi:10.1007/978-1-4615-7819-2}}.
+The identity function $\text{Id}:\mathbb{R}\to \mathbb{R}$, $\text{Id}(x) = x$ from {S57} to {S25} is a continuous bijection. Since every subspace of {S25} is realcompact ({S25} is {P5} and {P131}, and see {T384}), {S57} is realcompact from corollary 8.18 in {{doi:10.1007/978-1-4615-7819-2}}.

--- a/spaces/S000074/properties/P000162.md
+++ b/spaces/S000074/properties/P000162.md
@@ -7,4 +7,4 @@ refs:
   name: Rings of Continuous Functions (Gillman and Jerison)
 ---
 
-The identity function $\text{Id}:X\to \mathbb{R}^2$, $\text{Id}(x) = x$ from {S74} to {S176} is a continuous bijection. Since every subspace of {S176} is realcompact, {S74} is realcompact from corollary 8.18 in {{doi:10.1007/978-1-4615-7819-2}}.
+The identity function $\text{Id}:X\to \mathbb{R}^2$, $\text{Id}(x) = x$ from {S74} to {S176} is a continuous injection. Since every subspace of {S176} is realcompact, {S74} is realcompact from corollary 8.18 in {{doi:10.1007/978-1-4615-7819-2}}.

--- a/spaces/S000074/properties/P000162.md
+++ b/spaces/S000074/properties/P000162.md
@@ -7,4 +7,4 @@ refs:
   name: Rings of Continuous Functions (Gillman and Jerison)
 ---
 
-The identity function $\text{Id}:X\to \mathbb{R}^2$, $\text{Id}(x) = x$ from {S000074} to {S000176} is a continuous bijection. Since every subspace of {S000176} is realcompact, {S000074} is realcompact from corollary 8.18 in {{doi:10.1007/978-1-4615-7819-2}}.
+The identity function $\text{Id}:X\to \mathbb{R}^2$, $\text{Id}(x) = x$ from {S74} to {S176} is a continuous bijection. Since every subspace of {S176} is realcompact, {S74} is realcompact from corollary 8.18 in {{doi:10.1007/978-1-4615-7819-2}}.

--- a/spaces/S000074/properties/P000162.md
+++ b/spaces/S000074/properties/P000162.md
@@ -7,4 +7,4 @@ refs:
   name: Rings of Continuous Functions (Gillman and Jerison)
 ---
 
-The identity function $\text{Id}:X\to \mathbb{R}^2$, $\text{Id}(x) = x$ from {S74} to {S176} is a continuous injection. Since every subspace of {S176} is realcompact ({S176} is hereditarily Lindelof, and $T_{3.5}$ Lindelof space is realcompact), {S74} is realcompact from corollary 8.18 in {{doi:10.1007/978-1-4615-7819-2}}.
+The identity function $\text{Id}:X\to \mathbb{R}^2$, $\text{Id}(x) = x$ from {S74} to {S176} is a continuous injection. Since every subspace of {S176} is realcompact ({S176} is {P5} and {P131}, and see {T384}), {S74} is realcompact from corollary 8.18 in {{doi:10.1007/978-1-4615-7819-2}}.

--- a/spaces/S000074/properties/P000162.md
+++ b/spaces/S000074/properties/P000162.md
@@ -7,4 +7,4 @@ refs:
   name: Rings of Continuous Functions (Gillman and Jerison)
 ---
 
-The identity function $\text{Id}:X\to \mathbb{R}^2$, $\text{Id}(x) = x$ from {S74} to {S176} is a continuous injection. Since every subspace of {S176} is realcompact, {S74} is realcompact from corollary 8.18 in {{doi:10.1007/978-1-4615-7819-2}}.
+The identity function $\text{Id}:X\to \mathbb{R}^2$, $\text{Id}(x) = x$ from {S74} to {S176} is a continuous injection. Since every subspace of {S176} is realcompact ({S176} is hereditarily Lindelof, and $T_{3.5}$ Lindelof space is realcompact), {S74} is realcompact from corollary 8.18 in {{doi:10.1007/978-1-4615-7819-2}}.

--- a/spaces/S000074/properties/P000162.md
+++ b/spaces/S000074/properties/P000162.md
@@ -1,0 +1,10 @@
+---
+space: S000074
+property: P000162
+value: false
+refs:
+- doi: 10.1007/978-1-4615-7819-2
+  name: Rings of Continuous Functions (Gillman and Jerison)
+---
+
+The identity function $\text{Id}:X\to \mathbb{R}^2$, $\text{Id}(x) = x$ from {S000074} to {S000176} is a continuous bijection. Since every subspace of {S000176} is realcompact, {S000074} is realcompact from corollary 8.18 in {{doi:10.1007/978-1-4615-7819-2}}.

--- a/spaces/S000074/properties/P000162.md
+++ b/spaces/S000074/properties/P000162.md
@@ -1,7 +1,7 @@
 ---
 space: S000074
 property: P000162
-value: false
+value: true
 refs:
 - doi: 10.1007/978-1-4615-7819-2
   name: Rings of Continuous Functions (Gillman and Jerison)

--- a/spaces/S000091/properties/P000162.md
+++ b/spaces/S000091/properties/P000162.md
@@ -1,0 +1,10 @@
+---
+space: S000091
+property: P000162
+value: false
+refs:
+- mathse: 4732529
+  name: Thomas plank is not realcompact
+---
+
+See {{mathse:4732529}}.

--- a/spaces/S000107/properties/P000162.md
+++ b/spaces/S000107/properties/P000162.md
@@ -7,5 +7,5 @@ refs:
   name: Rings of Continuous Functions (Gillman and Jerison)
 ---
 
-The identity function $\text{Id}:\mathbb{R}^\omega\to \mathbb{R}^\omega$, $\text{Id}(x) = x$ from {S107} to $\mathbb{R}^\omega$ with product topology is a continuous bijection. Since every subspace of $\mathbb{R}^\omega$ with product topology is realcompact, {S107} is realcompact from corollary 8.18 in {{doi:10.1007/978-1-4615-7819-2}}.
+The identity function $\text{Id}:\mathbb{R}^\omega\to \mathbb{R}^\omega$, $\text{Id}(x) = x$ from {S107} to $\mathbb{R}^\omega$ with product topology is a continuous bijection. Since every subspace of $\mathbb{R}^\omega$ with product topology is realcompact ($\mathbb{R}^\omega$ is hereditarily Lindelof, and $T_{3.5}$ Lindelof space is realcompact), {S107} is realcompact from corollary 8.18 in {{doi:10.1007/978-1-4615-7819-2}}.
 

--- a/spaces/S000107/properties/P000162.md
+++ b/spaces/S000107/properties/P000162.md
@@ -7,5 +7,5 @@ refs:
   name: Rings of Continuous Functions (Gillman and Jerison)
 ---
 
-The identity function $\text{Id}:\mathbb{R}^\omega\to \mathbb{R}^\omega$, $\text{Id}(x) = x$ from {S107} to $\mathbb{R}^\omega$ with product topology is a continuous bijection. Since every subspace of $\mathbb{R}^\omega$ with product topology is realcompact ($\mathbb{R}^\omega$ is hereditarily Lindelof, and $T_{3.5}$ Lindelof space is realcompact), {S107} is realcompact from corollary 8.18 in {{doi:10.1007/978-1-4615-7819-2}}.
+The identity function $\text{Id}:\mathbb{R}^\omega\to \mathbb{R}^\omega$, $\text{Id}(x) = x$ from {S107} to $\mathbb{R}^\omega$ with product topology is a continuous bijection. Since every subspace of $\mathbb{R}^\omega$ with product topology is realcompact ($\mathbb{R}^\omega$ is {P5} and {P131}, and see {T384}), {S107} is realcompact from corollary 8.18 in {{doi:10.1007/978-1-4615-7819-2}}.
 

--- a/spaces/S000107/properties/P000162.md
+++ b/spaces/S000107/properties/P000162.md
@@ -1,0 +1,11 @@
+---
+space: S000107
+property: P000162
+value: true
+refs:
+- doi: 10.1007/978-1-4615-7819-2
+  name: Rings of Continuous Functions (Gillman and Jerison)
+---
+
+The identity function $\text{Id}:\mathbb{R}^\omega\to \mathbb{R}^\omega$, $\text{Id}(x) = x$ from {S000107} to $\mathbb{R}^\omega$ with product topology is a continuous bijection. Since every subspace of $\mathbb{R}^\omega$ with product topology is realcompact, {S000107} is realcompact from corollary 8.18 in {{doi:10.1007/978-1-4615-7819-2}}.
+

--- a/spaces/S000107/properties/P000162.md
+++ b/spaces/S000107/properties/P000162.md
@@ -7,5 +7,5 @@ refs:
   name: Rings of Continuous Functions (Gillman and Jerison)
 ---
 
-The identity function $\text{Id}:\mathbb{R}^\omega\to \mathbb{R}^\omega$, $\text{Id}(x) = x$ from {S000107} to $\mathbb{R}^\omega$ with product topology is a continuous bijection. Since every subspace of $\mathbb{R}^\omega$ with product topology is realcompact, {S000107} is realcompact from corollary 8.18 in {{doi:10.1007/978-1-4615-7819-2}}.
+The identity function $\text{Id}:\mathbb{R}^\omega\to \mathbb{R}^\omega$, $\text{Id}(x) = x$ from {S107} to $\mathbb{R}^\omega$ with product topology is a continuous bijection. Since every subspace of $\mathbb{R}^\omega$ with product topology is realcompact, {S107} is realcompact from corollary 8.18 in {{doi:10.1007/978-1-4615-7819-2}}.
 

--- a/spaces/S000153/properties/P000162.md
+++ b/spaces/S000153/properties/P000162.md
@@ -7,4 +7,4 @@ refs:
   name: Rings of Continuous Functions (Gillman and Jerison)
 ---
 
-The subspace $X\subseteq Y$ of {S000153} given by $X = \{(x, 0) : 0 < x < \omega_1\}$ is a closed copy of $\omega_1$ in $Y$. If $Y$ were realcompact, then its closed subspace $X$ would be realcompact (see theorem 8.10 in {{doi:10.1007/978-1-4615-7819-2}}). But $\omega_1$ is a pseudocompact non-compact Tychonoff space, so is not realcompact, see {T388}.
+The subspace $X\subseteq Y$ of {S153} given by $X = \{(x, 0) : 0 < x < \omega_1\}$ is a closed copy of $\omega_1$ in $Y$. If $Y$ were realcompact, then its closed subspace $X$ would be realcompact (see theorem 8.10 in {{doi:10.1007/978-1-4615-7819-2}}). But $\omega_1$ is a pseudocompact non-compact Tychonoff space, so is not realcompact, see {T388}.

--- a/spaces/S000153/properties/P000162.md
+++ b/spaces/S000153/properties/P000162.md
@@ -1,0 +1,10 @@
+---
+space: S000153
+property: P000162
+value: false
+refs:
+- doi: 10.1007/978-1-4615-7819-2
+  name: Rings of Continuous Functions (Gillman and Jerison)
+---
+
+The subspace $X\subseteq Y$ of {S000153} given by $X = \{(x, 0) : 0 < x < \omega_1\}$ is a closed copy of $\omega_1$ in $Y$. If $Y$ were realcompact, then its closed subspace $X$ would be realcompact (see theorem 8.10 in {{10.1007/978-1-4615-7819-2}}). But $\omega_1$ is a pseudocompact non-compact Tychonoff space, so is not realcompact, see {T000388}.

--- a/spaces/S000153/properties/P000162.md
+++ b/spaces/S000153/properties/P000162.md
@@ -7,4 +7,4 @@ refs:
   name: Rings of Continuous Functions (Gillman and Jerison)
 ---
 
-The subspace $X\subseteq Y$ of {S000153} given by $X = \{(x, 0) : 0 < x < \omega_1\}$ is a closed copy of $\omega_1$ in $Y$. If $Y$ were realcompact, then its closed subspace $X$ would be realcompact (see theorem 8.10 in {{10.1007/978-1-4615-7819-2}}). But $\omega_1$ is a pseudocompact non-compact Tychonoff space, so is not realcompact, see {T000388}.
+The subspace $X\subseteq Y$ of {S000153} given by $X = \{(x, 0) : 0 < x < \omega_1\}$ is a closed copy of $\omega_1$ in $Y$. If $Y$ were realcompact, then its closed subspace $X$ would be realcompact (see theorem 8.10 in {{doi:10.1007/978-1-4615-7819-2}}). But $\omega_1$ is a pseudocompact non-compact Tychonoff space, so is not realcompact, see {T388}.


### PR DESCRIPTION
I've added the property of realcompactness (or lack thereof) to four spaces.

Three out of those are based on corollary 8.18 from Gillman and Jerison.

The fourth one, of Thomas plank, is disproved by me in this answer: https://math.stackexchange.com/questions/4732528/thomas-plank-is-not-realcompact/4732529#4732529

For the future I'd like to verify this property for Bing's Space and Open Long Ray as well.