### PR TITLE
Strong ultrafilter topology is not a P-space + cardinality of it.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "githubPullRequests.ignoredPullRequestBranches": [
+        "main"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "githubPullRequests.ignoredPullRequestBranches": [
-        "main"
-    ]
-}

--- a/spaces/S000110/properties/P000059.md
+++ b/spaces/S000110/properties/P000059.md
@@ -1,0 +1,13 @@
+---
+space: S000110
+property: P000059
+value: true
+refs:
+- doi: 10.1007/978-1-4612-6290-9_6
+  name: Counterexamples in Topology
+---
+
+{S110} is equinumerous with {S108}, which is of size $2^\mathfrak{c}$.
+
+Asserted in the General Reference Chart for space #113 in
+{{doi:10.1007/978-1-4612-6290-9_6}}.

--- a/spaces/S000110/properties/P000147.md
+++ b/spaces/S000110/properties/P000147.md
@@ -1,0 +1,10 @@
+---
+space: S000110
+property: P000147
+value: false
+refs:
+- mathse: 4744376
+  Are all Hausdorff extremally disconnected P-spaces also regular?
+---
+
+Given any free ultrafilter $\mathcal{U}$ on $\mathbb{N}$, since $\mathbb{N}$ is realcompact there exist $A_n\in\mathcal{U}$ such that $\bigcap_{n\in\mathbb{N}} A_n = \emptyset$. Then $\bigcap_{n\in\mathbb{N}} (A_n\cup \{\mathcal{U}}) = \{\mathcal{U}\}$ is a countable intersection of open sets, but is not open.

--- a/spaces/S000110/properties/P000163.md
+++ b/spaces/S000110/properties/P000163.md
@@ -1,0 +1,13 @@
+---
+space: S000110
+property: P000163
+value: false
+refs:
+- doi: 10.1007/978-1-4612-6290-9_6
+  name: Counterexamples in Topology
+---
+
+{S110} is equinumerous with {S108}, which is of size $2^\mathfrak{c} > \mathfrak{c}$.
+
+Asserted in the General Reference Chart for space #113 in
+{{doi:10.1007/978-1-4612-6290-9_6}}.


### PR DESCRIPTION
I've added that strong ultrafilter topology is not a P-space, with reference to my own mathse post (this is something so obscure that I doubt there's a better reference).
I've also added cardinality properties of strong ultrafilter topology.
I'm not sure what the json file is, I must have done something wrong.