### PR TITLE
Add aliases to P134, P135, and S43

### DIFF
--- a/properties/P000134.md
+++ b/properties/P000134.md
@@ -3,6 +3,7 @@ uid: P000134
 name: $R_1$
 aliases:
   - Preregular
+  - R1
 refs:
   - mr: 1417259
     name: Handbook of Analysis and its Foundations (Schechter)

--- a/properties/P000135.md
+++ b/properties/P000135.md
@@ -1,6 +1,8 @@
 ---
 uid: P000135
 name: $R_0$
+aliases:
+  - R0
 refs:
   - wikipedia: T1_space
     name: T1 space on Wikipedia

--- a/spaces/S000043/README.md
+++ b/spaces/S000043/README.md
@@ -3,6 +3,7 @@ uid: S000043
 name: Sorgenfrey line
 aliases:
   - Right half-open interval topology
+  - Lower limit topology
 counterexamples_id: 51
 refs:
   - doi: 10.1007/978-1-4612-6290-9 

--- a/spaces/S000043/README.md
+++ b/spaces/S000043/README.md
@@ -3,7 +3,7 @@ uid: S000043
 name: Sorgenfrey line
 aliases:
   - Right half-open interval topology
-  - Lower limit topology
+  - Lower limit topology on $\mathbb R$
 counterexamples_id: 51
 refs:
   - doi: 10.1007/978-1-4612-6290-9 


### PR DESCRIPTION
This adds aliases to R0 and R1 in line with the T series of separation axioms and another common name for S43. 