### PR TITLE
Remove redundant T294

### DIFF
--- a/theorems/T000294.md
+++ b/theorems/T000294.md
@@ -1,9 +1,0 @@
----
-uid: T000294
-if:
-  P000052: true
-then:
-  P000136: true
----
-
-Infinite subsets of a discrete space are themselves infinite discrete spaces, and therefore non-compact.


### PR DESCRIPTION
T294 (discrete ==> anticompact) is redundant, via the $\omega$ C property.
