### PR TITLE
Expand definition of cosmic space, add definitions of sigma-space, aleph-space and aleph_0-space

### DIFF
--- a/properties/P000074.md
+++ b/properties/P000074.md
@@ -5,4 +5,4 @@ refs:
   - mr: 1305126
     name: Spaces having star-countable k-Networks
 ---
-Defined in the introduction of {{mr:1305126}}
+A family $\mathcal{P}$ of subsets of $X$ is called a network if for any open set $U \subseteq X$ there is some subfamily $\mathcal{P}' \subseteq \mathcal{P}$ with $U = \bigcup \mathcal{P}'$. $X$ is called a cosmic space if it is $T_3$ and has a countable network.

--- a/properties/P000177.md
+++ b/properties/P000177.md
@@ -1,0 +1,8 @@
+---
+uid: P000177
+name: $\sigma$-space
+refs:
+  - mr: 1305126
+    name: Spaces having star-countable k-Networks
+---
+A family $\mathcal{P}$ of subsets of $X$ is called a network if for any open set $U \subseteq X$ there is some subfamily $\mathcal{P}' \subseteq \mathcal{P}$ with $U = \bigcup \mathcal{P}'$. A family of subsets of $X$ is called $\sigma$-locally finite if it is a countable union of locally finite families. $X$ is called a $\sigma$-space if it is $T_3$ and has a $\sigma$-locally finite network.

--- a/properties/P000178.md
+++ b/properties/P000178.md
@@ -1,0 +1,8 @@
+---
+uid: P000178
+name: $\aleph$-space
+refs:
+  - mr: 1305126
+    name: Spaces having star-countable k-Networks
+---
+A family $\mathcal{P}$ of subsets of $X$ is called a $k$-network if for any compact set $K \subseteq X$ and open set $U \subseteq X$ with $K \subseteq U$, there exists a finite $\mathcal{P}^* \subseteq \mathcal{P}$ with $K \subseteq \bigcup \mathcal{P}^* \subseteq U$. A family of subsets of $X$ is called $\sigma$-locally finite if it is a countable union of locally finite families. $X$ is called an $\aleph$-space if it is $T_3$ and has a $\sigma$-locally finite $k$-network.

--- a/properties/P000179.md
+++ b/properties/P000179.md
@@ -1,0 +1,8 @@
+---
+uid: P000179
+name: $\aleph_0$-space
+refs:
+  - mr: 1305126
+    name: Spaces having star-countable k-Networks
+---
+A family $\mathcal{P}$ of subsets of $X$ is called a $k$-network if for any compact set $K \subseteq X$ and open set $U \subseteq X$ with $K \subseteq U$, there exists a finite $\mathcal{P}^* \subseteq \mathcal{P}$ with $K \subseteq \bigcup \mathcal{P}^* \subseteq U$. $X$ is called an $\aleph_0$-space if it is $T_3$ and has a countable $k$-network.


### PR DESCRIPTION
This depends on #508.

Expand the definition of cosmic space and add definitions of $\sigma$-space, $\aleph$-space and $\aleph_0$-space. The latter 3 terms are all defined analogously to and in the same reference as the first term, so if the first term is relevant enough to be included, I think the latter 3 terms are relevant enough as well.