### PR TITLE
Update T409 for submetrizable

### DIFF
--- a/theorems/T000409.md
+++ b/theorems/T000409.md
@@ -3,9 +3,9 @@ uid: T000409
 if:
   and:
     - P000026: true
-    - P000053: true
+    - P000112: true
 then:
   P000166: true
 ---
 
-Immediate from the definition.
+Suppose $D$ is a countable dense set in $X$.  If $\tau$ is a coarser metrizable topology on $X$, the set $D$ is still dense for the coarser topology.  So $\tau$ is separable metrizable.


### PR DESCRIPTION
- old T409: separable + metrizable ==> has coarser separable metrizable topology
- new T409: separable + submetrizable ==> has coarser separable metrizable topology

The contrapositive allows to deduce that four more spaces are not submetrizable.

@Almanzoris FYI
