### PR TITLE
Aleph spaces and Lindelof property

### DIFF
--- a/theorems/T000376.md
+++ b/theorems/T000376.md
@@ -1,0 +1,16 @@
+---
+uid: T000376
+if:
+  and:
+  - P000117: true
+  - P000018: true
+then:
+  P000182: true
+refs:
+  - zb: "0684.54001"
+    name: General Topology (Engelking, 1989)
+---
+
+Every $\sigma$-locally finite collection of sets in a {P18} space is countable.
+
+See Lemma 5.1.24 in {{zb:0684.54001}} for locally finite collections, and take a countable union of those.

--- a/theorems/T000387.md
+++ b/theorems/T000387.md
@@ -1,0 +1,16 @@
+---
+uid: T000387
+if:
+  and:
+  - P000118: true
+  - P000018: true
+then:
+  P000183: true
+refs:
+  - zb: "0684.54001"
+    name: General Topology (Engelking, 1989)
+---
+
+Every $\sigma$-locally finite collection of sets in a {P18} space is countable.
+
+See Lemma 5.1.24 in {{zb:0684.54001}} for locally finite collections, and take a countable union of those.


### PR DESCRIPTION
Add theorems implying that under the Lindelof hypothesis, $\aleph$-spaces and $\aleph_0$-spaces are equivalent and $\sigma$-spaces and cosmic spaces are equivalent.

This allows to deduce that 15 more spaces are not $\sigma$-spaces.  In particular, the Sorgenfrey line is not a $\sigma$-space:
https://topology.pi-base.org/spaces/S000043/properties/P000177
