### PR TITLE
Radial and pseudoradial spaces

### DIFF
--- a/properties/P000079.md
+++ b/properties/P000079.md
@@ -5,4 +5,5 @@ refs:
   - mr: MR0687569
     name: Products of convergence properties
 ---
-A topological space is sequential if every sequentially closed set is closed.
+
+A space in which every sequentially closed set is closed.

--- a/properties/P000080.md
+++ b/properties/P000080.md
@@ -1,8 +1,6 @@
 ---
 uid: P000080
 name: Fréchet Urysohn
-aliases:
-  - Fréchet
 refs:
   - mr: MR0687569
     name: Products of convergence properties

--- a/properties/P000172.md
+++ b/properties/P000172.md
@@ -8,6 +8,6 @@ refs:
     name: Encyclopedia of general topology
 ---
 
-A space such that for each $A\subseteq X$ and each $p\in \overline A$ there is a transfinite sequence $(x_\alpha)_{\alpha<\lambda}$ in $A$ converging to $p$.  (Here $\lambda$ is a limit ordinal and can always be taken to be a regular cardinal.)
+A space such that for each $A\subseteq X$ and each $p\in \overline A$ there is a transfinite sequence $(x_\alpha)_{\alpha<\lambda}$ of points of $A$ converging to $p$.  (Here $\lambda$ is a limit ordinal and can always be taken to be a regular cardinal.)
 
 See the chapter "d-4 Pseudoradial spaces" in {{mr:MR2049453}}.

--- a/properties/P000172.md
+++ b/properties/P000172.md
@@ -1,0 +1,13 @@
+---
+uid: P000172
+name: Radial
+aliases:
+  - Fréchet chain-net
+refs:
+  - mr: MR2049453
+    name: Encyclopedia of general topology
+---
+
+A space such that for each $A\subseteq X$ and each $p\in \overline A$ there is a transfinite sequence $(x_\alpha)_{\alpha<\lambda}$ in $A$ converging to $p$.  (Here $\lambda$ is a limit ordinal and can always be taken to be a regular cardinal.)
+
+See the chapter "d-4 Pseudoradial spaces" in {{mr:MR2049453}}.

--- a/properties/P000173.md
+++ b/properties/P000173.md
@@ -8,6 +8,6 @@ refs:
     name: Encyclopedia of general topology
 ---
 
-A space in which every radially closed set is closed, where a set $A\subseteq X$ is *radially closed* if it contains the limits of all convergent transfinite sequences consisting of points of $A$.  In other words, for every non-closed set $A\subseteq X$ there is a point $p\in \overline A\setminus A$ and a transfinite sequence $(x_\alpha)_{\alpha<\lambda}$ in $A$ that converges to $p$.  (Here $\lambda$ is a limit ordinal and can always be taken to be a regular cardinal.)
+A space in which every radially closed set is closed, where a set $A\subseteq X$ is *radially closed* if it contains the limits of all convergent transfinite sequences consisting of points of $A$.  In other words, for every non-closed set $A\subseteq X$ there is a point $p\in \overline A\setminus A$ and a transfinite sequence $(x_\alpha)_{\alpha<\lambda}$ of points of $A$ that converges to $p$.  (Here $\lambda$ is a limit ordinal and can always be taken to be a regular cardinal.)
 
 See the chapter "d-4 Pseudoradial spaces" in {{mr:MR2049453}}.

--- a/properties/P000173.md
+++ b/properties/P000173.md
@@ -1,0 +1,13 @@
+---
+uid: P000173
+name: Pseudoradial
+aliases:
+  - Chain-net
+refs:
+  - mr: MR2049453
+    name: Encyclopedia of general topology
+---
+
+A space in which every radially closed set is closed, where a set $A\subseteq X$ is *radially closed* if it contains the limits of all convergent transfinite sequences consisting of points of $A$.  In other words, for every non-closed set $A\subseteq X$ there is a point $p\in \overline A\setminus A$ and a transfinite sequence $(x_\alpha)_{\alpha<\lambda}$ in $A$ that converges to $p$.  (Here $\lambda$ is a limit ordinal and can always be taken to be a regular cardinal.)
+
+See the chapter "d-4 Pseudoradial spaces" in {{mr:MR2049453}}.

--- a/theorems/T000205.md
+++ b/theorems/T000205.md
@@ -1,0 +1,12 @@
+---
+uid: T000205
+if:
+  P000172: true
+then:
+  P000173: true
+refs:
+- mr: MR2049453
+  name: Encyclopedia of general topology
+---
+
+Follows directly from the definitions.

--- a/theorems/T000206.md
+++ b/theorems/T000206.md
@@ -1,0 +1,14 @@
+---
+uid: T000206
+if:
+  P000080: true
+then:
+  P000172: true
+refs:
+- mr: MR2049453
+  name: Encyclopedia of general topology
+---
+
+Evident from the definitions, as ordinary sequences are transfinite sequences.
+
+See the chapter "d-4 Pseudoradial spaces" in {{mr:MR2049453}}.

--- a/theorems/T000207.md
+++ b/theorems/T000207.md
@@ -1,0 +1,14 @@
+---
+uid: T000207
+if:
+  P000079: true
+then:
+  P000173: true
+refs:
+- mr: MR2049453
+  name: Encyclopedia of general topology
+---
+
+Evident from the definitions, as ordinary sequences are transfinite sequences.
+
+See the chapter "d-4 Pseudoradial spaces" in {{mr:MR2049453}}.


### PR DESCRIPTION
Definitions of radial and pseudoradial properties and basic relationship with Frechet-Urysohn and sequential.

We can add more theorems after that.  In particular, it seems clear that all LOTS should be radial, but looking for a good reference for that.  That would automatically give $\omega_1+1$ as an example of a radial space that is not sequential.

Also removed "Frechet" as an alias for Frechet-Urysohn.  Not sure what that alias was for.
