### PR TITLE
S121 Bernstein's connected set is Metrizable and Cardinality = c

### DIFF
--- a/spaces/S000121/properties/P000053.md
+++ b/spaces/S000121/properties/P000053.md
@@ -1,0 +1,7 @@
+---
+space: S000121
+property: P000053
+value: true
+---
+
+Metrizable as a subspace of {S176}.

--- a/spaces/S000121/properties/P000078.md
+++ b/spaces/S000121/properties/P000078.md
@@ -1,0 +1,10 @@
+---
+space: S000121
+property: P000078
+value: false
+refs:
+- wikipedia: Ordinal_number
+  name: Ordinal number on Wikipedia
+---
+
+Points of the space are indexed by ordinal numbers below the initial ordinal of $\mathfrak c$, which by definition form a set of cardinality $\mathfrak c$. See {{wikipedia:Ordinal_number}} for further explanation.

--- a/spaces/S000121/properties/P000129.md
+++ b/spaces/S000121/properties/P000129.md
@@ -1,7 +1,0 @@
----
-space: S000121
-property: P000129
-value: false
----
-
-The space is non-trivial by definition.


### PR DESCRIPTION
This PR adds to [S121](https://topology.pi-base.org/spaces/S000121) Bernstein's connected set the properties [P53](https://topology.pi-base.org/properties/P000053) Metrizable and [P65](https://topology.pi-base.org/properties/P000065) Cardinality $=\mathfrak c$. The indiscrete property was also deleted as it can be deduced from the others.