### PR TITLE
Upgrade locally countable to countably tight in T211

### DIFF
--- a/theorems/T000211.md
+++ b/theorems/T000211.md
@@ -11,4 +11,4 @@ refs:
     mathse: 4785088
 ---
 
-Given a set $A\subseteq X$ and a point $p\in \overline{A}$, by {P81} there is some countable subset $D\subseteq A$ with $p\in\overline{D}$. Since $X$ is radial there is a transfinite sequence in $D$ converging to $p$.  Then, as explained in {{mathse:4785088}}, there exists a countable sequence of points in $D$ (and also a fortiori in $A$) converging to $p$.
+Given a set $A\subseteq X$ and a point $p\in \overline{A}$, since $X$ is {P81} there is some countable subset $D\subseteq A$ with $p\in\overline{D}$. Since $X$ is {P172} there is a transfinite sequence in $D$ converging to $p$.  Then, as explained in {{mathse:4785088}}, there exists a countable sequence of points in $D$ (and also a fortiori in $A$) converging to $p$.

--- a/theorems/T000211.md
+++ b/theorems/T000211.md
@@ -2,7 +2,7 @@
 uid: T000211
 if:
   and:
-  - P000093: true
+  - P000081: true
   - P000172: true
 then:
   P000080: true
@@ -11,4 +11,4 @@ refs:
     mathse: 4785088
 ---
 
-Given a transfinite sequence with values in a set $A$ and converging to a point $p\in X$, first replace it by a tail end belonging to a countable neighborhood of $p$ by {P93}. So we can assume without loss of generality that $A$ is countable.  Then, as explained in {{mathse:4785088}}, there exists a countable sequence of points of $A$ converging to $p$.
+Given a set $A\subseteq X$ and a point $p\in \overline{A}$, by {P81} there is some countable subset $D\subseteq A$ with $p\in\overline{D}$. Since $X$ is radial there is a transfinite sequence in $D$ converging to $p$.  Then, as explained in {{mathse:4785088}}, there exists a countable sequence of points in $D$ (and also a fortiori in $A$) converging to $p$.

--- a/theorems/T000211.md
+++ b/theorems/T000211.md
@@ -7,8 +7,9 @@ if:
 then:
   P000080: true
 refs:
-  - name: Radial/pseudoradial implies Fréchet-Urysohn/sequential for locally countable spaces
-    mathse: 4785088
+  - name: Answer to "Radial/pseudoradial implies Fréchet-Urysohn/sequential for locally countable spaces"
+    mathse: 4850979
 ---
 
-Given a set $A\subseteq X$ and a point $p\in \overline{A}$, since $X$ is {P81} there is some countable subset $D\subseteq A$ with $p\in\overline{D}$. Since $X$ is {P172} there is a transfinite sequence in $D$ converging to $p$.  Then, as explained in {{mathse:4785088}}, there exists a countable sequence of points in $D$ (and also a fortiori in $A$) converging to $p$.
+Established in {{mathse:4850979}}. 
+


### PR DESCRIPTION
Small upgrade to [T211](https://topology.pi-base.org/theorems/T000211) using basically the same proof.  

(Note that unfortunately we can't do the same upgrade for [T210](https://topology.pi-base.org/theorems/T000210), $\mathbb R\cup \\{\infty\\}$ with neighborhoods at $\infty$ being cocountable dense open subsets of $\mathbb R$ is a counter-example.)