### PR TITLE
T496: sigma-spaces are G_delta spaces

### DIFF
--- a/theorems/T000495.md
+++ b/theorems/T000495.md
@@ -3,7 +3,7 @@ uid: T000495
 if:
   and:
     - P000190: true
-    - P000015: true
+    - P000132: true
 then:
   P000057: true
 ---
@@ -14,6 +14,6 @@ $\{(\alpha_n,\omega_1]:n\in\omega\}$ is a countable collection of open intervals
 containing $\omega_1$, then $\bigcap_{n<\omega} (\alpha_n,\omega_1]\supseteq
 (\sup\{\alpha_n:n<\omega\},\omega_1]\not=\{\omega_1\}$.
 
-The fact that $\omega_1$ ({S35}) is not {P15} follows from the Pressing Down 
+The fact that $\omega_1$ ({S35}) is not {P132} follows from the Pressing Down 
 Lemma; see for example item C of 
 <https://dantopology.wordpress.com/2009/10/11/the-first-uncountable-ordinal>.

--- a/theorems/T000496.md
+++ b/theorems/T000496.md
@@ -1,14 +1,18 @@
 ---
 uid: T000496
 if:
-  P000177: true
+  and:
+    - P000117: true
+    - P000011: true
 then:
   P000132: true
 refs:
+- mathse: 4944702
+  name: In a regular space with a $\sigma$-locally finite network, is every closed set a $G_\delta$?
 - zb: "0153.52404"
   name: Some generalizations of metric spaces, their metrization theorems and product spaces (A. Okuyama)
 ---
 
-Shown in the proof of Theorem 2.8 in {{zb:0153.52404}} (<https://www.jstor.org/stable/43699115>):
+See {{mathse:4944702}}.
 
-Suppose $\mathcal N=\bigcup_{n=1}^\infty\mathcal N_n$ is a network for $X$, with each $\mathcal N_n$ locally finite.  By regularity, we can assume all the element of $\mathcal N$ are closed.  Given an open set $U$, let $F_n=\bigcup\{A\in\mathcal N_n:A\subseteq U\}$.  Then $F_n$ is closed and $U=\bigcup_{n=1}^\infty F_n$ is an $F_\sigma$.
+Note that similar ideas were used in the proof of Theorem 2.8 in {{zb:0153.52404}} (<https://www.jstor.org/stable/43699115>).

--- a/theorems/T000496.md
+++ b/theorems/T000496.md
@@ -1,0 +1,14 @@
+---
+uid: T000496
+if:
+  P000177: true
+then:
+  P000132: true
+refs:
+- zb: "0153.52404"
+  name: Some generalizations of metric spaces, their metrization theorems and product spaces (A. Okuyama)
+---
+
+Shown in the proof of Theorem 2.8 in {{zb:0153.52404}} (<https://www.jstor.org/stable/43699115>):
+
+Suppose $\mathcal N=\bigcup_{n=1}^\infty\mathcal N_n$ is a $\sigma$-locally finite network in $X$, with each $\mathcal N_n$ locally finite.  By regularity, we can assume all the element of $\mathcal N$ are closed.  Given an open set $U$, let $F_n=\bigcup\{A\in\mathcal N_n:A\subseteq U\}$.  Then $F_n$ is closed and $U=\bigcup_{n=1}^\infty F_n$ is an $F_\sigma$.

--- a/theorems/T000496.md
+++ b/theorems/T000496.md
@@ -11,4 +11,4 @@ refs:
 
 Shown in the proof of Theorem 2.8 in {{zb:0153.52404}} (<https://www.jstor.org/stable/43699115>):
 
-Suppose $\mathcal N=\bigcup_{n=1}^\infty\mathcal N_n$ is a $\sigma$-locally finite network in $X$, with each $\mathcal N_n$ locally finite.  By regularity, we can assume all the element of $\mathcal N$ are closed.  Given an open set $U$, let $F_n=\bigcup\{A\in\mathcal N_n:A\subseteq U\}$.  Then $F_n$ is closed and $U=\bigcup_{n=1}^\infty F_n$ is an $F_\sigma$.
+Suppose $\mathcal N=\bigcup_{n=1}^\infty\mathcal N_n$ is a network for $X$, with each $\mathcal N_n$ locally finite.  By regularity, we can assume all the element of $\mathcal N$ are closed.  Given an open set $U$, let $F_n=\bigcup\{A\in\mathcal N_n:A\subseteq U\}$.  Then $F_n$ is closed and $U=\bigcup_{n=1}^\infty F_n$ is an $F_\sigma$.


### PR DESCRIPTION
Add T496: $\sigma$-space ==> $G_\delta$ space.

The contrapositive allows to deduce that 7 more spaces are not $\sigma$-spaces, including S35 (ordinal space $\omega_1$).