### PR TITLE
T497: strengthen conclusion to Tychonoff

### DIFF
--- a/theorems/T000497.md
+++ b/theorems/T000497.md
@@ -13,5 +13,6 @@ refs:
 
 If every point has a local base of compact neighborhoods and every compact set is closed, every point has a local base of closed neighborhoods.  Thus the space is {P11}.
 
-The conclusion can then be strenghthened to {P6} using other theorems known to pi-base.
-Specifically, combine the results that [Locally compact regular spaces are completely regular](https://topology.pi-base.org/spaces?q=Locally+Compact%2BRegular%2B%7ECompletely+regular) and [KC spaces are $T_1$](https://topology.pi-base.org/spaces?q=KC%2B%7Et1).
+The conclusion can then be strenghthened to {P6} using other theorems known to π-Base.
+Specifically, note that [{P130} and {P11} implies {P12}](https://topology.pi-base.org/spaces?q=Locally+Compact%2BRegular%2B%7ECompletely+regular)
+and [{P100} implies {P2}](https://topology.pi-base.org/spaces?q=KC%2B%7Et1).

--- a/theorems/T000497.md
+++ b/theorems/T000497.md
@@ -13,6 +13,5 @@ refs:
 
 If every point has a local base of compact neighborhoods and every compact set is closed, every point has a local base of closed neighborhoods.  Thus the space is {P11}.
 
-Then {P11} may be improved to {P6}
-according to
-[π-Base, Search for `locally compact + KC + regular + ~$T_{3 \frac{1}{2}}$`](https://topology.pi-base.org/spaces?q=locally+compact+%2B+KC+%2B+regular+%2B+%7E%24T_%7B3+%5Cfrac%7B1%7D%7B2%7D%7D%24).
+The conclusion can then be strenghthened to {P6} using other theorems known to pi-base.
+Specifically, combine the results that [Locally compact regular spaces are completely regular](https://topology.pi-base.org/spaces?q=Locally+Compact%2BRegular%2B%7ECompletely+regular) and [KC spaces are $T_1$](https://topology.pi-base.org/spaces?q=KC%2B%7Et1).

--- a/theorems/T000497.md
+++ b/theorems/T000497.md
@@ -14,5 +14,5 @@ refs:
 If every point has a local base of compact neighborhoods and every compact set is closed, every point has a local base of closed neighborhoods.  Thus the space is {P11}.
 
 The conclusion can then be strenghthened to {P6} using other theorems known to π-Base.
-Specifically, note that [{P130} and {P11} implies {P12}](https://topology.pi-base.org/spaces?q=Locally+Compact%2BRegular%2B%7ECompletely+regular)
-and [{P100} implies {P2}](https://topology.pi-base.org/spaces?q=KC%2B%7Et1).
+Specifically, note that {P130} and {P11} implies {P12} [(Explore)](https://topology.pi-base.org/spaces?q=Locally+Compact%2BRegular%2B%7ECompletely+regular)
+and {P100} implies {P2} [(Explore)](https://topology.pi-base.org/spaces?q=KC%2B%7Et1).

--- a/theorems/T000497.md
+++ b/theorems/T000497.md
@@ -5,10 +5,14 @@ if:
     - P000130: true
     - P000100: true
 then:
-  P000011: true
+  P000006: true
 refs:
 - mathse: 4940160
   name: Answer to "Show that every locally compact Hausdorff space is regular"
 ---
 
 If every point has a local base of compact neighborhoods and every compact set is closed, every point has a local base of closed neighborhoods.  Thus the space is {P11}.
+
+Then {P11} may be improved to {P6}
+according to
+[π-Base, Search for `locally compact + KC + regular + ~$T_{3 \frac{1}{2}}$`](https://topology.pi-base.org/spaces?q=locally+compact+%2B+KC+%2B+regular+%2B+%7E%24T_%7B3+%5Cfrac%7B1%7D%7B2%7D%7D%24).


### PR DESCRIPTION
See #679.  The current version of T497 [locally compact + KC ==> regular] can be updated to a stronger conclusion of Tychonoff (P6).

Experiment from today's community call - note that the search uses the theorem we're proving, so it's not ideal to explain why the result can be strengthened.