### PR TITLE
Theorems for cosmic and related properties

### DIFF
--- a/properties/P000074.md
+++ b/properties/P000074.md
@@ -8,6 +8,6 @@ refs:
     name: $\mathfrak P$-spaces and related concepts (Gabriyelyan & Kakol)
 ---
 
-A space that is {P5} and has a countable network.  Here, a family $\mathcal{P}$ of subsets of $X$ is called a *network* if for every $x\in X$ and every neighborhood $U$ of $x$ there is some $P\in\mathcal P$ such that $x\in P\subseteq U$.
+A space that is {P5} and {P182}.
 
 The notion was originally defined in section 10 of {{mr:206907}}, which is available at <https://www.jstor.org/stable/24901448>.

--- a/properties/P000179.md
+++ b/properties/P000179.md
@@ -8,10 +8,6 @@ refs:
     name: $\mathfrak P$-spaces and related concepts (Gabriyelyan & Kakol)
 ---
 
-A space that is {P5} and has a countable $k$-network.  Here, a family $\mathcal{P}$ of subsets of $X$ is called a *$k$-network* if for every compact set $K$ and open set $U$ in $X$ with $K \subseteq U$, there exists a finite $\mathcal{P}^* \subseteq \mathcal{P}$ with $K \subseteq \bigcup \mathcal{P}^* \subseteq U$.
+A space that is {P5} and {P183}.
 
-Equivalently, a space that is {P5} and has a countable pseudobase.  Here, a family $\mathcal{P}$ of subsets of $X$ is called a *pseudobase* if for every compact set $K$ and open set $U$ in $X$ with $K \subseteq U$, there exists some $P\in\mathcal{P}$ with $K \subseteq P \subseteq U$.
-
-For the equivalence between the two, note that every pseudobase is a $k$-network.  And conversely given a countable $k$-network $\mathcal P$, the collection of finite unions of elements of $\mathcal P$ is a countable pseudobase.
-
-Originally defined in {{mr:206907}}, which is available at <https://www.jstor.org/stable/24901448>.
+Originally defined in {{mr:206907}}, available at <https://www.jstor.org/stable/24901448>.

--- a/properties/P000183.md
+++ b/properties/P000183.md
@@ -1,0 +1,21 @@
+---
+uid: P000183
+name: Has a countable $k$-network
+refs:
+  - mr: 206907
+    name: $\aleph_0$-spaces (E. Michael)
+  - doi: 10.1016/j.topol.2015.05.085
+    name: $\mathfrak P$-spaces and related concepts (Gabriyelyan & Kakol)
+---
+
+A space with a (finite or infinite) countable $k$-network.
+
+Equivalently, a space with a countable pseudobase.
+
+A family $\mathcal N$ of subsets of $X$ is called a *$k$-network* if for every compact set $K$ and open set $U$ in $X$ with $K\subseteq U$, there exists a finite $\mathcal{N}^* \subseteq \mathcal{N}$ with $K \subseteq \bigcup\mathcal{N}^* \subseteq U$.
+
+And a family $\mathcal{N}$ of subsets of $X$ is called a *pseudobase* if for every compact set $K$ and open set $U$ in $X$ with $K\subseteq U$, there exists some $A\in\mathcal{N}$ with $K \subseteq A \subseteq U$.
+
+For the equivalence between the two characterizations, note that every pseudobase is a $k$-network.  And conversely given a countable $k$-network $\mathcal N$, the collection of finite unions of elements of $\mathcal N$ is a countable pseudobase.
+
+See {{mr:206907}}, available at <https://www.jstor.org/stable/24901448>.

--- a/theorems/T000011.md
+++ b/theorems/T000011.md
@@ -1,0 +1,9 @@
+---
+uid: T000011
+if:
+  P000183: true
+then:
+  P000182: true
+---
+
+Evident from the definitions, as a $k$-network is a network.

--- a/theorems/T000022.md
+++ b/theorems/T000022.md
@@ -1,0 +1,11 @@
+---
+uid: T000022
+if:
+  and:
+  - P000136: true
+  - P000057: true
+then:
+  P000183: true
+---
+
+In an {P136} space the collection of all singletons is a $k$-network, which is countable if the space is {P57}.

--- a/theorems/T000055.md
+++ b/theorems/T000055.md
@@ -1,0 +1,9 @@
+---
+uid: T000055
+if:
+  P000074: true
+then:
+  P000182: true
+---
+
+Follows from the definition.

--- a/theorems/T000061.md
+++ b/theorems/T000061.md
@@ -1,0 +1,11 @@
+---
+uid: T000061
+if:
+  and:
+  - P000182: true
+  - P000005: true
+then:
+  P000074: true
+---
+
+Follows from the definition.

--- a/theorems/T000084.md
+++ b/theorems/T000084.md
@@ -1,0 +1,9 @@
+---
+uid: T000084
+if:
+  P000177: true
+then:
+  P000005: true
+---
+
+Follows from the definition.

--- a/theorems/T000116.md
+++ b/theorems/T000116.md
@@ -1,0 +1,9 @@
+---
+uid: T000116
+if:
+  P000179: true
+then:
+  P000183: true
+---
+
+Follows from the definition.

--- a/theorems/T000117.md
+++ b/theorems/T000117.md
@@ -1,0 +1,11 @@
+---
+uid: T000117
+if:
+  and:
+  - P000183: true
+  - P000005: true
+then:
+  P000179: true
+---
+
+Follows from the definition.

--- a/theorems/T000241.md
+++ b/theorems/T000241.md
@@ -1,0 +1,9 @@
+---
+uid: T000241
+if:
+  P000179: true
+then:
+  P000074: true
+---
+
+Evident from the definitions, as a $k$-network is a network.

--- a/theorems/T000242.md
+++ b/theorems/T000242.md
@@ -1,0 +1,9 @@
+---
+uid: T000242
+if:
+  P000074: true
+then:
+  P000177: true
+---
+
+Evident from the definitions, as a countable family of sets is $\sigma$-locally finite.

--- a/theorems/T000243.md
+++ b/theorems/T000243.md
@@ -1,0 +1,9 @@
+---
+uid: T000243
+if:
+  P000179: true
+then:
+  P000178: true
+---
+
+Evident from the definitions, as a countable family of sets is $\sigma$-locally finite.

--- a/theorems/T000244.md
+++ b/theorems/T000244.md
@@ -1,0 +1,9 @@
+---
+uid: T000244
+if:
+  P000178: true
+then:
+  P000177: true
+---
+
+Evident from the definitions, as a $k$-network is a network.

--- a/theorems/T000271.md
+++ b/theorems/T000271.md
@@ -3,12 +3,7 @@ uid: T000271
 if:
   P000027: true
 then:
-  P000182: true
-refs:
-  - mr: 1039321
-    name: General Topology (Engelking, 1989)
+  P000183: true
 ---
 
-Evident, as a base for the topology is a network.
-
-See page 127 and the diagram on page 225 in {{mr:1039321}}.
+Follows from the definitions, as a base for the topology is a $k$-network.


### PR DESCRIPTION
Various theorems regarding cosmic and related properties.  This implements what was discussed in #511.

Similarly to [P182 ](https://topology.pi-base.org/properties/P000182/)(countable network) which was introduced to better manage P74 (cosmic), I have introduced [P183 ](https://topology.pi-base.org/properties/P000183/)(countable $k$-network) corresponding to P179 ($\aleph_0$-space).  This makes things more convenient as countable $k$-network is implied by [second countable] and also by [anticompact + countable].

I did not do it, but one could also introduce the properties [has a $\sigma$-locally finite network] and [has a $\sigma$-locally finite $k$-network] to parallel $\sigma$-space and $\aleph$-space.  Could be done at some later point if it ends up being convenient.  Feel free to comment.

