### PR TITLE
Strengthen T216

### DIFF
--- a/theorems/T000216.md
+++ b/theorems/T000216.md
@@ -3,12 +3,9 @@ uid: T000216
 if:
   P000133: true
 then:
-  P000172: true
-refs:
-- doi: 10.4064/fm-61-1-79-81
-  name: Quotienten geordneter Räume und Folgenkonvergenz (H. Herrlich)
+  P000174: true
 ---
 
-Stated as evident in the first sentence of the proof of Satz 1 in {{doi:10.4064/fm-61-1-79-81}}.
-
-Given a subset $A$ of a {P133} space $X$, a point $p\in\overline A\setminus A$ is in the closure of the part of $A$ to one side of $p$, say the left side.  So the set $B=\{a\in A:a<p\}$ has no maximum point and is cofinal in the set of points of $X$ to the left of $p$.  As $B$ is totally ordered, it admits a well-ordered cofinal subset and that set corresponds to a transfinite sequence of points of $A$ converging to $p$.
+A local basis for each point $p\in X$ is the set of open intervals containing $p$ $\mathcal B_p=\{(a,b)\mid a<p<b; a,b\in X\cup\{-\infty,\infty\}\}$.
+To construct a subbasis that is totally ordered by set inclusion, take any two (possibly) transfinite sequences $a:\Gamma\rightarrow[-\infty,p)$ and $b:\Gamma\rightarrow(p,\infty]$ that are monotonic and surjective with $a_0=-\infty$ and $b_0=\infty$.
+Then $\mathcal B_p'=\{(a_\alpha,b_\alpha)\mid\alpha\in\Gamma\}$ is totally ordered and a local basis as $\mathcal B_p'\subseteq \mathcal B_p$ and any set in $\mathcal B_p$ has a subset in $\mathcal B_p'$.


### PR DESCRIPTION
This PR strengthens [T216](https://topology.pi-base.org/theorems/T000216/) from [LOTS](https://topology.pi-base.org/properties/P000133) ⇒ [Radial](https://topology.pi-base.org/properties/P000172) to LOTS ⇒ [Well-based](https://topology.pi-base.org/properties/P000174), which implies the former via [T103](https://topology.pi-base.org/theorems/T000103) Well-based ⇒ Radial.

It took me a while to settle on an explanation that I was satisfied with, so let me know if there's any way I can make it clearer.