### PR TITLE
Add Countable + T_3 => Cosmic and Cosmic => sigma-space as well as {Cosmic, sigma-space, aleph-space, aleph_0-space} => T_3

### DIFF
--- a/theorems/T000434.md
+++ b/theorems/T000434.md
@@ -1,0 +1,11 @@
+---
+uid: T000434
+if:
+  and:
+    - P000005: true
+    - P000057: true
+then:
+  P000074: true
+---
+
+If $X$ is countable and $T_3$, choose $\mathcal{P} = \\{\\{x\\} \mid x \in X\\}$.

--- a/theorems/T000435.md
+++ b/theorems/T000435.md
@@ -1,0 +1,9 @@
+---
+uid: T000435
+if:
+  P000074: true
+then:
+  P000177: true
+---
+
+Any countable family is also $\sigma$-locally finite.

--- a/theorems/T000436.md
+++ b/theorems/T000436.md
@@ -1,0 +1,9 @@
+---
+uid: T000436
+if:
+  P000074: true
+then:
+  P000005: true
+---
+
+By definition.

--- a/theorems/T000437.md
+++ b/theorems/T000437.md
@@ -1,0 +1,9 @@
+---
+uid: T000437
+if:
+  P000177: true
+then:
+  P000005: true
+---
+
+By definition.

--- a/theorems/T000438.md
+++ b/theorems/T000438.md
@@ -1,0 +1,9 @@
+---
+uid: T000438
+if:
+  P000178: true
+then:
+  P000005: true
+---
+
+By definition.

--- a/theorems/T000439.md
+++ b/theorems/T000439.md
@@ -1,0 +1,9 @@
+---
+uid: T000439
+if:
+  P000179: true
+then:
+  P000005: true
+---
+
+By definition.


### PR DESCRIPTION
We would like to deduce the properties Cosmic and $\sigma$-space in some trivial cases, so this adds the theorems Countable + T_3 => Cosmic and Cosmic => $\sigma$-space. Additionally, $T_3$ is now part of the definition of the properties Cosmic, $\sigma$-space, $\aleph$-space and $\aleph_0$-space, so this adds the corresponding theorems.