### PR TITLE
T236: LOTS + countably tight imply first countable

### DIFF
--- a/theorems/T000236.md
+++ b/theorems/T000236.md
@@ -1,0 +1,15 @@
+---
+uid: T000236
+if:
+  and:
+  - P000133: true
+  - P000081: true
+then:
+  P000028: true
+---
+
+Suppose $(X,<)$ is a totally ordered set with the corresponding order topology and let $a\in X$.
+
+If $a$ is not isolated to the left (that is, in $(\leftarrow,a]$), it is in the closure of $(\leftarrow,a)$ and by {P81} there is a countably infinite set $C\subseteq(\leftarrow,a)$ with $a=\sup C$.  We can then extract a strictly increasing sequence $(x_n)$ in $C$ with $a=\sup x_n$.  Similarly, if $a$ is not isolated to the right, there is a strictly decreasing sequence $(y_n)$ with $a=\inf y_n$.
+
+So, if $a$ is not isolated on either side, the collection of intervals $(x_n,y_n)$ forms a countable local base at $a$.  And if $a$ is isolated on one side or both, one can take the collection of intervals $(x_n,a]$ or $[a,y_n)$ or the singleton $\{a\}$.


### PR DESCRIPTION
New T236: LOTS + countably tight ==> first countable.

Allows to deduce that [S154](https://topology.pi-base.org/spaces/S000154) is not a LOTS.

No trait files to clean up.
