### PR TITLE
Improve markdown files

### DIFF
--- a/properties/P000074.md
+++ b/properties/P000074.md
@@ -4,6 +4,5 @@ name: Cosmic
 refs:
 - mr: 1305126
   name: Spaces having star-countable k-Networks
-counterexamples_id: null
 ---
 Defined in the introduction of {{mr:1305126}}

--- a/properties/P000074.md
+++ b/properties/P000074.md
@@ -1,6 +1,5 @@
 ---
 uid: P000074
-aliases: []
 name: Cosmic
 refs:
 - mr: 1305126

--- a/properties/P000074.md
+++ b/properties/P000074.md
@@ -2,7 +2,7 @@
 uid: P000074
 name: Cosmic
 refs:
-- mr: 1305126
-  name: Spaces having star-countable k-Networks
+  - mr: 1305126
+    name: Spaces having star-countable k-Networks
 ---
 Defined in the introduction of {{mr:1305126}}

--- a/properties/P000075.md
+++ b/properties/P000075.md
@@ -10,4 +10,4 @@ refs:
 A compact sober space for which the collection of compact open subsets is
 closed under finite intersections and forms a base for the topology.
 
-See example 21, section 2.6 of {{MR1077251}}.
+See example 21, section 2.6 of {{mr:1077251}}.

--- a/properties/P000083.md
+++ b/properties/P000083.md
@@ -1,6 +1,5 @@
 ---
 uid: P000083
-aliases: []
 name: Almost Čech Complete
 refs:
 - mr: 2492954

--- a/properties/P000083.md
+++ b/properties/P000083.md
@@ -4,6 +4,5 @@ name: Almost Čech Complete
 refs:
 - mr: 2492954
   name: ! 'The compact-open topology: A new perspective'
-counterexamples_id: null
 ---
 Defined following Corollary 4.2 of {{mr:2492954}}

--- a/properties/P000085.md
+++ b/properties/P000085.md
@@ -1,6 +1,5 @@
 ---
 uid: P000085
-aliases: []
 name: Ascoli
 refs:
 - mr: 3571035

--- a/properties/P000085.md
+++ b/properties/P000085.md
@@ -4,6 +4,5 @@ name: Ascoli
 refs:
 - mr: 3571035
   name: The Ascoli property for function spaces
-counterexamples_id: null
 ---
 Defined in Section 1 of {{mr:3571035}}

--- a/properties/P000092.md
+++ b/properties/P000092.md
@@ -1,6 +1,5 @@
 ---
 uid: P000092
-aliases: []
 name: Moving Off Property
 refs:
 - mr: 3347950

--- a/properties/P000092.md
+++ b/properties/P000092.md
@@ -4,6 +4,5 @@ name: Moving Off Property
 refs:
 - mr: 3347950
   name: Completeness properties in the compact-open topology on fans
-counterexamples_id: null
 ---
 Defined following Theorem 2.1 of {{mr:3347950}}

--- a/properties/P000094.md
+++ b/properties/P000094.md
@@ -1,6 +1,5 @@
 ---
 uid: P000094
-aliases: []
 name: q Space
 refs:
 - mr: 2492954

--- a/properties/P000094.md
+++ b/properties/P000094.md
@@ -4,6 +4,5 @@ name: q Space
 refs:
 - mr: 2492954
   name: ! 'The compact-open topology: A new perspective'
-counterexamples_id: null
 ---
 Defined in Definitions 3.7 of {{mr:2492954}}

--- a/properties/P000097.md
+++ b/properties/P000097.md
@@ -4,6 +4,5 @@ name: Homotopy Dense
 refs:
 - mr: 3679084
   name: Topological classification of function spaces with the Fell topology IV
-counterexamples_id: null
 ---
 Defined in Section 2 of {{mr:3679084}}

--- a/properties/P000097.md
+++ b/properties/P000097.md
@@ -1,6 +1,5 @@
 ---
 uid: P000097
-aliases: []
 name: Homotopy Dense
 refs:
 - mr: 3679084

--- a/properties/P000102.md
+++ b/properties/P000102.md
@@ -4,6 +4,5 @@ name: Semimetrizable
 refs:
 - mr: 2492954
   name: ! 'The compact-open topology: A new perspective'
-counterexamples_id: null
 ---
 Defined in Definition 3.7 of {{mr:2492954}}

--- a/properties/P000102.md
+++ b/properties/P000102.md
@@ -1,6 +1,5 @@
 ---
 uid: P000102
-aliases: []
 name: Semimetrizable
 refs:
 - mr: 2492954

--- a/properties/P000104.md
+++ b/properties/P000104.md
@@ -4,6 +4,5 @@ name: K Analytic
 refs:
 - mr: 2248392
   name: A note on a theorem of Talagrand
-counterexamples_id: null
 ---
 Defined in Section 1 of {{mr:2248392}}

--- a/properties/P000104.md
+++ b/properties/P000104.md
@@ -1,6 +1,5 @@
 ---
 uid: P000104
-aliases: []
 name: K Analytic
 refs:
 - mr: 2248392

--- a/properties/P000105.md
+++ b/properties/P000105.md
@@ -4,6 +4,5 @@ name: Angelic
 refs:
 - mr: 2280918
   name: A class of angelic sequential non-Fréchet-Urysohn topological groups
-counterexamples_id: null
 ---
 Defined in Section 1 of {{mr:2280918}}

--- a/properties/P000105.md
+++ b/properties/P000105.md
@@ -1,6 +1,5 @@
 ---
 uid: P000105
-aliases: []
 name: Angelic
 refs:
 - mr: 2280918

--- a/properties/P000106.md
+++ b/properties/P000106.md
@@ -4,6 +4,5 @@ name: Strictly Angelic
 refs:
 - mr: 2280918
   name: A class of angelic sequential non-Fréchet-Urysohn topological groups
-counterexamples_id: null
 ---
 Defined in Section 1 of {{mr:2280918}}

--- a/properties/P000106.md
+++ b/properties/P000106.md
@@ -1,6 +1,5 @@
 ---
 uid: P000106
-aliases: []
 name: Strictly Angelic
 refs:
 - mr: 2280918

--- a/properties/P000107.md
+++ b/properties/P000107.md
@@ -4,6 +4,5 @@ name: Pointwise Countable Type
 refs:
 - mr: 2492954
   name: ! 'The compact-open topology: A new perspective'
-counterexamples_id: null
 ---
 Defined in Definitions 3.7 of {{mr:2492954}}

--- a/properties/P000107.md
+++ b/properties/P000107.md
@@ -1,6 +1,5 @@
 ---
 uid: P000107
-aliases: []
 name: Pointwise Countable Type
 refs:
 - mr: 2492954

--- a/properties/P000108.md
+++ b/properties/P000108.md
@@ -4,6 +4,5 @@ name: Locally Čech Complete
 refs:
 - mr: 2492954
   name: ! 'The compact-open topology: A new perspective'
-counterexamples_id: null
 ---
 Defined following Corollary 4.2 of {{mr:2492954}}

--- a/properties/P000108.md
+++ b/properties/P000108.md
@@ -1,6 +1,5 @@
 ---
 uid: P000108
-aliases: []
 name: Locally Čech Complete
 refs:
 - mr: 2492954

--- a/properties/P000109.md
+++ b/properties/P000109.md
@@ -4,6 +4,5 @@ name: Countable Type
 refs:
 - mr: 2492954
   name: ! 'The compact-open topology: A new perspective'
-counterexamples_id: null
 ---
 Defined in Definitions 3.7 of {{mr:2492954}}

--- a/properties/P000109.md
+++ b/properties/P000109.md
@@ -1,6 +1,5 @@
 ---
 uid: P000109
-aliases: []
 name: Countable Type
 refs:
 - mr: 2492954

--- a/properties/P000110.md
+++ b/properties/P000110.md
@@ -4,6 +4,5 @@ name: Has A Compact Resolution
 refs:
 - mr: 3571035
   name: The Ascoli property for function spaces
-counterexamples_id: null
 ---
 Defined before Lemma 3.6 of {{mr:3571035}}

--- a/properties/P000110.md
+++ b/properties/P000110.md
@@ -1,6 +1,5 @@
 ---
 uid: P000110
-aliases: []
 name: Has A Compact Resolution
 refs:
 - mr: 3571035

--- a/properties/P000111.md
+++ b/properties/P000111.md
@@ -1,6 +1,5 @@
 ---
 uid: P000111
-aliases: []
 name: Hemicompact
 refs:
   - mr: 17525

--- a/properties/P000111.md
+++ b/properties/P000111.md
@@ -6,7 +6,6 @@ refs:
     name: A topology for spaces of transformations
   - mr: 2048350
     name: General Topology (Willard)
-counterexamples_id: null
 ---
 
 Defined in Section 8 of {{mr:0017525}}, see also {{mr:2048350}}. A space which is the union of countably-many

--- a/properties/P000113.md
+++ b/properties/P000113.md
@@ -4,6 +4,5 @@ name: k$\mathbb{R}$ Space
 refs:
 - mr: 2248392
   name: A note on a theorem of Talagrand
-counterexamples_id: null
 ---
 Defined in Section 1 of {{mr:2248392}}

--- a/properties/P000113.md
+++ b/properties/P000113.md
@@ -1,6 +1,5 @@
 ---
 uid: P000113
-aliases: []
 name: k$\mathbb{R}$ Space
 refs:
 - mr: 2248392

--- a/properties/P000115.md
+++ b/properties/P000115.md
@@ -1,6 +1,5 @@
 ---
 uid: P000115
-aliases: []
 name: Weakly K Analytic
 refs:
 - mr: 2248392

--- a/properties/P000115.md
+++ b/properties/P000115.md
@@ -4,6 +4,5 @@ name: Weakly K Analytic
 refs:
 - mr: 2248392
   name: A note on a theorem of Talagrand
-counterexamples_id: null
 ---
 Defined in Section 1 of {{mr:2248392}}

--- a/properties/P000117.md
+++ b/properties/P000117.md
@@ -4,6 +4,5 @@ name: M Space
 refs:
 - mr: 2492954
   name: ! 'The compact-open topology: A new perspective'
-counterexamples_id: null
 ---
 Defined in Definitions 3.7 of {{mr:2492954}}

--- a/properties/P000117.md
+++ b/properties/P000117.md
@@ -1,6 +1,5 @@
 ---
 uid: P000117
-aliases: []
 name: M Space
 refs:
 - mr: 2492954

--- a/properties/P000118.md
+++ b/properties/P000118.md
@@ -1,6 +1,5 @@
 ---
 uid: P000118
-aliases: []
 name: Pseudo-Polish
 refs:
 - mr: 2915445

--- a/properties/P000118.md
+++ b/properties/P000118.md
@@ -4,6 +4,5 @@ name: Pseudo-Polish
 refs:
 - mr: 2915445
   name: Topological conditions for the representation of preorders by continuous utilities
-counterexamples_id: null
 ---
 Defined at the beginning of Section 3 of {{mr:2915445}}

--- a/properties/P000119.md
+++ b/properties/P000119.md
@@ -4,6 +4,5 @@ name: Z-Compact
 refs:
 - mr: 3720884
   name: On a question of Kaplansky
-counterexamples_id: null
 ---
 Defined in Section 1 of {{mr:3720884}}

--- a/properties/P000119.md
+++ b/properties/P000119.md
@@ -1,6 +1,5 @@
 ---
 uid: P000119
-aliases: []
 name: Z-Compact
 refs:
 - mr: 3720884

--- a/properties/P000120.md
+++ b/properties/P000120.md
@@ -1,6 +1,5 @@
 ---
 uid: P000120
-aliases: []
 name: r Space
 refs:
 - mr: 2492954

--- a/properties/P000120.md
+++ b/properties/P000120.md
@@ -4,6 +4,5 @@ name: r Space
 refs:
 - mr: 2492954
   name: ! 'The compact-open topology: A new perspective'
-counterexamples_id: null
 ---
 Defined in Definitions 3.7 of {{mr:2492954}}

--- a/properties/P000122.md
+++ b/properties/P000122.md
@@ -4,6 +4,5 @@ name: S space
 refs:
 - mr: 17525
   name: A topology for spaces of transformations
-counterexamples_id: null
 ---
 Defined in Section 9 of {{mr:0017525}}

--- a/properties/P000122.md
+++ b/properties/P000122.md
@@ -1,6 +1,5 @@
 ---
 uid: P000122
-aliases: []
 name: S space
 refs:
 - mr: 17525

--- a/properties/P000123.md
+++ b/properties/P000123.md
@@ -4,7 +4,6 @@ name: Locally Euclidean
 refs:
 - mr: '3728284'
   name: Topology (Munkres)
-counterexamples_id: null
 ---
 For each point of the space, there is a neighborhood that is homeomorphic to an open subset of $\mathbb R^n$ for some $n$.
 

--- a/properties/P000123.md
+++ b/properties/P000123.md
@@ -1,6 +1,5 @@
 ---
 uid: P000123
-aliases: []
 name: Locally Euclidean
 refs:
 - mr: '3728284'

--- a/properties/P000124.md
+++ b/properties/P000124.md
@@ -4,7 +4,6 @@ name: Topological manifold
 refs:
 - mr: '3728284'
   name: Topology (Munkres)
-counterexamples_id: null
 ---
 A locally Euclidean space that is Hausdorff and second-countable.
 

--- a/properties/P000124.md
+++ b/properties/P000124.md
@@ -1,6 +1,5 @@
 ---
 uid: P000124
-aliases: []
 name: Topological manifold
 refs:
 - mr: '3728284'

--- a/properties/P000128.md
+++ b/properties/P000128.md
@@ -1,6 +1,5 @@
 ---
 uid: P000128
-aliases: []
 name: $k$-Lindelöf
 refs:
 - doi: 10.1016/j.topol.2005.07.015


### PR DESCRIPTION
Some simple changes to improve the consistency of the markdown files. Unnecessary lines are removed and in two files, the indentation and MR-links are fixed.