### PR TITLE
establish k_omega among strengthenings of sigma-compact

### DIFF
--- a/theorems/T000321.md
+++ b/theorems/T000321.md
@@ -3,7 +3,11 @@ uid: T000321
 if:
   P000098: true
 then:
-  P000017: true
+  P000111: true
+refs:
+  - mathse: 4585825
+    name: Without Hausdorff, what implications can we prove about $k_\omega$
+          related to other covering properties?
 ---
 
 By definition.

--- a/theorems/T000434.md
+++ b/theorems/T000434.md
@@ -1,13 +1,15 @@
 ---
-uid: T000321
+uid: T000434
 if:
-  P000098: true
+  and: 
+    - P000111: true
+    - P000140: true
 then:
-  P000111: true
+  P000098: true
 refs:
   - mathse: 4585825
     name: Without Hausdorff, what implications can we prove about $k_\omega$
           related to other covering properties?
 ---
 
-Shown in {{mathse:4585825}}.
+Shown in {{mathse:4585825}}


### PR DESCRIPTION
With @marswill's answer at https://math.stackexchange.com/questions/4585825/without-hausdorff-what-implications-can-we-prove-about-k-omega-related-to-ot/4845730#4845730 we have 

$$\text{exhaustible-by-compacts}\implies k_\omega\implies \text{hemicompact}\implies \sigma\text{-compact}$$

This PR implements this, providng results for these two searches currently missing:

https://topology.pi-base.org/spaces?q=Hemicompact%2BGenerated+by+compact+subspaces%2B%7EGenerated+by+countably-many+compacts

https://topology.pi-base.org/spaces?q=%7EHemicompact%2BGenerated+by+countably-many+compacts