### PR TITLE
Metacompact and other names for it

### DIFF
--- a/properties/P000031.md
+++ b/properties/P000031.md
@@ -1,9 +1,14 @@
 ---
 uid: P000031
 name: Metacompact
+aliases:
+  - Weakly paracompact
+  - Pointwise paracompact
 refs:
   - doi: 10.1007/978-1-4612-6290-9
     name: Counterexamples in Topology
+  - mr: MR1039321
+    name: General Topology (Engelking, 1989)
 ---
 
 Every open cover of the space has a point-finite open refinement.


### PR DESCRIPTION
Via @Moniker1998's original PR #431

> I've added names weakly paracompact and pointwise paracompact as other names for metacompact.
As for reference to those names I've added Engelking