### PR TITLE
S141: example of non-well-based LOTS

### DIFF
--- a/spaces/S000020/README.md
+++ b/spaces/S000020/README.md
@@ -4,6 +4,7 @@ name: Fort Space on a Countably Infinite Set
 aliases:
   - Countable Fort Space
   - Converging sequence
+  - $\omega+1$
 counterexamples_id: 23
 refs:
   - doi: 10.1007/978-1-4612-6290-9 
@@ -14,8 +15,9 @@ refs:
 Let $X=\omega\cup\{\infty\}=\{0,1,2\dots\}\cup\{\infty\}$.
 Define $U \subseteq X$ to be open if its complement either is finite or includes $\infty$.
 
-This space is the one-point compactification of a countably infinite discrete space,
-and is homeomorphic to $\{0\}\cup\{2^{-n}:n<\omega\}$ as a subspace of {S25}.
+This space is the one-point compactification of a countably infinite discrete space.
+It is homeomorphic to $\{0\}\cup\{2^{-n}:n<\omega\}$ as a subspace of {S25},
+and is also homeomorphic to the ordinal space $\omega+1$.
 
 Defined as counterexample #23 ("Countable Fort Space")
 in {{doi:10.1007/978-1-4612-6290-9}}.

--- a/spaces/S000020/properties/P000167.md
+++ b/spaces/S000020/properties/P000167.md
@@ -1,10 +1,10 @@
 ---
 space: S000020
-property: P000049
+property: P000167
 value: false
 refs:
 - doi: 10.1007/978-1-4612-6290-9_6
   name: Counterexamples in Topology
 ---
 
-See item #7 for space #23 in {{doi:10.1007/978-1-4612-6290-9_6}}.
+The sequence $(n)_{n\in\omega}$ converges to $\infty$ and is not eventually constant.

--- a/spaces/S000039/README.md
+++ b/spaces/S000039/README.md
@@ -10,7 +10,7 @@ refs:
 ---
 The unique (one-point) compactification of {S38}. Equivalently,
 the space $\omega_1\times[0,1)\cup\{\langle\omega_1,0\rangle\}$
-with the lexicographic topology.
+with the lexicographic order topology.
 
 Defined as counterexample #46 ("The Extended Long Line")
 in {{doi:10.1007/978-1-4612-6290-9}}.

--- a/spaces/S000039/properties/P000174.md
+++ b/spaces/S000039/properties/P000174.md
@@ -1,0 +1,10 @@
+---
+space: S000039
+property: P000174
+value: true
+refs:
+  - mathse: 4886508 
+    name: Answer to "Are linearly ordered topological spaces well-based?"
+---
+
+$X$ is well-based at every point of its open subset {S38}, since {S38|P174}.  And $X$ is well-based at $\langle\omega_1,0\rangle$, as it is the maximum point of its order (see {{mathse:4886508}}).

--- a/spaces/S000141/README.md
+++ b/spaces/S000141/README.md
@@ -1,0 +1,13 @@
+---
+uid: S000141
+name: Ordered space $\omega_1+1+\omega^*$
+refs:
+  - mathse: 4884795 
+    name: Are linearly ordered topological spaces well-based?
+---
+
+Let $X$ be the ordered space $\omega_1+1+\omega^*$ with the corresponding order topology.  Here $+$ is concatenation, $\omega_1$ is {S35}, $1$ is the singleton $\{p\}$ for some point $p$, and $\omega^*$ is $\omega$ with the reverse order.
+
+This provides an example of a {P133} space that is not {P174}.
+
+See {{mathse:4884795}}.

--- a/spaces/S000141/properties/P000016.md
+++ b/spaces/S000141/properties/P000016.md
@@ -1,0 +1,7 @@
+---
+space: S000141
+property: P000016
+value: true
+---
+
+$X$ the union of its two compact subspaces $\omega_1+1$ ({S36}), and $1+\omega^*$, homeomorphic to $\omega+1$ ({S20}).

--- a/spaces/S000141/properties/P000020.md
+++ b/spaces/S000141/properties/P000020.md
@@ -1,0 +1,7 @@
+---
+space: S000141
+property: P000020
+value: true
+---
+
+$X$ the union of its two {P20} subspaces $\omega_1$ and $1+\omega^*$: {S35|P20} and {S20|P20}.

--- a/spaces/S000141/properties/P000051.md
+++ b/spaces/S000141/properties/P000051.md
@@ -1,0 +1,7 @@
+---
+space: S000141
+property: P000051
+value: true
+---
+
+Let $A\subseteq X$ be nonempty.  If $A$ meets $\omega^*$, any point in their intersection is isolated in $X$ (and in $A$).  Otherwise, $A\subseteq\omega_1+1$ and hence there is a point of $A$ isolated in $A$, since {S36|P51}.

--- a/spaces/S000141/properties/P000081.md
+++ b/spaces/S000141/properties/P000081.md
@@ -1,0 +1,7 @@
+---
+space: S000141
+property: P000081
+value: false
+---
+
+{P81} is a hereditary property.  The space contains the subspace $\omega_1+1$, and {S36|P81}.

--- a/spaces/S000141/properties/P000114.md
+++ b/spaces/S000141/properties/P000114.md
@@ -1,0 +1,7 @@
+---
+space: S000141
+property: P000114
+value: true
+---
+
+By construction.

--- a/spaces/S000141/properties/P000133.md
+++ b/spaces/S000141/properties/P000133.md
@@ -1,0 +1,10 @@
+---
+space: S000141
+property: P000133
+value: true
+refs:
+  - mathse: 4884795 
+    name: Are linearly ordered topological spaces well-based?
+---
+
+By definition.

--- a/spaces/S000141/properties/P000167.md
+++ b/spaces/S000141/properties/P000167.md
@@ -1,0 +1,7 @@
+---
+space: S000141
+property: P000167
+value: false
+---
+
+{P167} is a hereditary property.  The subspace $1+\omega^*$ is homeomorphic to $\omega+1$, and {S20|P167}.

--- a/spaces/S000141/properties/P000174.md
+++ b/spaces/S000141/properties/P000174.md
@@ -1,0 +1,10 @@
+---
+space: S000141
+property: P000174
+value: false
+refs:
+  - mathse: 4884795 
+    name: Are linearly ordered topological spaces well-based?
+---
+
+$X$ is not well-based at the point $p$, since $p$ has infinite and distinct cofinalities on the left and on the right.  See {{mathse:4884795}}.


### PR DESCRIPTION
New space S141 providing an example of a LOTS that is not well-based (see #595):
https://topology.pi-base.org/spaces?q=LOTS%2B%7EWell-based

Also added a well-based trait to S39 (Closed long ray), so that well-basedness can be determined for all the LOTS currently in pi-base.

And some minor tweaks for S20 ($\omega+1$) as it is used for S141.  In particular, replaced trait file for extremely disconnected with one for sequentially discrete (makes for simpler proofs and simpler deductions).
