### PR TITLE
T463 update for GO-space

### DIFF
--- a/theorems/T000463.md
+++ b/theorems/T000463.md
@@ -2,7 +2,7 @@
 uid: T000463
 if:
   and:
-    - P000133: true
+    - P000154: true
     - P000027: true
 then:
   P000097: true
@@ -11,6 +11,10 @@ refs:
     name: Every second countable LOTS is embeddable in $\mathbb R$
   - zb: "0684.54001"
     name: General Topology (Engelking, 1989)
+  - mathse: 4925245
+    name: A second countable GO-space can be homeomorphically embedded in a second countable LOTS
 ---
 
-See {{mathse:4913495}} and Problem 6.3.2(c) in {{zb:0684.54001}}.
+For the result with the stronger hypothesis of {P133} in place of {P154}, see {{mathse:4913495}} and Problem 6.3.2(c) in {{zb:0684.54001}}.
+
+For the general result, suppose $X$ is a {P154} that is {P27}.  {{mathse:4925245}} shows that $X$ can be homeomorphically embedded into a {P27} {P133} space $Y$.  The space $Y$ is {P97} by the first result.  The conclusion then follows since {P97} is a hereditary property.


### PR DESCRIPTION
Generalizing T463 [LOTS + second countable ==> embeddable in the reals] to GO-spaces.
