### PR TITLE
Replace obsolete strongly locally compact

### DIFF
--- a/spaces/S000029/README.md
+++ b/spaces/S000029/README.md
@@ -5,8 +5,12 @@ counterexamples_id: 35
 refs:
   - doi: 10.1007/978-1-4612-6290-9 
     name: Counterexamples in Topology
+  - wikipedia: Alexandroff_extension
+    name: Alexandroff extension on Wikipedia
 ---
-Let $X = \mathbb{Q} \cup \{\infty\}$ and $U \subset X$ be open if and only if $U \subset \mathbb{Q}$ is open or $X \setminus U$ is compact in $\mathbb{Q}$.
+
+The space $X = \mathbb{Q} \cup \{\infty\}$ is the one point compactification of $\mathbb Q$ ({S27}).
+The open sets in $X$ are the open subsets of $\mathbb Q$ together with the sets $X\setminus C$ with $C$ compact in $\mathbb Q$.
 
 Defined as counterexample #35 ("One Point Compactification of the Rationals")
 in {{doi:10.1007/978-1-4612-6290-9}}.

--- a/spaces/S000029/properties/P000129.md
+++ b/spaces/S000029/properties/P000129.md
@@ -1,7 +1,0 @@
----
-space: S000029
-property: P000129
-value: false
----
-
-The space is non-trivial by definition.

--- a/spaces/S000029/properties/P000130.md
+++ b/spaces/S000029/properties/P000130.md
@@ -2,17 +2,7 @@
 space: S000029
 property: P000130
 value: false
-refs:
-  - doi: 10.2307/24340250
-    name: What is Locally Compact?
-  - mathse: 2934970
-    name: Rational numbers are not locally compact
 ---
 
-Shown in
-{{doi:10.2307/24340250}}.
-Also, {{mathse:2934970}} notes the subspace of rationals
-are not even [weakly locally compact](/properties/P000023/)
-and any open subspace
-of a strongly locally compact space must be strongly locally
-compact.
+The {P130} property is a local property, hence inherited by open sets.
+$\mathbb Q$ ({S27}) is open in $X$, but {S27|P130}.


### PR DESCRIPTION
PR #63 replaced the terminology "strongly locally compact" in the property files.  But it seems we forgot to replace a few instances of that use in trait files.  This PR remedies that.

Also add a link from S29 (one point compactification of $\mathbb Q$) to S27 ($\mathbb Q$) for ease of navigation.