### PR TITLE
Add two theorems relating to P50 Zero Dimensional

### DIFF
--- a/theorems/T000464.md
+++ b/theorems/T000464.md
@@ -1,0 +1,14 @@
+---
+uid: T000464
+if:
+  P000146: true
+then:
+  P000050: true
+refs:
+  - doi: 10.48550/arXiv.1306.6086
+    name: Ultraparacompactness and Ultranormality (J. Van Name)
+---
+
+For any open set $U$ and point $p\in U$, consider the open cover $\{U, X\setminus\text{cl}p\}$.
+A clopen refinement of this contains a clopen set $C$ with $p\in C\subseteq U$.
+Thus, there is a basis of clopen sets.

--- a/theorems/T000464.md
+++ b/theorems/T000464.md
@@ -1,14 +1,19 @@
 ---
 uid: T000464
 if:
-  P000146: true
+  and:
+    - P000146: true
+    - P000135: true
 then:
   P000050: true
 refs:
   - doi: 10.48550/arXiv.1306.6086
     name: Ultraparacompactness and Ultranormality (J. Van Name)
+  - wikipedia: T1_space
+    name: T1 space on Wikipedia
 ---
 
-For any open set $U$ and point $p\in U$, consider the open cover $\{U, X\setminus\text{cl}p\}$.
+In a {P135} space, the closure of each point is contained in all of its open neighborhoods.
+Then for any open set $U$ and point $p\in U$, consider the open cover $\{U, X\setminus\text{cl }\{p\}\}$.
 A clopen refinement of this contains a clopen set $C$ with $p\in C\subseteq U$.
 Thus, there is a basis of clopen sets.

--- a/theorems/T000465.md
+++ b/theorems/T000465.md
@@ -8,7 +8,7 @@ then:
   P000050: true
 refs:
   - mr: 1475806
-    name: On the dimension of ordered spaces 
+    name: On the dimension of ordered spaces (B. Brunet)
 ---
 
-In {{mr:1475806}} it is proven that a {P133} space is {P50} if and only if it is {P47}.
+In {{mr:1475806}} (available at <https://eudml.org/doc/40507>) it is proven that a {P133} space is {P50} if and only if it is {P47}.

--- a/theorems/T000465.md
+++ b/theorems/T000465.md
@@ -1,0 +1,14 @@
+---
+uid: T000465
+if:
+  and:
+    - P000133: true
+    - P000047: true
+then:
+  P000050: true
+refs:
+  - mr: 1475806
+    name: On the dimension of ordered spaces 
+---
+
+In {{mr:1475806}} it is proven that a {P133} space is {P50} if and only if it is {P47}.


### PR DESCRIPTION
This PR adds two theorems that came up in my other research:
- [Ultraparacompact](https://topology.pi-base.org/properties/P000146) ⇒ [Zero Dimensional](https://topology.pi-base.org/properties/P000050) 
- [LOTS](https://topology.pi-base.org/properties/P000133) ∧ [Totally Disconnected](https://topology.pi-base.org/properties/P000047) ⇒ [Zero Dimensional](https://topology.pi-base.org/properties/P000050)

ID numbering was chosen to prevent conflict with active PRs.