### PR TITLE
Generalization of T173

### DIFF
--- a/properties/P000084.md
+++ b/properties/P000084.md
@@ -2,7 +2,10 @@
 uid: P000084
 name: Locally Hausdorff
 refs:
-  - mr: MR3084709
-    name: The equivalence relations of local homeomorphisms and Fell algebras
+- mr: MR0702721
+  name: A note on the locally Hausdorff property (S. B. Niefield)
+- wikipedia: Locally_Hausdorff_space
+  name: Locally Hausdorff space on Wikipedia
 ---
-A space is locally Hausdorff if each point has a neighborhood which is Hausdorff.
+
+Each point has a neighborhood that is {P3}.

--- a/theorems/T000173.md
+++ b/theorems/T000173.md
@@ -1,12 +1,12 @@
 ---
 uid: T000173
 if:
-  P000003: true
+  P000084: true
 then:
   P000073: true
 refs:
-- mr: MR1002193
-  name: Topology via logic
+- mr: MR0702721
+  name: A note on the locally Hausdorff property (S. B. Niefield)
 ---
 
-See page 92 of {{mr:MR1002193}}.
+See Proposition 3.5 of {{mr:MR0702721}}.


### PR DESCRIPTION
- Old version: T2 ==> sober
- New version: locally Hausdorff ==> sober

Also use better references for P84 (loc Hausdorff).