### PR TITLE
Update for T465 and T236 for GO-space

### DIFF
--- a/theorems/T000236.md
+++ b/theorems/T000236.md
@@ -11,7 +11,8 @@ refs:
     name: Is there a generalized order space $X$ with countable tightness which is not first countable?
 ---
 
-Suppose $X$ is a {P154} for some linear order $<$ and let $a\in X$.
+Shown by KP Hart at {{mo:312803}}. To see this,
+suppose $X$ is a {P154} for some linear order $<$ and let $a\in X$.
 
 If $a$ is not isolated to the left (that is, in $(\leftarrow,a]$), it is in the closure of $(\leftarrow,a)$ and by {P81} there is a countably infinite set $C\subseteq(\leftarrow,a)$ with $a=\sup C$.  We can then extract a strictly increasing sequence $(x_n)$ in $C$ with $a=\sup x_n$.  Similarly, if $a$ is not isolated to the right, there is a strictly decreasing sequence $(y_n)$ with $a=\inf y_n$.
 

--- a/theorems/T000236.md
+++ b/theorems/T000236.md
@@ -2,14 +2,17 @@
 uid: T000236
 if:
   and:
-  - P000133: true
+  - P000154: true
   - P000081: true
 then:
   P000028: true
+refs:
+  - mo: 312803
+    name: Is there a generalized order space $X$ with countable tightness which is not first countable?
 ---
 
-Suppose $(X,<)$ is a totally ordered set with the corresponding order topology and let $a\in X$.
+Suppose $X$ is a {P154} for some linear order $<$ and let $a\in X$.
 
 If $a$ is not isolated to the left (that is, in $(\leftarrow,a]$), it is in the closure of $(\leftarrow,a)$ and by {P81} there is a countably infinite set $C\subseteq(\leftarrow,a)$ with $a=\sup C$.  We can then extract a strictly increasing sequence $(x_n)$ in $C$ with $a=\sup x_n$.  Similarly, if $a$ is not isolated to the right, there is a strictly decreasing sequence $(y_n)$ with $a=\inf y_n$.
 
-So, if $a$ is not isolated on either side, the collection of intervals $(x_n,y_n)$ forms a countable local base at $a$.  And if $a$ is isolated on one side or both, one can take the collection of intervals $(x_n,a]$ or $[a,y_n)$ or the singleton $\{a\}$.
+So, if $a$ is not isolated on either side, any neighborhood of $a$ contains an order-convex neighborhood, which necessarily contains points on either side of $a$, and hence contains an interval $(x_n,y_n)$.  Thus the collection of intervals $(x_n,y_n)$ forms a countable local base at $a$.  And if $a$ is isolated on one side or both, one can take the collection of intervals $(x_n,a]$ or $[a,y_n)$ or the singleton $\{a\}$.

--- a/theorems/T000465.md
+++ b/theorems/T000465.md
@@ -2,13 +2,13 @@
 uid: T000465
 if:
   and:
-    - P000133: true
+    - P000154: true
     - P000047: true
 then:
   P000050: true
 refs:
-  - mr: 1475806
+  - zb: "0905.54021"
     name: On the dimension of ordered spaces (B. Brunet)
 ---
 
-In {{mr:1475806}} (available at <https://eudml.org/doc/40507>) it is proven that a {P133} space is {P50} if and only if it is {P47}.
+See Theorem 5.1 in {{zb:0905.54021}}, where a {P154} is called a "line".


### PR DESCRIPTION
Updated T465 and T236 for GO-spaces.

I removed the explicit link to eudml, but the nice thing about zb is that it's available right from the zbmath page.