### PR TITLE
The Birkhoff-Kakutani theorem

### DIFF
--- a/theorems/T000348.md
+++ b/theorems/T000348.md
@@ -1,0 +1,20 @@
+---
+uid: T000348
+if:
+  and:
+    - P000087: true
+    - P000028: true
+then:
+  P000121: true
+refs:
+  - zb: "1052.54001"
+    name: General Topology (Willard)
+  - zb: "0684.54001"
+    name: General Topology (Engelking, 1989)
+---
+
+This is essentially the Birkhoff-Kakutani theorem (<https://terrytao.wordpress.com/2011/05/17/the-birkhoff-kakutani-theorem/>), which says that a topological group is metrizable if and only if it is Hausdorff and first countable.  The current version without Hausdorff is obtained by passing to the Kolmogorov quotient.
+
+One way to prove it is to show that a uniformity on a set is induced by a pseudometric if it has a countable base.  And if a topological group is first countable, the usual left (or right) uniformity on the group has a countable base.
+
+See Theorem 38.3 and Problem 38C(1) in {{zb:1052.54001}}, or Theorem 8.1.21 and Exercise 8.1.G in {{zb:0684.54001}}.


### PR DESCRIPTION
The Birkhoff-Kakutani theorem.

Allows to deduce that the Sorgenfrey line is not homeomorphic to a topological group.