### PR TITLE
(Corrected) Tighten Theorem T404 by relaxing 1st Countable and Hausdorff to Sequential and US

### DIFF
--- a/theorems/T000404.md
+++ b/theorems/T000404.md
@@ -14,6 +14,6 @@ refs:
   name: Answer to "Does a separable, $US$, sequential space have cardinality at most the continuum?"
 ---
 
-Proved in or {{mathse:4850951}} with a generalization of the ideas in Theorem 4.4 of {{mr:0776620}}.
+Proved in {{mathse:4850951}} with a generalization of the ideas in Theorem 4.4 of {{mr:0776620}}.
 
 Note also that density $\leq\mathfrak c$ is sufficient.

--- a/theorems/T000404.md
+++ b/theorems/T000404.md
@@ -2,9 +2,9 @@
 uid: T000404
 if:
   and:
-    - P000003: true
     - P000026: true
-    - P000028: true
+    - P000079: true
+    - P000099: true
 then:
   P000163: true
 refs:
@@ -14,5 +14,6 @@ refs:
   name: A first-countable, separable Hausdorff space has at most the continuum cardinality c
 ---
 
-See Theorem 4.4 of {{mr:0776620}}, or {{mathse:2995939}}.
-Note that density $\leq\mathfrak c$ is sufficient.
+See Theorem 4.4 of {{mr:0776620}}, or {{mathse:2995939}}, and note that the proofs, though stated with the assumptions of first-countability and Hausdorff, only use the former to establish $X$ is sequential, and only use the latter to establish that it is $US$.
+
+Note also that density $\leq\mathfrak c$ is sufficient.

--- a/theorems/T000404.md
+++ b/theorems/T000404.md
@@ -10,10 +10,10 @@ then:
 refs:
 - mr: 776620
   name: Cardinal functions. I. Handbook of set-theoretic topology (R. Hodel)
-- mathse: 2995939
-  name: A first-countable, separable Hausdorff space has at most the continuum cardinality c
+- mathse: 4850951
+  name: Answer to "Does a separable, $US$, sequential space have cardinality at most the continuum?"
 ---
 
-See Theorem 4.4 of {{mr:0776620}}, or {{mathse:2995939}}, and note that though the proofs are stated with the assumption that $X$ is {P28} and {P3}, the former property is only used to establish that $X$ is {P79}, and the latter is only used to establish that $X$ is {P99}.
+Proved in or {{mathse:4850951}} with a generalization of the ideas in Theorem 4.4 of {{mr:0776620}}.
 
 Note also that density $\leq\mathfrak c$ is sufficient.

--- a/theorems/T000404.md
+++ b/theorems/T000404.md
@@ -14,6 +14,6 @@ refs:
   name: A first-countable, separable Hausdorff space has at most the continuum cardinality c
 ---
 
-See Theorem 4.4 of {{mr:0776620}}, or {{mathse:2995939}}, and note that the proofs, though stated with the assumptions of first-countability and Hausdorff, only use the former to establish $X$ is sequential, and only use the latter to establish that it is $US$.
+See Theorem 4.4 of {{mr:0776620}}, or {{mathse:2995939}}, and note that though the proofs are stated with the assumption that $X$ is {P28} and {P3}, the former property is only used to establish that $X$ is {P79}, and the latter is only used to establish that $X$ is {P99}.
 
 Note also that density $\leq\mathfrak c$ is sufficient.


### PR DESCRIPTION
This supplies a correct argument to upgrade [T404] (https://topology.pi-base.org/theorems/T000404), which was incorrectly argued in #536 

closes #535

(In retrospect, I suppose a new PR was not necessary for this, and I could have kept the original PR open and fixed things there.)

[Correct argument given [here](https://math.stackexchange.com/a/4850951/1210477). ]