### PR TITLE
Consistent capitalization of property names

### DIFF
--- a/properties/P000006.md
+++ b/properties/P000006.md
@@ -3,7 +3,7 @@ uid: P000006
 name: "$T_{3 \\frac{1}{2}}$"
 aliases:
   - Tychonoff
-  - Completely Regular Hausdorff
+  - Completely regular Hausdorff
   - T3.5
 refs:
   - zb: "1052.54001"

--- a/properties/P000020.md
+++ b/properties/P000020.md
@@ -1,6 +1,6 @@
 ---
 uid: P000020
-name: Sequentially Compact
+name: Sequentially compact
 refs:
   - doi: 10.1007/978-1-4612-6290-9
     name: Counterexamples in Topology

--- a/properties/P000021.md
+++ b/properties/P000021.md
@@ -1,6 +1,6 @@
 ---
 uid: P000021
-name: Weakly Countably Compact
+name: Weakly countably compact
 aliases:
   - Limit point compact
 refs:

--- a/properties/P000023.md
+++ b/properties/P000023.md
@@ -1,6 +1,6 @@
 ---
 uid: P000023
-name: Weakly Locally Compact
+name: Weakly locally compact
 refs:
   - doi: 10.1007/978-1-4612-6290-9
     name: Counterexamples in Topology

--- a/properties/P000024.md
+++ b/properties/P000024.md
@@ -1,8 +1,8 @@
 ---
 uid: P000024
-name: Locally Relatively Compact
+name: Locally relatively compact
 aliases:
-- Weakly Locally Closed-and-Compact
+- Weakly locally closed-and-compact
 refs:
   - doi: 10.1007/978-1-4612-6290-9
     name: Counterexamples in Topology

--- a/properties/P000025.md
+++ b/properties/P000025.md
@@ -2,7 +2,7 @@
 uid: P000025
 name: Exhaustible by compacts
 aliases:
-  - "$\\sigma$-Locally Compact"
+  - $\sigma$-locally compact
 refs:
   - doi: 10.1007/978-1-4612-6290-9
     name: Counterexamples in Topology
@@ -21,4 +21,4 @@ Equivalently, $X=\bigcup_{n<\omega}K_n$ for $K_n$ compact, and such that $K_n\su
 
 The equivalences above can be shown using the ideas in {{mathse:4568032}}.
 
-Defined on page 21 of {{doi:10.1007/978-1-4612-6290-9}} as "$\sigma$-Locally Compact".
+Defined on page 21 of {{doi:10.1007/978-1-4612-6290-9}} as "$\sigma$-locally compact".

--- a/properties/P000027.md
+++ b/properties/P000027.md
@@ -1,6 +1,6 @@
 ---
 uid: P000027
-name: Second Countable
+name: Second countable
 refs:
   - doi: 10.1007/978-1-4612-6290-9
     name: Counterexamples in Topology

--- a/properties/P000028.md
+++ b/properties/P000028.md
@@ -1,6 +1,6 @@
 ---
 uid: P000028
-name: First Countable
+name: First countable
 refs:
   - doi: 10.1007/978-1-4612-6290-9
     name: Counterexamples in Topology

--- a/properties/P000037.md
+++ b/properties/P000037.md
@@ -1,6 +1,6 @@
 ---
 uid: P000037
-name: Path Connected
+name: Path connected
 refs:
   - doi: 10.1007/978-1-4612-6290-9
     name: Counterexamples in Topology

--- a/properties/P000041.md
+++ b/properties/P000041.md
@@ -1,6 +1,6 @@
 ---
 uid: P000041
-name: Locally Connected
+name: Locally connected
 refs:
   - doi: 10.1007/978-1-4612-6290-9
     name: Counterexamples in Topology

--- a/properties/P000042.md
+++ b/properties/P000042.md
@@ -1,6 +1,6 @@
 ---
 uid: P000042
-name: Locally Path Connected
+name: Locally path connected
 refs:
   - doi: 10.1007/978-1-4612-6290-9
     name: Counterexamples in Topology

--- a/properties/P000043.md
+++ b/properties/P000043.md
@@ -1,6 +1,6 @@
 ---
 uid: P000043
-name: Locally Arc Connected
+name: Locally arc connected
 refs:
   - doi: 10.1007/978-1-4612-6290-9
     name: Counterexamples in Topology

--- a/properties/P000045.md
+++ b/properties/P000045.md
@@ -1,6 +1,6 @@
 ---
 uid: P000045
-name: Has a Dispersion Point
+name: Has a dispersion point
 refs:
   - doi: 10.1007/978-1-4612-6290-9
     name: Counterexamples in Topology

--- a/properties/P000046.md
+++ b/properties/P000046.md
@@ -1,6 +1,6 @@
 ---
 uid: P000046
-name: Totally Path Disconnected
+name: Totally path disconnected
 refs:
   - doi: 10.1007/978-1-4612-6290-9
     name: Counterexamples in Topology

--- a/properties/P000047.md
+++ b/properties/P000047.md
@@ -1,6 +1,6 @@
 ---
 uid: P000047
-name: Totally Disconnected
+name: Totally disconnected
 refs:
   - doi: 10.1007/978-1-4612-6290-9
     name: Counterexamples in Topology

--- a/properties/P000048.md
+++ b/properties/P000048.md
@@ -1,6 +1,6 @@
 ---
 uid: P000048
-name: Totally Separated
+name: Totally separated
 refs:
   - doi: 10.1007/978-1-4612-6290-9
     name: Counterexamples in Topology

--- a/properties/P000050.md
+++ b/properties/P000050.md
@@ -1,6 +1,6 @@
 ---
 uid: P000050
-name: Zero Dimensional
+name: Zero dimensional
 refs:
   - doi: 10.1007/978-1-4612-6290-9
     name: Counterexamples in Topology

--- a/properties/P000060.md
+++ b/properties/P000060.md
@@ -1,6 +1,6 @@
 ---
 uid: P000060
-name: Strongly Connected
+name: Strongly connected
 refs:
   - doi: 10.1007/978-1-4612-6290-9
     name: Counterexamples in Topology

--- a/properties/P000089.md
+++ b/properties/P000089.md
@@ -1,6 +1,6 @@
 ---
 uid: P000089
-name: Fixed Point Property
+name: Fixed point property
 refs:
   - mr: 187120
     name: Nonexpansive nonlinear operators in a Banach space.

--- a/properties/P000130.md
+++ b/properties/P000130.md
@@ -1,6 +1,6 @@
 ---
 uid: P000130
-name: Locally Compact
+name: Locally compact
 refs:
   - wikipedia: Locally_compact_space
     name: Locally compact space on Wikipedia


### PR DESCRIPTION
As discussed in #636, we'll follow a consistent naming for properties where only the first word and proper names will be capitalized.
