### PR TITLE
feat: auto-install pi-base editor extension in codespaces

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -31,6 +31,9 @@
       ]
     },
     "vscode": {
+      "extensions": [
+        "pi-base.pi-base"
+      ],
       "settings": {
         "workbench.editorAssociations": {
           "codespace-welcome.md": "vscode.markdown.preview.editor"


### PR DESCRIPTION
Related to https://github.com/pi-base/data/commit/dd40b6f366feb8bf93f2ad7360653f267e1051ad; this should entirely auto-install the extension in codespaces / devcontainers (assuming I'm reading https://code.visualstudio.com/docs/devcontainers/create-dev-container correctly).