### PR TITLE
Sequentially discrete implies totally path disconnected

### DIFF
--- a/theorems/T000305.md
+++ b/theorems/T000305.md
@@ -1,14 +1,12 @@
 ---
 uid: T000305
 if:
-  and:
-    - P000136: true
-    - P000002: true
+  P000167: true
 then:
   P000046: true
 refs:
-  - doi: 10.1215/ijm/1256048236
-    name: The total negation of a topological property (P. Bankston)
+  - mathse: 4882280
+    name: Every sequentially discrete space is totally path disconnected
 ---
 
-See Proposition 1.3(ii) in {{doi:10.1215/ijm/1256048236}}.
+See {{mathse:4882280}}.


### PR DESCRIPTION
Generalize T305:
- (old T305) anticompact + T1 ==> totally path disconnected
- (new T305) sequentially discrete ==> totally path disconnected

We don't lose anything because of T413 (anticompact + T1 ==> sequentially discrete).

This allows to automatically deduce that 8 more spaces are not sequentially discrete:
https://topology.pi-base.org/spaces?q=%3FSequentially+discrete%2B%7ETotally+Path+Disconnected
