### PR TITLE
Adding fixed point property implies T0, plus giving property values to many more spaces

### DIFF
--- a/spaces/S000007/properties/P000089.md
+++ b/spaces/S000007/properties/P000089.md
@@ -1,0 +1,10 @@
+---
+space: S000007
+property: P000089
+value: true
+---
+
+Let $f:X \rightarrow X$ be a continuous selfmap and $p \in X$ be the included point.
+If $f$ is a constant function then it has a fixed point.
+Otherwise, it must be that $f(p) = p$, as if were not, then $X\setminus {f(p)}$ would be open
+yet $f^{-1}(X\setminus {f(p)}) \not\ni p$ would not be, making $f$ not continuous.

--- a/spaces/S000008/properties/P000089.md
+++ b/spaces/S000008/properties/P000089.md
@@ -1,0 +1,10 @@
+---
+space: S000008
+property: P000089
+value: true
+---
+
+Let $f:X \rightarrow X$ be a continuous selfmap and $p \in X$ be the included point.
+If $f$ is a constant function then it has a fixed point.
+Otherwise, it must be that $f(p) = p$, as if were not, then $X\setminus {f(p)}$ would be open
+yet $f^{-1}(X\setminus {f(p)}) \not\ni p$ would not be, making $f$ not continuous.

--- a/spaces/S000009/properties/P000089.md
+++ b/spaces/S000009/properties/P000089.md
@@ -1,0 +1,10 @@
+---
+space: S000009
+property: P000089
+value: true
+---
+
+Let $f:X \rightarrow X$ be a continuous selfmap and $p \in X$ be the included point.
+If $f$ is a constant function then it has a fixed point.
+Otherwise, it must be that $f(p) = p$, as if were not, then $X\setminus {f(p)}$ would be open
+yet $f^{-1}(X\setminus {f(p)}) \not\ni p$ would not be, making $f$ not continuous.

--- a/spaces/S000010/properties/P000089.md
+++ b/spaces/S000010/properties/P000089.md
@@ -1,0 +1,7 @@
+---
+space: S000010
+property: P000089
+value: true
+---
+
+The only selfmap with no fixed points is given by $0\mapsto 1, 1\mapsto 0$, which is not continuous.

--- a/spaces/S000011/properties/P000089.md
+++ b/spaces/S000011/properties/P000089.md
@@ -1,0 +1,10 @@
+---
+space: S000011
+property: P000089
+value: true
+---
+
+Let $f:X \rightarrow X$ be a continuous selfmap and $p \in X$ be the excluded point.
+If $f$ is a constant function then it has a fixed point.
+Otherwise, it must be that $f(p) = p$, as if were not, then $X\setminus {f(p)}$ would be closed
+yet $f^{-1}(X\setminus {f(p)}) \not\ni p$ would not be, making $f$ not continuous.

--- a/spaces/S000012/properties/P000089.md
+++ b/spaces/S000012/properties/P000089.md
@@ -1,0 +1,10 @@
+---
+space: S000012
+property: P000089
+value: true
+---
+
+Let $f:X \rightarrow X$ be a continuous selfmap and $p \in X$ be the excluded point.
+If $f$ is a constant function then it has a fixed point.
+Otherwise, it must be that $f(p) = p$, as if were not, then $X\setminus {f(p)}$ would be closed
+yet $f^{-1}(X\setminus {f(p)}) \not\ni p$ would not be, making $f$ not continuous.

--- a/spaces/S000013/properties/P000089.md
+++ b/spaces/S000013/properties/P000089.md
@@ -1,0 +1,10 @@
+---
+space: S000013
+property: P000089
+value: true
+---
+
+Let $f:X \rightarrow X$ be a continuous selfmap and $p \in X$ be the excluded point.
+If $f$ is a constant function then it has a fixed point.
+Otherwise, it must be that $f(p) = p$, as if were not, then $X\setminus {f(p)}$ would be closed
+yet $f^{-1}(X\setminus {f(p)}) \not\ni p$ would not be, making $f$ not continuous.

--- a/spaces/S000015/properties/P000089.md
+++ b/spaces/S000015/properties/P000089.md
@@ -1,0 +1,7 @@
+---
+space: S000015
+property: P000089
+value: false
+---
+
+Any permutation of the space is a self-homeomorphism, as bijections preserve cardinality of sets and therefore openness. Thus, any derangement is a selfmap with no fixed points.

--- a/spaces/S000016/properties/P000089.md
+++ b/spaces/S000016/properties/P000089.md
@@ -1,0 +1,7 @@
+---
+space: S000016
+property: P000089
+value: false
+---
+
+Any permutation of the space is a self-homeomorphism, as bijections preserve cardinality of sets and therefore openness. Thus, any derangement is a selfmap with no fixed points.

--- a/spaces/S000017/properties/P000089.md
+++ b/spaces/S000017/properties/P000089.md
@@ -1,0 +1,7 @@
+---
+space: S000017
+property: P000089
+value: false
+---
+
+Any permutation of the space is a self-homeomorphism, as bijections preserve cardinality of sets and therefore openness. Thus, any derangement is a selfmap with no fixed points.

--- a/spaces/S000018/properties/P000089.md
+++ b/spaces/S000018/properties/P000089.md
@@ -1,0 +1,7 @@
+---
+space: S000018
+property: P000089
+value: false
+---
+
+$(x,0) \mapsto (x,1), (x,1) \mapsto (x,0)$ gives a self-homeomorphism with no fixed points.

--- a/spaces/S000030/properties/P000087.md
+++ b/spaces/S000030/properties/P000087.md
@@ -1,0 +1,7 @@
+---
+space: S000030
+property: P000087
+value: true
+---
+
+$\mathbb{R}^\omega$ is a product of topological groups, namely $\mathbb{R}$. See {S25|P87}.

--- a/spaces/S000032/properties/P000089.md
+++ b/spaces/S000032/properties/P000089.md
@@ -9,4 +9,4 @@ refs:
     name: Schauder fixed-point theorem on Wikipedia
 ---
 
-The property follows from the Schauder fixed-point theorem (see {{wikipedia:Schauder fixed-point theorem}})
+Since we can embed $[0,1]^\omega$ as a compact subspace of the topological vector space $\mathbb{R}^\omega$, the property follows from the Schauder fixed-point theorem (see {{wikipedia:Schauder fixed-point theorem}}).

--- a/spaces/S000032/properties/P000089.md
+++ b/spaces/S000032/properties/P000089.md
@@ -1,5 +1,5 @@
 ---
-space: S000018
+space: S000032
 property: P000089
 value: true
 refs:

--- a/spaces/S000032/properties/P000089.md
+++ b/spaces/S000032/properties/P000089.md
@@ -9,4 +9,4 @@ refs:
     name: Schauder fixed-point theorem on Wikipedia
 ---
 
-Since we can embed $[0,1]^\omega$ as a compact subspace of the topological vector space $\mathbb{R}^\omega$, the property follows from the Schauder fixed-point theorem (see {{wikipedia:Schauder fixed-point theorem}}).
+Since we can embed $[0,1]^\omega$ as a compact subspace of the topological vector space $\mathbb{R}^\omega$ ({S30}), the property follows from the Schauder fixed-point theorem (see {{wikipedia:Schauder fixed-point theorem}}).

--- a/spaces/S000032/properties/P000089.md
+++ b/spaces/S000032/properties/P000089.md
@@ -4,9 +4,9 @@ property: P000089
 value: true
 refs:
   - mathse: 884045
-    Homogeneous topological space with the fixed-point property
+    name: Homogeneous topological space with the fixed-point property
   - wikipedia: Schauder_fixed-point_theorem
-    Schauder fixed-point theorem on Wikipedia
+    name: Schauder fixed-point theorem on Wikipedia
 ---
 
 The property follows from the Schauder fixed-point theorem (see {{wikipedia:Schauder fixed-point theorem}})

--- a/spaces/S000032/properties/P000089.md
+++ b/spaces/S000032/properties/P000089.md
@@ -1,0 +1,12 @@
+---
+space: S000018
+property: P000089
+value: true
+refs:
+  - mathse: 884045
+    Homogeneous topological space with the fixed-point property
+  - wikipedia: Schauder_fixed-point_theorem
+    Schauder fixed-point theorem on Wikipedia
+---
+
+The property follows from the Schauder fixed-point theorem (see {{wikipedia:Schauder fixed-point theorem}})

--- a/spaces/S000042/properties/P000089.md
+++ b/spaces/S000042/properties/P000089.md
@@ -1,0 +1,7 @@
+---
+space: S000042
+property: P000089
+value: false
+---
+
+For any non-zero $a$, $x\mapsto x+a$ is a self-homeomorphism with no fixed points.

--- a/spaces/S000082/properties/P000036.md
+++ b/spaces/S000082/properties/P000036.md
@@ -1,0 +1,7 @@
+---
+space: S000082
+property: P000036
+value: false
+---
+
+Each copy of {S42} is clopen by construction.

--- a/spaces/S000083/properties/P000089.md
+++ b/spaces/S000083/properties/P000089.md
@@ -1,0 +1,7 @@
+---
+space: S000083
+property: P000089
+value: false
+---
+
+For any non-zero $a$, $(x,i)\mapsto (x+a,i)$ is a self-homeomorphism of $\mathbb R\times\{1,2\}$ with no fixed points, which is preserved under retract to the quotient space.

--- a/spaces/S000083/properties/P000089.md
+++ b/spaces/S000083/properties/P000089.md
@@ -4,4 +4,4 @@ property: P000089
 value: false
 ---
 
-For any non-zero $a$, $(x,i)\mapsto (x+a,i)$ is a self-homeomorphism of $\mathbb R\times\{1,2\}$ with no fixed points, which is preserved under retract to the quotient space.
+For any non-zero $a$, $(x,i)\mapsto (x+a,i)$ is a self-homeomorphism of $\mathbb R\times\{1,2\}$ with no fixed points, which remains a continuous function with no fixed points after selecting a representative element for each equivalence class.

--- a/spaces/S000084/properties/P000089.md
+++ b/spaces/S000084/properties/P000089.md
@@ -4,4 +4,4 @@ property: P000089
 value: false
 ---
 
-For any non-zero $a$, $(x,i)\mapsto (x+a,i)$ is a self-homeomorphism of $\mathbb R\times S$ with no fixed points, which is preserved under retract to the quotient space.
+For any non-zero $a$, $(x,i)\mapsto (x+a,i)$ is a self-homeomorphism of $\mathbb R\times S$ with no fixed pointswhich remains a continuous function with no fixed points after selecting a representative element for each equivalence class.

--- a/spaces/S000084/properties/P000089.md
+++ b/spaces/S000084/properties/P000089.md
@@ -1,0 +1,7 @@
+---
+space: S000084
+property: P000089
+value: false
+---
+
+For any non-zero $a$, $(x,i)\mapsto (x+a,i)$ is a self-homeomorphism of $\mathbb R\times S$ with no fixed points, which is preserved under retract to the quotient space.

--- a/spaces/S000085/properties/P000089.md
+++ b/spaces/S000085/properties/P000089.md
@@ -4,4 +4,4 @@ property: P000089
 value: false
 ---
 
-For any non-zero $a$, $(x,i)\mapsto (x+a,i)$ is a self-homeomorphism of $\mathbb R\times S$ with no fixed points, which is preserved under retract to the quotient space.
+For any non-zero $a$, $(x,i)\mapsto (x+a,i)$ is a self-homeomorphism of $\mathbb R\times S$ with no fixed points, which remains a continuous function with no fixed points after selecting a representative element for each equivalence class.

--- a/spaces/S000085/properties/P000089.md
+++ b/spaces/S000085/properties/P000089.md
@@ -1,0 +1,7 @@
+---
+space: S000085
+property: P000089
+value: false
+---
+
+For any non-zero $a$, $(x,i)\mapsto (x+a,i)$ is a self-homeomorphism of $\mathbb R\times S$ with no fixed points, which is preserved under retract to the quotient space.

--- a/spaces/S000086/properties/P000089.md
+++ b/spaces/S000086/properties/P000089.md
@@ -4,4 +4,4 @@ property: P000089
 value: false
 ---
 
-For any non-zero $a$, $\langle x,i\rangle\mapsto \langle x+a,i\rangle\$ is a self-homeomorphism with no fixed points.
+For any non-zero $a$, $\langle x,i\rangle\mapsto \langle x+a,i\rangle$ is a self-homeomorphism with no fixed points.

--- a/spaces/S000086/properties/P000089.md
+++ b/spaces/S000086/properties/P000089.md
@@ -1,0 +1,7 @@
+---
+space: S000086
+property: P000089
+value: false
+---
+
+For any non-zero $a$, $\langle x,i\rangle\mapsto \langle x+a,i\rangle\$ is a self-homeomorphism with no fixed points.

--- a/spaces/S000176/properties/P000087.md
+++ b/spaces/S000176/properties/P000087.md
@@ -1,0 +1,7 @@
+---
+space: S000176
+property: P000087
+value: true
+---
+
+$\mathbb{R}^2$ is a product of topological groups, namely $\mathbb{R}$. See {S25|P87}.

--- a/theorems/T000446.md
+++ b/theorems/T000446.md
@@ -1,0 +1,9 @@
+---
+uid: T000446
+if:
+  P000089: true
+then:
+  P000137: false
+---
+
+To have fixed points of a selfmap, a space must contain points.

--- a/theorems/T000446.md
+++ b/theorems/T000446.md
@@ -1,9 +1,0 @@
----
-uid: T000446
-if:
-  P000089: true
-then:
-  P000137: false
----
-
-To have fixed points of a selfmap, a space must contain points.

--- a/theorems/T000447.md
+++ b/theorems/T000447.md
@@ -1,9 +1,9 @@
 ---
 uid: T000447
 if:
-  P000001: false
+  P000089: true
 then:
-  P000089: false
+  P000001: true
 ---
 
 If $X$ is a non-$T_0$ space, then there exist distinct points $x,y\in X$ which have the same open neighborhoods.

--- a/theorems/T000447.md
+++ b/theorems/T000447.md
@@ -1,0 +1,11 @@
+---
+uid: T000447
+if:
+  P000001: false
+then:
+  P000089: false
+---
+
+If $X$ is a non-$T_0$ space, then there exist distinct points $x,y\in X$ which have the same open neighborhoods.
+Then any selfmap $f: X\rightarrow X$ that maps into the set $\\{x, y\\}$ is continuous as $f^{-1}(U)$ is either $X$ or $\varnothing$ for any open set $U\subseteq X$.
+We may then easily select such maps without fixed points by requiring that $f(x)=y$ and $f(y)=x$.


### PR DESCRIPTION
I was already working on contributions relating to [P89 fixed point property](https://topology.pi-base.org/properties/P000089) before seeing PR #558, so I decided to wrap up some work and submit a supplementary PR of my own. I added two theorems: T446 saying fpp => nonempty and T447 saying fpp => T0. I also added property values for 20 other spaces either directly for the fixed point property or for properties allowing a deduction of the fixed point property.