### PR TITLE
Strategically Rothberger update and a new space

### DIFF
--- a/properties/P000151.md
+++ b/properties/P000151.md
@@ -1,8 +1,17 @@
 ---
 uid: P000151
-name: Strategically $\omega$-Rothberger
+name: Strategically Rothberger
+aliases:
+  - Strategically $\Omega$-Rothberger
 refs:
-- doi: 10.1016/j.topol.2019.07.008
-  name: Limited information strategies and discrete selectivity (Clontz & Holshouser)
+  - doi: 10.1016/j.topol.2019.07.008
+    name: Limited information strategies and discrete selectivity (Clontz & Holshouser)
+  - mathse: 4738368
+    name: Can P1 improve an open cover to an omega-cover in the finite-open game?
 ---
-The second player has a winning strategy in the game $\mathsf{G}_1(\Omega_X,\Omega_X)$. See pages 2 and 3 of {{doi:10.1016/j.topol.2019.07.008}} for more details.
+
+Strategically Rothberger: The second player has a winning strategy in the Rothberger game $\mathsf{G}_1(\mathcal O_X,\mathcal O_X)$. See pages 2 and 3 of {{doi:10.1016/j.topol.2019.07.008}} for more details.
+
+Strategically $\Omega$-Rothberger: The second player has a winning strategy in the game $\mathsf{G}_1(\Omega_X,\Omega_X)$. See pages 2 and 3 of {{doi:10.1016/j.topol.2019.07.008}} for more details.
+
+Theorem 15 of {{doi:10.1016/j.topol.2019.07.008}} states the equivalence for {P6} spaces, but the equivalence is shown to not require any separations axioms at {{mathse:4738368}}.

--- a/spaces/S000181/README.md
+++ b/spaces/S000181/README.md
@@ -1,6 +1,6 @@
 ---
 uid: S000181
-name: Countable sigma product on ω_1+1
+name: Countable sigma product on $\omega_1+1$
 refs:
   - doi: 10.1515/math-2015-0018
     name: Vietoris topology on spaces dominated by second countable ones

--- a/spaces/S000181/README.md
+++ b/spaces/S000181/README.md
@@ -1,0 +1,13 @@
+---
+uid: S000181
+name: Countable sigma product on ω_1+1
+refs:
+  - doi: 10.1515/math-2015-0018
+    name: Vietoris topology on spaces dominated by second countable ones
+  - doi: 10.1016/j.topol.2010.10.014
+    name: Domination by second countable spaces and Lindelöf Σ-property
+  - mathse: 4736734
+    name: A space which is 𝜎-compact but neither hemicompact nor second countable
+---
+
+A particular subspace of the countable product of {S36}. Particularly, the space of all functions $\omega \to (\omega_1+1)$ that are non-zero on only finitely many inputs. It was verified to be {P17} and neither {P27} nor {P111} at {{mathse:4736734}}.

--- a/spaces/S000181/properties/P000006.md
+++ b/spaces/S000181/properties/P000006.md
@@ -1,0 +1,10 @@
+---
+space: S000181
+property: P000006
+value: true
+refs:
+  - mathse: 4736734
+    name: A space which is 𝜎-compact but neither hemicompact nor second countable
+---
+
+As a subspace of the countable product of {S36}; {P6} is productive and hereditary.

--- a/spaces/S000181/properties/P000017.md
+++ b/spaces/S000181/properties/P000017.md
@@ -1,0 +1,12 @@
+---
+space: S000181
+property: P000006
+value: true
+refs:
+  - doi: 10.1515/math-2015-0018
+    name: Vietoris topology on spaces dominated by second countable ones
+  - mathse: 4736734
+    name: A space which is 𝜎-compact but neither hemicompact nor second countable
+---
+
+See {{mathse:4736734}}.

--- a/spaces/S000181/properties/P000017.md
+++ b/spaces/S000181/properties/P000017.md
@@ -1,6 +1,6 @@
 ---
 space: S000181
-property: P000006
+property: P000017
 value: true
 refs:
   - doi: 10.1515/math-2015-0018

--- a/spaces/S000181/properties/P000027.md
+++ b/spaces/S000181/properties/P000027.md
@@ -1,0 +1,12 @@
+---
+space: S000181
+property: P000027
+value: false
+refs:
+  - mathse: 4736734
+    name: A space which is 𝜎-compact but neither hemicompact nor second countable
+---
+
+See {{mathse:4736734}}.
+
+{S181} contains {S36} as a subspace and {S36} is not {P27}.

--- a/spaces/S000181/properties/P000028.md
+++ b/spaces/S000181/properties/P000028.md
@@ -1,12 +1,10 @@
 ---
 space: S000181
-property: P000027
+property: P000028
 value: false
 refs:
   - mathse: 4736734
     name: A space which is 𝜎-compact but neither hemicompact nor second countable
 ---
 
-See {{mathse:4736734}}.
-
-{S181} contains {S36} as a subspace and {S36} is not {P27}.
+{S36} embeds as a subspace and {S36} is not {P28}.

--- a/spaces/S000181/properties/P000111.md
+++ b/spaces/S000181/properties/P000111.md
@@ -1,0 +1,12 @@
+---
+space: S000181
+property: P000111
+value: false
+refs:
+  - mathse: 4736734
+    name: A space which is 𝜎-compact but neither hemicompact nor second countable
+  - doi: 10.1016/j.topol.2010.10.014
+    name: Domination by second countable spaces and Lindelöf Σ-property
+---
+
+See {{mathse:4736734}}.


### PR DESCRIPTION
Updated {P151} to include the singleton selection variant. Also added the example from https://math.stackexchange.com/questions/4736734 to have an example to fill this gap: https://topology.pi-base.org/spaces?q=%24%5Csigma%24-compact%2B~Second%20Countable%2B~Hemicompact