### PR TITLE
Support live viewer reloading on changes in codespace

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,41 +1,47 @@
 {
-    "image": "mcr.microsoft.com/vscode/devcontainers/javascript-node:18",
-    "containerEnv": {
-      "DATA_WORKSPACE": "/workspaces/data"
+  "image": "mcr.microsoft.com/vscode/devcontainers/javascript-node:18",
+  "containerEnv": {
+    "DATA_WORKSPACE": "/workspaces/data"
+  },
+  "remoteEnv": {
+    "VITE_BUNDLE_HOST": "https://${localEnv:CODESPACE_NAME}-3141.${localEnv:GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}",
+    "VITE_BUNDLE_SSE": "true"
+  },
+  "onCreateCommand": "rm -rf web && git clone https://github.com/pi-base/web.git && cd web && pnpm install && pnpm run --filter core build",
+  "postAttachCommand": {
+    "viewer": "cd web && pnpm run --filter viewer dev --host --open",
+    "compile": "cd web && pnpm run --filter compile dev",
+    "core": "cd web && pnpm run --filter core dev",
+    // See https://github.com/orgs/community/discussions/4068
+    "publicize": "gh codespace ports visibility 3141:public -c $CODESPACE_NAME"
+  },
+  "forwardPorts": [3141, 5173],
+  "portsAttributes": {
+    "3141": {
+      "label": "compile"
     },
-    "remoteEnv": {
-      "PUBLIC_DATA_URL": "https://${localEnv:CODESPACE_NAME}-3141.${localEnv:GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}"
+    "5173": {
+      "label": "viewer"
+    }
+  },
+  "customizations": {
+    "codespaces": {
+      "openFiles": [
+        "codespace-welcome.md"
+      ]
     },
-    "onCreateCommand": "rm -rf web && git clone https://github.com/pi-base/web.git && cd web && pnpm install && pnpm run --filter core build",
-    "postAttachCommand": {
-      "viewer": "cd web && pnpm run --filter viewer dev --host --open",
-      "compile": "cd web && pnpm run --filter compile dev",
-      "core": "cd web && pnpm run --filter core dev"
-    },
-    "forwardPorts": [3141, 5173],
-    "portsAttributes": {
-      "3141": {
-        "label": "compile"
-      },
-      "5173": {
-        "label": "viewer"
-      }
-    },
-    "customizations": {
-      "codespaces": {
-        "openFiles": [
-          "codespace-welcome.md"
-        ]
-      },
-      "vscode": {
-        "settings": {
-          "workbench.editorAssociations": {
-            "codespace-welcome.md": "vscode.markdown.preview.editor"
-          },
-          "files.exclude": {
-            "web": true
-          }
+    "vscode": {
+      "settings": {
+        "workbench.editorAssociations": {
+          "codespace-welcome.md": "vscode.markdown.preview.editor"
+        },
+        "files.exclude": {
+          "web": true
         }
       }
     }
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  }
 }

--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -4,7 +4,7 @@
     "DATA_WORKSPACE": "/workspaces/data"
   },
   "remoteEnv": {
-    "VITE_BUNDLE_HOST": "https://${localEnv:CODESPACE_NAME}-3141.${localEnv:GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}",
+    "VITE_BUNDLE_HOST": "https://${localEnv:CODESPACE_NAME}-5173.${localEnv:GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}/bundle",
     "VITE_BUNDLE_SSE": "true"
   },
   "onCreateCommand": "rm -rf web && git clone https://github.com/pi-base/web.git && cd web && pnpm install && pnpm run --filter core build",

--- a/codespace-welcome.md
+++ b/codespace-welcome.md
@@ -1,22 +1,30 @@
 ## Welcome to the π-Base Codespace!
 
-### Initial setup
-
-Use the `Ports` tab, and right-click `compile (3141)` to set
-`Port visibility > Public`.
-
 ### Editing and refreshing
 
 A window should automatically open with a preview of the data
 repository. If it is closed, you can re-open it by ctrl/cmd-clicking
 this link: <http://localhost:5173>.
 
-To refresh your preview, you must visit the `Advanced` or branch tab
-of the viewer app at <http://localhost:5173/dev>. Click the refresh (⟳)
-icon next to "Sync" to reload the data with your updates.
+Making changes to file in your codespace should trigger an automatic rebuild and
+reload of the viewer.
 
 ### More information
 
 Visit the [π-Base wiki](https://github.com/pi-base/data/wiki)
 to learn more about how to use this Codespace to contribute to the
 `pi-base/data` repository.
+
+### Troubleshooting
+
+#### Data changes not visible
+
+First, ensure that your changes compiled without error by examining the output
+in the `Terminal` > `Codespaces: compile` process. A red `Build failed` should
+include validation messages with instructions about errors to correct.
+
+Successful `Build finished` messages should automatically trigger a reload of
+the preview viewer. To manually refresh your preview – or to inspect the status
+of its loaded data any time – visit the `Advanced` or branch tab
+of the viewer app at <http://localhost:5173/dev>. Click the refresh (⟳)
+icon next to "Sync" to reload the data with your updates.


### PR DESCRIPTION
pi-base/web#120 added support for server-sent events on compiler rebuilds to trigger a viewer reload. This PR wires that up in the `.devcontainer` config.

Fixes #497
Fixes pi-base/web#116