### PR TITLE
add theorems T443 T444 and T445 for discovery of fixed point property…

### DIFF
--- a/theorems/T000443.md
+++ b/theorems/T000443.md
@@ -1,0 +1,16 @@
+---
+uid: T000443
+if:
+  P000089: true
+then:
+  P000036: true
+---
+
+If $X$ is not connected, let $p\in U$, $q\in V$, where $X= U\cup V$ is a separation by disjoint nonempty open sets $U$ and $V$. Then
+$$f(x)=
+\begin{cases}
+q & x\in U\\
+p & x\in V
+\end{cases}
+$$
+is continuous with no fixed point.

--- a/theorems/T000444.md
+++ b/theorems/T000444.md
@@ -1,0 +1,11 @@
+---
+uid: T000444
+if:
+  and:
+  - P000087: true
+  - P000125: true
+then:
+  P000089: false
+---
+
+If $g\in X$ is not the identity, then $x\mapsto g\cdot x$ is a continuous self-map with no fixed point.

--- a/theorems/T000445.md
+++ b/theorems/T000445.md
@@ -5,6 +5,7 @@ if:
   - P000016: true
   - P000036: true
   - P000133: true
+  - P000137: false
 then:
   P000089: true
 refs:
@@ -17,4 +18,4 @@ Then for $x\in f^{-1}(V)\cap U$, $f(x)>x$, so $A:=\{x\in X\mid f(x)>x\}$ is open
 
 If $f$ has no fixed point, then $X=A\cup B$, and since $X$ is {P36}, $A$ or $B$ must be empty.  But if $X=A$, then $X$ has no maximum element, and likewise if $X=B$, it has no minimum element.
 
-This contradicts that if $X$ is {P133} and {P16}, then it has a maximum and minimum element, by the remark in {{mathse:4786659}}.
+This contradicts that if $X$ is {P133} and {P16} and not {P137}, then it has a maximum and minimum element, by the remark in {{mathse:4786659}}.

--- a/theorems/T000445.md
+++ b/theorems/T000445.md
@@ -10,7 +10,7 @@ then:
   P000089: true
 refs:
   - mathse: 4786659
-    name: Answer to "Use compactness to prove that a close bounded set of real number has a maximum"
+    name: Answer to "Use compactness to prove that a closed bounded set of real numbers has a maximum"
 ---
 
 Let $f\colon X\to X$ be continuous.  For $x_0\in X$, if $f(x_0)>x_0$, then let $U,V$ be disjoint open neighborhoods with $x_0\in U$, $f(x_0)\in V$, and $u<v$ for each $u\in U$, $v\in V$.

--- a/theorems/T000445.md
+++ b/theorems/T000445.md
@@ -1,0 +1,20 @@
+---
+uid: T000445
+if:
+  and:
+  - P000016: true
+  - P000036: true
+  - P000133: true
+then:
+  P000089: true
+refs:
+  - mathse: 4786659
+    name: Answer to "Use compactness to prove that a close bounded set of real number has a maximum"
+---
+
+Let $f\colon X\to X$ be continuous.  For $x_0\in X$, if $f(x_0)>x_0$, then let $U,V$ be disjoint open neighborhoods with $x_0\in U$, $f(x_0)\in V$, and $u<v$ for each $u\in U$, $v\in V$.
+Then for $x\in f^{-1}(V)\cap U$, $f(x)>x$, so $A:=\{x\in X\mid f(x)>x\}$ is open, as is $B:=\{x\in X\mid f(x)<x\}$.
+
+If $f$ has no fixed point, then $X=A\cup B$, and since $X$ is {P36}, $A$ or $B$ must be empty.  But if $X=A$, then $X$ has no maximum element, and likewise if $X=B$, it has no minimum element.
+
+This contradicts that if $X$ is {P133} and {P16}, then it has a maximum and minimum element, by the remark in {{mathse:4786659}}.

--- a/theorems/T000446.md
+++ b/theorems/T000446.md
@@ -1,0 +1,9 @@
+---
+uid: T000446
+if:
+  P000089: true
+then:
+  P000137: false
+---
+
+The empty set has one (empty) self-map, which has no fixed point.


### PR DESCRIPTION
This PR adds theorems [T443](https://topology.pi-base.org/theorems/T000443) (fixed point property => connected), [T444](https://topology.pi-base.org/theorems/T000444) (group topology + multiple points => no fpp),  [T445](https://topology.pi-base.org/theorems/T000445) (connected + compact +LOTS +not empty => fpp), to aid in the discovery of the the fixed point property [P89](https://missing-traits.topology.pages.dev/properties/P000089) and its negation.

This allows discovery of 4 additional spaces with the fixed point property and 78 spaces with its negation.