### PR TITLE
Tweaks for P184 (Embeddable into Euclidean space)

### DIFF
--- a/properties/P000184.md
+++ b/properties/P000184.md
@@ -8,6 +8,6 @@ refs:
     name: Dimension Theory (Engelking)
 ---
 
-Can be expressed as a subspace of $\mathbb R^n$ for some finite $n$.
+Homeomorphic to a subspace of $\mathbb R^n$ for some finite $n$.
 
-Per theorem Theorem 1.11.4 of {{mr:0482697}}, this is equivalent to being {P27}, {P53}, and finite-dimensional, using any of the small inductive, large inductive, or covering dimensions by Theorem 1.7.7.
+Per Theorems 1.1.2 and 1.11.4 of {{mr:0482697}}, this is equivalent to being {P27}, {P53}, and finite-dimensional, using any of the small inductive, large inductive, or covering dimensions by Theorem 1.7.7.

--- a/theorems/T000461.md
+++ b/theorems/T000461.md
@@ -5,8 +5,8 @@ if:
 then:
   P000184: true
 refs:
-  - wikipedia: Whitney_embedding_theorem
-    name: Whitney embedding theorem on Wikipedia
+  - mr: 3728284
+    name: Topology (Munkres)
 ---
 
-Follows from the Whitney embedding theorem. See {{wikipedia:Whitney embedding theorem}}.
+See section 50, Exercise 7 on page 316 of {{mr:3728284}}.

--- a/theorems/T000462.md
+++ b/theorems/T000462.md
@@ -12,4 +12,4 @@ refs:
     name: Dimension Theory (Engelking)
 ---
 
-Per theorem Theorem 1.11.4 of {{mr:0482697}}, being {P184} is equivalent to being {P27}, {P53}, and finite-dimensional, and {P50} is equivalent to having small inductive dimension zero (Proposition 1.2.1 in the same source).
+{P50} is equivalent to having small inductive dimension zero (Proposition 1.2.1 in {{mr:0482697}}).  The result then follows from Theorem 1.11.4 in the same source.

--- a/theorems/T000463.md
+++ b/theorems/T000463.md
@@ -3,7 +3,6 @@ uid: T000463
 if:
   and:
     - P000027: true
-    - P000053: true
     - P000133: true
 then:
   P000184: true
@@ -11,8 +10,7 @@ refs:
   - mr: 0482697
     name: Dimension Theory (Engelking)
   - mr: 1475806
-    name: On the dimension of ordered spaces 
+    name: On the dimension of ordered spaces (B. Brunet)
 ---
 
-Per theorem Theorem 1.11.4 of {{mr:0482697}}, being {P184} is equivalent to being {P27}, {P53}, and finite-dimensional,
-and the main result of {{mr:1475806}} shows that {P133} spaces have covering dimension no greater than 1.
+The main result of {{mr:1475806}} (available at <https://eudml.org/doc/40507>) shows that {P133} spaces have covering dimension no greater than 1.  And on the other hand {P27} {P133} spaces are {P53} by the Urysohn metrization theorem.  The result then follows from Theorem 1.11.4 of {{mr:0482697}}.


### PR DESCRIPTION
Some tweaks for #602.

- Technically speaking, Engelking Thm 1.11.4 by itself only showed one half of the claimed equivalence.  So added mention of Thm 1.1.2 and rephased in other places.
- T461: the wikipedia article https://en.wikipedia.org/wiki/Whitney_embedding_theorem only seems to talk about smooth manifolds, not topological manifolds.  Replaced this with a reference I found in Munkres. I did not look very deeply, but could not find one in Engelking's Dimension Theory.  Maybe you know of one there?
- T463: the metrizable hypothesis was redundant.
