### PR TITLE
add compact wH not-RC example

### DIFF
--- a/spaces/S000031/properties/P000101.md
+++ b/spaces/S000031/properties/P000101.md
@@ -1,0 +1,13 @@
+---
+space: S000031
+property: P000101
+value: false
+refs:
+- mathse: 4762250
+  name: Are retracts always closed in a compact weak Hausdorff space?
+---
+
+The diagonal of any non-{P3} space fails to be closed, but
+is always a retract of the square under the map $(x,y)\mapsto(x,x)$.
+
+See {{mathse:4762250}}.


### PR DESCRIPTION
Provides result for https://topology.pi-base.org/spaces?q=Compact%2BWeak%20Hausdorff%2B~Retracts%20are%20closed