### PR TITLE
Generalize T449 about dispersion point

### DIFF
--- a/spaces/S000187/properties/P000045.md
+++ b/spaces/S000187/properties/P000045.md
@@ -1,0 +1,7 @@
+---
+space: S000187
+property: P000045
+value: false
+---
+
+Removing any point from $X$ leaves a space homeomorphic to {S10}, and {S10|P47}.

--- a/theorems/T000449.md
+++ b/theorems/T000449.md
@@ -2,10 +2,13 @@
 uid: T000449
 if:
   and:
-  - P000129: true
-  - P000175: true
+  - P000045: true   # dispersion pt
+  - P000175: true   # |X| >= 3
 then:
-  P000045: false
+  P000001: true   # T0
+refs:
+  - mathse: 4895754
+    name: Answer to "Are biconnected spaces T0?"
 ---
 
-Removing any point from an indiscrete space with at least 3 points gives a connected space with at least two points, which cannot be {P47} by {T52}.
+See {{mathse:4895754}}.


### PR DESCRIPTION
(old T449) [indiscrete + $|X|\geq 3$ ==> no dispersion point], equivalent by contraposition to [dispersion point + $|X|\geq 3$ ==> not indiscrete].

(new T449) [dispersion point + $|X|\geq 3$ ==> $T_0$].

One benefit of this theorem: pi-base has all the topological spaces with three elements except two of them (which are not $T_0$),  So if they ever get added to pi-base, we won't need a separate trait to assert they have no dispersion point.

Also added a dispersion point trait for S187, which gives one more counterexample for the converse of https://topology.pi-base.org/theorems/T000092.