### PR TITLE
add a non-LOTS subspace of R

### DIFF
--- a/spaces/S000198/README.md
+++ b/spaces/S000198/README.md
@@ -1,0 +1,6 @@
+---
+uid: S000198
+name: Disjoint union of the reals and a singleton
+---
+
+The disjoint union $X=\mathbb R\sqcup \{\star\}$ of {S25} and {S162}.

--- a/spaces/S000198/properties/P000016.md
+++ b/spaces/S000198/properties/P000016.md
@@ -1,0 +1,7 @@
+---
+space: S000198
+property: P000016 #compact
+value: false
+---
+
+Contains a closed copy of non-{P16} {S25}.

--- a/spaces/S000198/properties/P000017.md
+++ b/spaces/S000198/properties/P000017.md
@@ -1,0 +1,8 @@
+---
+space: S000198
+property: P000017 #sigma-compact
+value: true
+---
+
+This space is a countable union of {P17} spaces
+{S25} and {S162}.

--- a/spaces/S000198/properties/P000017.md
+++ b/spaces/S000198/properties/P000017.md
@@ -4,5 +4,5 @@ property: P000017 #sigma-compact
 value: true
 ---
 
-This space is a countable union of {P17} spaces
+This space is the union of {P17} spaces
 {S25} and {S162}.

--- a/spaces/S000198/properties/P000036.md
+++ b/spaces/S000198/properties/P000036.md
@@ -1,0 +1,7 @@
+---
+space: S000198
+property: P000036 #connected
+value: false
+---
+
+$\mathbb R,\{\star\}$ is a disconnection.

--- a/spaces/S000198/properties/P000043.md
+++ b/spaces/S000198/properties/P000043.md
@@ -1,0 +1,7 @@
+---
+space: S000198
+property: P000043 #locally arc connected
+value: true
+---
+
+Follows as the disjoint union of {P38} spaces.

--- a/spaces/S000198/properties/P000097.md
+++ b/spaces/S000198/properties/P000097.md
@@ -4,4 +4,4 @@ property: P000097 # Embeddable in the Reals
 value: true
 ---
 
-This space is a copy of $(0,1)\cup\{2\}$.
+This space is homeomorphic to $(0,1)\cup\{2\}$.

--- a/spaces/S000198/properties/P000097.md
+++ b/spaces/S000198/properties/P000097.md
@@ -1,0 +1,7 @@
+---
+space: S000198
+property: P000097 # Embeddable in the Reals
+value: true
+---
+
+This space is a copy of $(0,1)\cup\{2\}$.

--- a/spaces/S000198/properties/P000133.md
+++ b/spaces/S000198/properties/P000133.md
@@ -6,7 +6,7 @@ refs:
 - mathse: 4915404
   name: Why isn't every subspace of $\mathbb R$ a linearly ordered topological space (LOTS)?
 - wikipedia: Order_topology
-  name: Order topology
+  name: Order topology on Wikipedia
 ---
 
 See {{mathse:4915404}} and {{wikipedia:Order_topology}}.

--- a/spaces/S000198/properties/P000133.md
+++ b/spaces/S000198/properties/P000133.md
@@ -1,0 +1,10 @@
+---
+space: S000198
+property: P000133 # LOTS
+value: false
+refs:
+- mathse: 4915404
+  name: Why isn't every subspace of $\mathbb R$ a linearlly ordered topological space (LOTS)?
+---
+
+See {{mathse:4915404}}

--- a/spaces/S000198/properties/P000133.md
+++ b/spaces/S000198/properties/P000133.md
@@ -5,6 +5,8 @@ value: false
 refs:
 - mathse: 4915404
   name: Why isn't every subspace of $\mathbb R$ a linearlly ordered topological space (LOTS)?
+- wikipedia: Order_topology
+  name: Order topology
 ---
 
-See {{mathse:4915404}}
+See {{mathse:4915404}} and {{wikipedia:Order_topology}}.

--- a/spaces/S000198/properties/P000133.md
+++ b/spaces/S000198/properties/P000133.md
@@ -4,7 +4,7 @@ property: P000133 # LOTS
 value: false
 refs:
 - mathse: 4915404
-  name: Why isn't every subspace of $\mathbb R$ a linearlly ordered topological space (LOTS)?
+  name: Why isn't every subspace of $\mathbb R$ a linearly ordered topological space (LOTS)?
 - wikipedia: Order_topology
   name: Order topology
 ---


### PR DESCRIPTION
Continuing from #644, here I add the space $(0,1)\cup\{2\}\subseteq\mathbb R$ which is not a LOTS.

I think the proof that this space is not a LOTS is beyond the scope of a contribution to $\pi$-Base without a reference, so I'll ask the question on Math.SE. https://math.stackexchange.com/questions/4915404/