### PR TITLE
T217: countably tight + well-based imply first countable

### DIFF
--- a/theorems/T000217.md
+++ b/theorems/T000217.md
@@ -1,0 +1,14 @@
+---
+uid: T000217
+if:
+  and:
+  - P000081: true
+  - P000174: true
+then:
+  P000028: true
+refs:
+- mathse: 4856518
+  name: Countably tight well-based spaces are first countable
+---
+
+See {{mathse:4856518}}.


### PR DESCRIPTION
New T217: countably tight + well-based ==> first countable

Allows to deduce well-based=false for 5 more spaces:
https://topology.pi-base.org/spaces?q=Countably+tight%2B%7EFirst+Countable%2B%3FWell-based

I did not find any traits that could be cleaned up.
