### PR TITLE
Properties of countability

### DIFF
--- a/theorems/T000034.md
+++ b/theorems/T000034.md
@@ -1,0 +1,16 @@
+---
+uid: T000034
+if:
+  and:
+    P000062: true
+    P000053: true
+then:
+  P000027: true
+refs:
+- doi: 10.1016/c2009-0-12309-7
+  name: Handbook of Set-Theoretic Topology
+---
+
+For metrizable spaces $w(X) = wc(X)$ where $w(X)$ is the weight of $X$ and $wc(X)$ is the weak covering number of $X$. The space $X$ is weakly Lindelof if and only if $wc(X)\leq \aleph_0$, that is $w(X)\leq \aleph_0$ since $w(X) = wc(X)$. Thus $X$ is second-countable.
+
+See chapter 1, section 8 of {{10.1016/c2009-0-12309-7}}.

--- a/theorems/T000129.md
+++ b/theorems/T000129.md
@@ -1,15 +1,16 @@
 ---
 uid: T000129
 if:
-  P000026: true
+  P000029: true
 then:
   P000062: true
 refs:
-- doi: 10.2307/1996310
-  name: Products of weakly-א-compact spaces
+- doi: 10.1016/c2009-0-12309-7
+  name: Handbook of Set-Theoretic Topology
 ---
 
-Let $\{x_n\}$ be a countable dense subset of $X$ and $\mathcal{U}$ an open cover. For each $n$, choose $U_n \in \mathcal{U}$ with $x_n \in U_n$. Then $\{U_n\}$ is a countable dense subcover of $\mathcal{U}$.
+$wc(X)\leq c(X)$ where $wc(X)$ is the weak covering number of $X$ and $c(X)$ is the cellularity of $X$
+$X$ has CCC iff $c(X)\leq\alpeh_0$ and is weakly Lindelof iff $wc(X)\leq \aleph_0$
+Thus if $X$ has CCC, then it's weakly Lindelof.
 
-This follows the definition of weakly Lindelof given in
-e.g. {{doi:10.2307/1996310}}.
+See chapter 1, section 3 of {{10.1016/c2009-0-12309-7}}.


### PR DESCRIPTION
I've replaced [separable => weakly Lindelof] by the sharper [CCC => weakly Lindelof] (since [separable => CCC]).

I've also added [metrizable + weakly Lindelof => second-countable].

Perhaps [separable + metrizable => second-countable] should be deleted since it's already implied by [metrizable + weakly Lindelof => second-countable]?

@StevenClontz tell me what you think about deletion of that theorem.

Another thing is that we might want to give a more explicit proof instead of citing a theorem like I did