### PR TITLE
Improved definitions for cosmic, etc

### DIFF
--- a/properties/P000074.md
+++ b/properties/P000074.md
@@ -2,7 +2,12 @@
 uid: P000074
 name: Cosmic
 refs:
-  - mr: 1305126
-    name: Spaces having star-countable k-Networks
+  - mr: 206907
+    name: $\aleph_0$-spaces (E. Michael)
+  - doi: 10.1016/j.topol.2015.05.085
+    name: $\mathfrak P$-spaces and related concepts (Gabriyelyan & Kakol)
 ---
-A family $\mathcal{P}$ of subsets of $X$ is called a network if for any open set $U \subseteq X$ there is some subfamily $\mathcal{P}' \subseteq \mathcal{P}$ with $U = \bigcup \mathcal{P}'$. $X$ is called a cosmic space if it is $T_3$ and has a countable network.
+
+A space that is {P5} and has a countable network.  Here, a family $\mathcal{P}$ of subsets of $X$ is called a *network* if for every $x\in X$ and every neighborhood $U$ of $x$ there is some $P\in\mathcal P$ such that $x\in P\subseteq U$.
+
+The notion was originally defined in section 10 of {{mr:206907}}, which is available at <https://www.jstor.org/stable/24901448>.

--- a/properties/P000177.md
+++ b/properties/P000177.md
@@ -2,7 +2,12 @@
 uid: P000177
 name: $\sigma$-space
 refs:
-  - mr: 1305126
-    name: Spaces having star-countable k-Networks
+  - doi: 10.3792/pja/1195521153
+    name: $\sigma$-spaces and closed mappings, I (A. Okuyama)
+  - doi: 10.1016/j.topol.2015.05.085
+    name: $\mathfrak P$-spaces and related concepts (Gabriyelyan & Kakol)
 ---
-A family $\mathcal{P}$ of subsets of $X$ is called a network if for any open set $U \subseteq X$ there is some subfamily $\mathcal{P}' \subseteq \mathcal{P}$ with $U = \bigcup \mathcal{P}'$. A family of subsets of $X$ is called $\sigma$-locally finite if it is a countable union of locally finite families. $X$ is called a $\sigma$-space if it is $T_3$ and has a $\sigma$-locally finite network.
+
+A space that is {P5} and has a $\sigma$-locally finite network.  Here, a family $\mathcal{P}$ of subsets of $X$ is called a *network* if for every $x\in X$ and every neighborhood $U$ of $x$ there is some $P\in\mathcal P$ such that $x\in P\subseteq U$.  And the family $\mathcal P$ is *$\sigma$-locally finite* if it is a countable union of locally finite families.
+
+The notion was introduced by A. Okuyama (see {{doi:10.3792/pja/1195521153}}) without the {P5} condition.  But most later papers, for example {{doi:10.1016/j.topol.2015.05.085}}, assume {P5}.

--- a/properties/P000178.md
+++ b/properties/P000178.md
@@ -2,7 +2,10 @@
 uid: P000178
 name: $\aleph$-space
 refs:
-  - mr: 1305126
-    name: Spaces having star-countable k-Networks
+  - doi: 10.1090/S0002-9939-1971-0276919-3
+    name: "On paracompactness in function spaces with the compact-open topology (P. O'Meara)"
+  - doi: 10.1016/j.topol.2015.05.085
+    name: $\mathfrak P$-spaces and related concepts (Gabriyelyan & Kakol)
 ---
-A family $\mathcal{P}$ of subsets of $X$ is called a $k$-network if for any compact set $K \subseteq X$ and open set $U \subseteq X$ with $K \subseteq U$, there exists a finite $\mathcal{P}^* \subseteq \mathcal{P}$ with $K \subseteq \bigcup \mathcal{P}^* \subseteq U$. A family of subsets of $X$ is called $\sigma$-locally finite if it is a countable union of locally finite families. $X$ is called an $\aleph$-space if it is $T_3$ and has a $\sigma$-locally finite $k$-network.
+
+A space that is {P5} and has a $\sigma$-locally finite $k$-network.  Here, a family $\mathcal{P}$ of subsets of $X$ is called a *$k$-network* if for every compact set $K$ and open set $U$ in $X$ with $K \subseteq U$, there exists a finite $\mathcal{P}^* \subseteq \mathcal{P}$ with $K \subseteq \bigcup \mathcal{P}^* \subseteq U$.  And the family $\mathcal P$ is *$\sigma$-locally finite* if it is a countable union of locally finite families.

--- a/properties/P000179.md
+++ b/properties/P000179.md
@@ -2,7 +2,16 @@
 uid: P000179
 name: $\aleph_0$-space
 refs:
-  - mr: 1305126
-    name: Spaces having star-countable k-Networks
+  - mr: 206907
+    name: $\aleph_0$-spaces (E. Michael)
+  - doi: 10.1016/j.topol.2015.05.085
+    name: $\mathfrak P$-spaces and related concepts (Gabriyelyan & Kakol)
 ---
-A family $\mathcal{P}$ of subsets of $X$ is called a $k$-network if for any compact set $K \subseteq X$ and open set $U \subseteq X$ with $K \subseteq U$, there exists a finite $\mathcal{P}^* \subseteq \mathcal{P}$ with $K \subseteq \bigcup \mathcal{P}^* \subseteq U$. $X$ is called an $\aleph_0$-space if it is $T_3$ and has a countable $k$-network.
+
+A space that is {P5} and has a countable $k$-network.  Here, a family $\mathcal{P}$ of subsets of $X$ is called a *$k$-network* if for every compact set $K$ and open set $U$ in $X$ with $K \subseteq U$, there exists a finite $\mathcal{P}^* \subseteq \mathcal{P}$ with $K \subseteq \bigcup \mathcal{P}^* \subseteq U$.
+
+Equivalently, a space that is {P5} and has a countable pseudobase.  Here, a family $\mathcal{P}$ of subsets of $X$ is called a *pseudobase* if for every compact set $K$ and open set $U$ in $X$ with $K \subseteq U$, there exists some $P\in\mathcal{P}$ with $K \subseteq P \subseteq U$.
+
+For the equivalence between the two, note that every pseudobase is a $k$-network.  And conversely given a countable $k$-network $\mathcal P$, the collection of finite unions of elements of $\mathcal P$ is a countable pseudobase.
+
+Originally defined in {{mr:206907}}, which is available at <https://www.jstor.org/stable/24901448>.


### PR DESCRIPTION
This tweaks the definitions for cosmic, $\sigma$-space, $\aleph_0$-space, $\aleph$-space.  In particular, I thought the reference that was used was not very good.  I replaced it with the original paper that introduced the concept in each case, plus a good recent paper (Gabriyelyan & Kakol) that has all the involved notions (and more) in a well organized manner.  Also tweaked the definitions of network to follow Engelking.

Regarding the fact that all four definitions assume $T_3$, they were initially defined that way, except for $\sigma$-space.  But it seems recent papers usually assume $T_3$ also.

In particular, [cosmic <==> T3 + countable network].  But in order to derive basic implications, it seems to me it would be useful to add the property "has a countable network" by itself.  That would allow to derive simple things like [countable ==> has a countable network], etc without having to repeat T3 (countable + T3 ==> cosmic) for example.

@creator1creeper1, @StevenClontz, what do you think?
