### PR TITLE
T412 about submetrizable

### DIFF
--- a/spaces/S000076/properties/P000013.md
+++ b/spaces/S000076/properties/P000013.md
@@ -3,11 +3,8 @@ space: S000076
 property: P000013
 value: false
 refs:
-- doi: 10.1007/978-1-4612-6290-9_6
-  name: Counterexamples in Topology
+- mr: MR0464128
+  name: Topology (Munkres)
 ---
 
-Let $\Delta = \{(x,-x)\ |\ x \in \mathbb{R}\}$. Then $X$ and $X \setminus \Delta$ are closed sets that cannot be separated by open sets.
-
-Asserted in the General Reference Chart for space #84 in
-{{doi:10.1007/978-1-4612-6290-9_6}}.
+See Example 3 and Exercise 9 of section 31 in {{mr:MR3728284}}.

--- a/spaces/S000076/properties/P000013.md
+++ b/spaces/S000076/properties/P000013.md
@@ -3,7 +3,7 @@ space: S000076
 property: P000013
 value: false
 refs:
-- mr: MR0464128
+- mr: MR3728284
   name: Topology (Munkres)
 ---
 

--- a/spaces/S000076/properties/P000065.md
+++ b/spaces/S000076/properties/P000065.md
@@ -1,6 +1,6 @@
 ---
 space: S000076
-property: P000059
+property: P000065
 value: true
 refs:
 - doi: 10.1007/978-1-4612-6290-9_6

--- a/spaces/S000076/properties/P000129.md
+++ b/spaces/S000076/properties/P000129.md
@@ -1,7 +1,0 @@
----
-space: S000076
-property: P000129
-value: false
----
-
-The space is non-trivial by definition.

--- a/theorems/T000412.md
+++ b/theorems/T000412.md
@@ -6,4 +6,4 @@ then:
   P000163: true
 ---
 
-Suppose $X$ has a coarser topology that is {P26} and {P53}, hence also {P3} and {P28}.  By {T405}, the space has at most continuum cardinality.
+Suppose $X$ has a coarser topology that is {P26} and {P53}, hence also {P3} and {P28}.  By {T404}, the space has at most continuum cardinality.

--- a/theorems/T000412.md
+++ b/theorems/T000412.md
@@ -1,0 +1,9 @@
+---
+uid: T000412
+if:
+  P000166: true
+then:
+  P000163: true
+---
+
+Suppose $X$ has a coarser topology that is {P26} and {P53}, hence also {P3} and {P28}.  By {T405}, the space has at most continuum cardinality.


### PR DESCRIPTION
Add T412 to limit the cardinality of sub-separable-metrizable spaces.

Also some cleanup for S76 that I noticed while reviewing #402.  In particular, the previous justification that the Sorgenfrey plane is not normal was not making sense as written.
