### PR TITLE
proposed tweak to P48 definition

### DIFF
--- a/properties/P000048.md
+++ b/properties/P000048.md
@@ -6,6 +6,7 @@ refs:
     name: Counterexamples in Topology
 ---
 
-Given any two distinct $x,y \in X$ there are disjoint open $U, V \subset X$ containing $x$ and $y$ respectively with $X = U \cup V$.
+Given any two distinct points $x,y \in X$, there exists a clopen subset $A\subseteq X$ such that
+$x\in A$ and $y\not\in A$.
 
 Defined on page 32 of {{doi:10.1007/978-1-4612-6290-9}}.


### PR DESCRIPTION
No need to worry if the union of clopen sets is the whole space: just find one, and its complement serves as the other.