### PR TITLE
Theorems related to aleph-space and sigma-space

### DIFF
--- a/properties/P000054.md
+++ b/properties/P000054.md
@@ -1,6 +1,6 @@
 ---
 uid: P000054
-name: "$\\sigma$-Locally Finite Base"
+name: Has a $\sigma$-locally finite base
 refs:
   - doi: 10.1007/978-1-4612-6290-9
     name: Counterexamples in Topology

--- a/properties/P000054.md
+++ b/properties/P000054.md
@@ -5,6 +5,9 @@ refs:
   - doi: 10.1007/978-1-4612-6290-9
     name: Counterexamples in Topology
 ---
-A collection of subsets is $\sigma$-locally finite if it is a countable union of locally finite subcollections.
+
+A space with a $\sigma$-locally finite base for the topology.
+
+A collection of subsets of $X$ is *$\sigma$-locally finite* if it is a countable union of locally finite collections.
 
 Defined on page 37 of {{doi:10.1007/978-1-4612-6290-9}}.

--- a/properties/P000117.md
+++ b/properties/P000117.md
@@ -1,0 +1,13 @@
+---
+uid: P000117
+name: Has a $\sigma$-locally finite network
+refs:
+  - zb: "0684.54001"
+    name: General Topology (Engelking, 1989)
+---
+
+A space with a $\sigma$-locally finite network.
+
+A family $\mathcal N$ of subsets of $X$ is called a *network* if every open set is the union of a subfamily of $\mathcal N$; that is, for every open set $U$ and point $x\in U$ there is some $A\in\mathcal N$ with $x\in A\subseteq U$.  The family $\mathcal N$ is *$\sigma$-locally finite* if it is a countable union of locally finite families.
+
+See for example page 127 of {{zb:0684.54001}}.

--- a/properties/P000118.md
+++ b/properties/P000118.md
@@ -1,0 +1,13 @@
+---
+uid: P000118
+name: Has a $\sigma$-locally finite $k$-network
+refs:
+  - doi: 10.1016/j.topol.2015.05.085
+    name: $\mathfrak P$-spaces and related concepts (Gabriyelyan & Kakol)
+---
+
+A space with a $\sigma$-locally finite $k$-network.
+
+A family $\mathcal N$ of subsets of $X$ is called a *$k$-network* if for every compact set $K$ and open set $U$ in $X$ with $K\subseteq U$, there exists a finite $\mathcal{N}^* \subseteq \mathcal{N}$ with $K \subseteq \bigcup\mathcal{N}^* \subseteq U$.  The family $\mathcal N$ is *$\sigma$-locally finite* if it is a countable union of locally finite families.
+
+See for example Definition 2.1 in {{doi:10.1016/j.topol.2015.05.085}}.

--- a/properties/P000177.md
+++ b/properties/P000177.md
@@ -10,4 +10,4 @@ refs:
 
 A space that is {P5} and {P117}.
 
-The notion was introduced by A. Okuyama (see {{doi:10.3792/pja/1195521153}}) without the {P5} condition.  But most later papers, for example {{doi:10.1016/j.topol.2015.05.085}}, assume {P5}.
+The name "$\sigma$-space" was introduced by A. Okuyama (see {{doi:10.3792/pja/1195521153}}) to denote only the {P117} property. But most later papers, for example {{doi:10.1016/j.topol.2015.05.085}}, also include {P5} in this definition.

--- a/properties/P000177.md
+++ b/properties/P000177.md
@@ -8,6 +8,6 @@ refs:
     name: $\mathfrak P$-spaces and related concepts (Gabriyelyan & Kakol)
 ---
 
-A space that is {P5} and has a $\sigma$-locally finite network.  Here, a family $\mathcal{P}$ of subsets of $X$ is called a *network* if for every $x\in X$ and every neighborhood $U$ of $x$ there is some $P\in\mathcal P$ such that $x\in P\subseteq U$.  And the family $\mathcal P$ is *$\sigma$-locally finite* if it is a countable union of locally finite families.
+A space that is {P5} and {P117}.
 
 The notion was introduced by A. Okuyama (see {{doi:10.3792/pja/1195521153}}) without the {P5} condition.  But most later papers, for example {{doi:10.1016/j.topol.2015.05.085}}, assume {P5}.

--- a/properties/P000178.md
+++ b/properties/P000178.md
@@ -8,4 +8,6 @@ refs:
     name: $\mathfrak P$-spaces and related concepts (Gabriyelyan & Kakol)
 ---
 
-A space that is {P5} and has a $\sigma$-locally finite $k$-network.  Here, a family $\mathcal{P}$ of subsets of $X$ is called a *$k$-network* if for every compact set $K$ and open set $U$ in $X$ with $K \subseteq U$, there exists a finite $\mathcal{P}^* \subseteq \mathcal{P}$ with $K \subseteq \bigcup \mathcal{P}^* \subseteq U$.  And the family $\mathcal P$ is *$\sigma$-locally finite* if it is a countable union of locally finite families.
+A space that is {P5} and {P118}.
+
+The notion was introduced in {{doi:10.1090/S0002-9939-1971-0276919-3}}.

--- a/theorems/T000029.md
+++ b/theorems/T000029.md
@@ -1,0 +1,9 @@
+---
+uid: T000029
+if:
+  P000182: true
+then:
+  P000117: true
+---
+
+Evident from the definitions, as a countable family of sets in $X$ is $\sigma$-locally finite.

--- a/theorems/T000034.md
+++ b/theorems/T000034.md
@@ -1,0 +1,9 @@
+---
+uid: T000034
+if:
+  P000118: true
+then:
+  P000117: true
+---
+
+Evident from the definitions, as a $k$-network is a network.

--- a/theorems/T000137.md
+++ b/theorems/T000137.md
@@ -1,0 +1,9 @@
+---
+uid: T000137
+if:
+  P000054: true
+then:
+  P000118: true
+---
+
+Evident from the definitions, as a base for the topology is a $k$-network.

--- a/theorems/T000147.md
+++ b/theorems/T000147.md
@@ -1,0 +1,9 @@
+---
+uid: T000147
+if:
+  P000177: true
+then:
+  P000117: true
+---
+
+Follows from the definition.

--- a/theorems/T000150.md
+++ b/theorems/T000150.md
@@ -1,0 +1,11 @@
+---
+uid: T000150
+if:
+  and:
+  - P000117: true
+  - P000005: true
+then:
+  P000177: true
+---
+
+Follows from the definition.

--- a/theorems/T000182.md
+++ b/theorems/T000182.md
@@ -1,0 +1,9 @@
+---
+uid: T000182
+if:
+  P000178: true
+then:
+  P000118: true
+---
+
+Follows from the definition.

--- a/theorems/T000197.md
+++ b/theorems/T000197.md
@@ -1,0 +1,11 @@
+---
+uid: T000197
+if:
+  and:
+  - P000118: true
+  - P000005: true
+then:
+  P000178: true
+---
+
+Follows from the definition.

--- a/theorems/T000352.md
+++ b/theorems/T000352.md
@@ -1,0 +1,9 @@
+---
+uid: T000352
+if:
+  P000183: true
+then:
+  P000118: true
+---
+
+Evident from the definitions, as a countable family of sets in $X$ is $\sigma$-locally finite.


### PR DESCRIPTION
Add the plumbing to enable the deduction that metrizable spaces are $\aleph$-spaces.  This deduces $\aleph$-space for 5 more spaces that were metrizable and non-separable.

Two additional properties:
- (P117) Has a $\sigma$-locally finite network
- (P118) Has a $\sigma$-locally finite $k$-network