### PR TITLE
T497: locally compact KC spaces are regular

### DIFF
--- a/properties/P000011.md
+++ b/properties/P000011.md
@@ -12,4 +12,6 @@ In other words, given a closed set $A$ and a point
 $b \notin A$, there are disjoint open sets $O_A$ and $O_b$ containing $A$ and
 $b$, respectively.
 
-Defined in 14.1 of {{zb:1052.54001}}.
+Equivalently, every point has a neighborhood base consisting of closed sets.
+
+See Definition 14.1 and Theorem 14.3 in {{zb:1052.54001}}.

--- a/theorems/T000497.md
+++ b/theorems/T000497.md
@@ -1,0 +1,11 @@
+---
+uid: T000497
+if:
+  and:
+    - P000130: true
+    - P000100: true
+then:
+  P000011: true
+---
+
+If every point has a local base of compact neighborhoods and every compact set is closed, every point has a local base of closed neighborhoods.  Thus the space is {P11}.

--- a/theorems/T000497.md
+++ b/theorems/T000497.md
@@ -6,6 +6,9 @@ if:
     - P000100: true
 then:
   P000011: true
+refs:
+- mathse: 4940160
+  name: Answer to "Show that every locally compact Hausdorff space is regular"
 ---
 
 If every point has a local base of compact neighborhoods and every compact set is closed, every point has a local base of closed neighborhoods.  Thus the space is {P11}.


### PR DESCRIPTION
New T497: Locally compact + KC ==> regular.

The contrapositive allows to deduce that three more spaces are not locally compact.
