### PR TITLE
New property: GO-space

### DIFF
--- a/properties/P000154.md
+++ b/properties/P000154.md
@@ -1,0 +1,19 @@
+---
+uid: P000154
+name: GO-space
+aliases:
+  - Generalized ordered
+refs:
+  - zb: "0228.54026"
+    name: On generalized ordered spaces (D. Lutzer)
+  - mathse: 4917398
+    name: Equivalent definitions for GO-spaces (generalized ordered spaces)
+---
+
+The space $X$ (with topology $\tau$) is {P2} and there is a linear order $<$ on $X$ such that every point has a local base of $\tau$-open neighborhoods consisting of order-convex sets.  (A subset $A$ of an ordered set $(X,<)$ is *order-convex* if for each $a,b\in A$ with $a<b$, $A$ contains all points of $X$ between $a$ and $b$.)
+
+Equivalently, there is a linear order $<$ on $X$ such that the topology $\tau$ on $X$ contains the order topology induced by the order $<$ and every point has a local base of $\tau$-open neighborhoods consisting of order-convex sets.
+
+Equivalently, $X$ is homeomorphic to a subspace of a {P133}.
+
+For more details and the proof of these equivalences, see {{zb:0228.54026}} (<https://eudml.org/doc/268514>) and {{mathse:4917398}}.

--- a/theorems/T000066.md
+++ b/theorems/T000066.md
@@ -1,0 +1,9 @@
+---
+uid: T000066
+if:
+  P000133: true
+then:
+  P000154: true
+---
+
+By definition.

--- a/theorems/T000120.md
+++ b/theorems/T000120.md
@@ -1,0 +1,9 @@
+---
+uid: T000120
+if:
+  P000097: true
+then:
+  P000154: true
+---
+
+By definition, since $\mathbb R$ is a {P133}.

--- a/theorems/T000125.md
+++ b/theorems/T000125.md
@@ -1,0 +1,16 @@
+---
+uid: T000125
+if:
+  and:
+  - P000154: true
+  - P000016: true
+then:
+  P000133: true
+refs:
+  - zb: "0228.54026"
+    name: On generalized ordered spaces (D. Lutzer)
+---
+
+Let $\tau$ be the topology on $X$ and let $<$ be the order on $X$ in the definition of {P154}, with corresponding order topology $\sigma$.  Then $\sigma\subseteq\tau$ and the identity map $(X,\tau)\to(X,\sigma)$ is a continuous bijection from a compact space to a Hausdorff space, hence a homeomorphism.  So $\tau=\sigma$.
+
+See Lemma 6.1 in {{zb:0228.54026}} (<https://eudml.org/doc/268514>).

--- a/theorems/T000131.md
+++ b/theorems/T000131.md
@@ -1,0 +1,16 @@
+---
+uid: T000131
+if:
+  and:
+  - P000154: true
+  - P000036: true
+then:
+  P000133: true
+refs:
+  - zb: "0228.54026"
+    name: On generalized ordered spaces (D. Lutzer)
+  - mathse: 4917398
+    name: Equivalent definitions for GO-spaces (generalized ordered spaces)
+---
+
+See Lemma 6.1 in {{zb:0228.54026}} (<https://eudml.org/doc/268514>).

--- a/theorems/T000216.md
+++ b/theorems/T000216.md
@@ -1,7 +1,7 @@
 ---
 uid: T000216
 if:
-  P000133: true
+  P000154: true
 then:
   P000172: true
 refs:
@@ -9,6 +9,8 @@ refs:
   name: Quotienten geordneter Räume und Folgenkonvergenz (H. Herrlich)
 ---
 
-Stated as evident in the first sentence of the proof of Satz 1 in {{doi:10.4064/fm-61-1-79-81}}.
+The result for {P133} is stated as evident in the first sentence of the proof of Satz 1 in {{doi:10.4064/fm-61-1-79-81}}.
 
 Given a subset $A$ of a {P133} space $X$, a point $p\in\overline A\setminus A$ is in the closure of the part of $A$ to one side of $p$, say the left side.  So the set $B=\{a\in A:a<p\}$ has no maximum point and is cofinal in the set of points of $X$ to the left of $p$.  As $B$ is totally ordered, it admits a well-ordered cofinal subset and that set corresponds to a transfinite sequence of points of $A$ converging to $p$.
+
+And since {P172} is a hereditary property, the result also holds for {P154}.

--- a/theorems/T000273.md
+++ b/theorems/T000273.md
@@ -1,7 +1,7 @@
 ---
 uid: T000273
 if:
-  P000133: true
+  P000154: true
 then:
   P000008: true
 refs:
@@ -11,4 +11,6 @@ refs:
     name: Why are ordered spaces normal?
 ---
 
-See example 39 of {{doi:10.1007/978-1-4612-6290-9_6}}.
+For a {P133} space, see items #3-6 of example #39 in {{doi:10.1007/978-1-4612-6290-9_6}} or {{mathse:322683}}.
+
+Since {P8} is a hereditary property, the result also holds for {P154}.

--- a/theorems/T000277.md
+++ b/theorems/T000277.md
@@ -2,13 +2,19 @@
 uid: T000277
 if:
   and:
-  - P000133: true
+  - P000154: true
   - P000029: true
 then:
   P000131: true
 refs:
   - doi: 10.1090/S0002-9939-1969-0248762-3
     name: Separability, the countable chain condition and the Lindelöf property in linearly orderable spaces (Lutzer & Bennet)
+  - zb: "0228.54026"
+    name: On generalized ordered spaces (D. Lutzer)
+  - mathse: 4917398
+    name: Equivalent definitions for GO-spaces (generalized ordered spaces)
 ---
 
-See Theorem 2.2 in {{doi:10.1090/S0002-9939-1969-0248762-3}}.
+For the result with the stronger hypothesis of {P133} in place of {P154}, see Theorem 2.2 in {{doi:10.1090/S0002-9939-1969-0248762-3}}.
+
+The general result with {P154} is Proposition 2.10(b) in {{zb:0228.54026}} (<https://eudml.org/doc/268514>) and is proved as follows.  Suppose $X$ is a GO-space satisfying the CCC condition.  It can be topologically embedded as a dense subspace of a LOTS $Y$ (see for example {{mathse:4917398}}).  Since $X$ is dense in $Y$, the space $Y$ also satisfies CCC, hence is {P131} by the first result.  The conclusion then follows since {P131} is a hereditary property.

--- a/theorems/T000278.md
+++ b/theorems/T000278.md
@@ -2,15 +2,17 @@
 uid: T000278
 if:
   and:
-  - P000133: true
+  - P000154: true
   - P000029: true
 then:
   P000028: true
 refs:
   - zb: "0684.54001"
     name: General Topology (Engelking, 1989)
+  - mathse: 4917398
+    name: Equivalent definitions for GO-spaces (generalized ordered spaces)
 ---
 
-By Exercise 3.12.4(a) in {{zb:0684.54001}} the character of a linearly ordered topological space does not exceed its cellularity.  So if a LOTS satisfies CCC, it is first countable.
+For the result with the stronger hypothesis of {P133} in place of {P154}, Exercise 3.12.4(a) in {{zb:0684.54001}} states that the character of a linearly ordered topological space does not exceed its cellularity.  So if a LOTS satisfies CCC, it is first countable.  See Lemma 5 in <https://web.math.pmf.unizg.hr/glasnik/skenirano/mardesicpapic1962.pdf>, noting that the compactness assumption is not used.
 
-See Lemma 5 in <https://web.math.pmf.unizg.hr/glasnik/skenirano/mardesicpapic1962.pdf>, noting that the compactness assumption is not used.
+For the general result with {P154}, suppose $X$ is a GO-space satisfying the CCC condition.  It can be topologically embedded as a dense subspace of a LOTS $Y$ (see for example {{mathse:4917398}}).  Since $X$ is dense in $Y$, the space $Y$ also satisfies CCC, hence is {P28} by the first result.  The conclusion then follows since {P28} is a hereditary property.

--- a/theorems/T000294.md
+++ b/theorems/T000294.md
@@ -1,0 +1,20 @@
+---
+uid: T000294
+if:
+  and:
+  - P000154: true
+  - P000026: true
+then:
+  P000180: true
+refs:
+  - doi: 10.1090/S0002-9939-1969-0248762-3
+    name: Separability, the countable chain condition and the Lindelöf property in linearly orderable spaces (Lutzer & Bennet)
+  - zb: "0228.54026"
+    name: On generalized ordered spaces (D. Lutzer)
+  - mathse: 4917398
+    name: Equivalent definitions for GO-spaces (generalized ordered spaces)
+---
+
+For the result with the stronger hypothesis of {P133} in place of {P154}, see Theorem 3.3 in {{doi:10.1090/S0002-9939-1969-0248762-3}}.
+
+The general result with {P154} is Proposition 2.10(a) in {{zb:0228.54026}} (<https://eudml.org/doc/268514>) and is proved as follows.  Suppose $X$ is a GO-space containing a countable topologically dense subset $D$.  $X$ can be topologically embedded as a dense subspace of a LOTS $Y$ (see for example {{mathse:4917398}}).  Since $X$ is dense in $Y$, the set $D$ is also topologically dense in $Y$, hence $Y$ is {P180} by the first result.  The conclusion then follows since {P180} is a hereditary property.

--- a/theorems/T000441.md
+++ b/theorems/T000441.md
@@ -6,4 +6,4 @@ then:
   P000081: true
 ---
 
-If $p\in\overline{A}$, then since $X$ is {P180} there is a countable dense subset $D\subseteq A$, whereby $\overline{D}=\overline{A}\ni p$.
+Suppose $A\subseteq X$ and $p\in\overline A$.  Since $X$ is {P180}, there is a countable dense subset $D\subseteq A$, whereby $\overline{D}=\overline{A}\ni p$.


### PR DESCRIPTION
Adding GO-space as a new property, together with related theorems.

Some of the remaining theorems for LOTS can possibly also be converted to GO-spaces, but it's a first batch.  I'll do a later PR to add the property for spaces like the Sorgenfrey line or the Michael line.
