### PR TITLE
proposed change of default name for P149

### DIFF
--- a/properties/P000149.md
+++ b/properties/P000149.md
@@ -6,6 +6,8 @@ aliases:
 refs:
 - doi: 10.1016/0166-8641(82)90065-7
   name: Some properties of C(X), I (Gerlits & Nagy)
+- zb: '1153.54009'
+  name: Selection principles related to α-properties (Kočinac)
 ---
 
 Every $\omega$-cover of $X$ has a countable $\omega$-subcover.  (A family $\mathcal U$ of open subsets of $X$ is called an *$\omega$-cover* if each finite subset of $X$ is contained in an element of $\mathcal U$ and $X \notin \mathcal U$.)
@@ -13,3 +15,10 @@ Every $\omega$-cover of $X$ has a countable $\omega$-subcover.  (A family $\math
 Equivalently, every finite power of $X$ is {P18}.
 
 See {{doi:10.1016/0166-8641(82)90065-7}}; the equivalence with every finite power being {P18} is on page 156.
+
+The name $\omega$-Lindelöf used in e.g.
+{{zb:1153.54009}} is motivated as the adaptation of
+{P18} for $\omegea$-covers. This property is
+often called $\varepsilon$-space as it originally appeared
+as the fifth item "$\varepsilon$" in a list from
+{{doi:10.1016/0166-8641(82)90065-7}}.

--- a/properties/P000149.md
+++ b/properties/P000149.md
@@ -1,8 +1,8 @@
 ---
 uid: P000149
-name: $\varepsilon$-space
+name: $\omega$-Lindelöf
 aliases:
-  - $\omega$-Lindelöf
+  - $\varepsilon$-space
 refs:
 - doi: 10.1016/0166-8641(82)90065-7
   name: Some properties of C(X), I (Gerlits & Nagy)

--- a/properties/P000149.md
+++ b/properties/P000149.md
@@ -18,7 +18,7 @@ See {{doi:10.1016/0166-8641(82)90065-7}}; the equivalence with every finite powe
 
 The name $\omega$-Lindelöf used in e.g.
 {{zb:1153.54009}} is motivated as the adaptation of
-{P18} for $\omegea$-covers. This property is
+{P18} for $\omega$-covers. This property is
 often called $\varepsilon$-space as it originally appeared
 as the fifth item "$\varepsilon$" in a list from
 {{doi:10.1016/0166-8641(82)90065-7}}.


### PR DESCRIPTION
I propose we change "$\varepsilon$-space" to "$\omega$-Lindelof". This aligns elsewhere on $\pi$-Base where we use $\omega$ to mean covering properties closed under finite powers, which is typically equivalent to the use of $\omega$ covers rather than open covers.

But I failed to find this usage in the literature. Maybe @ccaruvana has an idea?