### PR TITLE
Add properties to S161 as asserted in reference

### DIFF
--- a/spaces/S000161/properties/P000016.md
+++ b/spaces/S000161/properties/P000016.md
@@ -1,0 +1,10 @@
+---
+space: S000161
+property: P000016
+value: true
+refs:
+  - doi: 10.1016/0166-8641(93)90147-6
+    name: An anti-Hausdorff Fréchet space in which convergent sequences have unique limits
+---
+
+Asserted in {{doi:10.1016/0166-8641(93)90147-6}}.

--- a/spaces/S000161/properties/P000039.md
+++ b/spaces/S000161/properties/P000039.md
@@ -1,0 +1,10 @@
+---
+space: S000161
+property: P000039
+value: true
+refs:
+  - doi: 10.1016/0166-8641(93)90147-6
+    name: An anti-Hausdorff Fréchet space in which convergent sequences have unique limits
+---
+
+Asserted in {{doi:10.1016/0166-8641(93)90147-6}}.

--- a/spaces/S000161/properties/P000078.md
+++ b/spaces/S000161/properties/P000078.md
@@ -1,0 +1,7 @@
+---
+space: S000161
+property: P000078
+value: false
+---
+
+By definition of $\omega$.

--- a/spaces/S000161/properties/P000080.md
+++ b/spaces/S000161/properties/P000080.md
@@ -1,0 +1,10 @@
+---
+space: S000161
+property: P000080
+value: true
+refs:
+  - doi: 10.1016/0166-8641(93)90147-6
+    name: An anti-Hausdorff Fréchet space in which convergent sequences have unique limits
+---
+
+Asserted in {{doi:10.1016/0166-8641(93)90147-6}}. Note: Fréchet in their terminology is {P80}.

--- a/spaces/S000161/properties/P000099.md
+++ b/spaces/S000161/properties/P000099.md
@@ -1,0 +1,10 @@
+---
+space: S000161
+property: P000099
+value: true
+refs:
+  - doi: 10.1016/0166-8641(93)90147-6
+    name: An anti-Hausdorff Fréchet space in which convergent sequences have unique limits
+---
+
+Asserted in {{doi:10.1016/0166-8641(93)90147-6}}.

--- a/spaces/S000161/properties/P000129.md
+++ b/spaces/S000161/properties/P000129.md
@@ -1,7 +1,0 @@
----
-space: S000161
-property: P000129
-value: false
----
-
-The space is non-trivial by definition.


### PR DESCRIPTION
This adds to [S161](https://topology.pi-base.org/spaces/S000161) "Van Douwen's anti-Hausdorff Fréchet space" the properties that are asserted in the reference [DOI 10.1016/0166-8641(93)90147-6](https://doi.org/10.1016/0166-8641(93)90147-6) but not yet listed. These are [P16](https://topology.pi-base.org/properties/P000016) Compact, [P39](https://topology.pi-base.org/properties/P000039) Hyperconnected/Anti-Hausdorff, [P78](https://topology.pi-base.org/properties/P000078) (not) Finite, and [P99](https://topology.pi-base.org/properties/P000099) US. Despite being in the title of the work, Fréchet / $T_1$ is not listed because it can be deduced from P99 via [T226](https://topology.pi-base.org/theorems/T000226).