### PR TITLE
T499: Locally countable Lindelof spaces are countable

### DIFF
--- a/theorems/T000499.md
+++ b/theorems/T000499.md
@@ -1,0 +1,11 @@
+---
+uid: T000499
+if:
+  and:
+    - P000093: true
+    - P000018: true
+then:
+  P000057: true
+---
+
+Since each point has a countable open neighborhood, there is an open cover of $X$ consisting of countable sets.  By {P18} one can extract a countable subcover.  Thus $X$ is covered by a countable number of countable sets and is countable.

--- a/theorems/T000499.md
+++ b/theorems/T000499.md
@@ -8,4 +8,5 @@ then:
   P000057: true
 ---
 
-Since each point has a countable open neighborhood, there is an open cover of $X$ consisting of countable sets.  By {P18} one can extract a countable subcover.  Thus $X$ is covered by a countable number of countable sets and is countable.
+Cover $X$ with countable open sets, then take a countable subcover by {P18}.
+The union is countable and is the whole space.


### PR DESCRIPTION
New T499: Locally countable + Lindelof ==> countable.

The contrapositive allows to deduce that 37 more spaces are not locally countable.
