### PR TITLE
T509: Functionally Hausdorff + countable network => submetrizable

### DIFF
--- a/properties/P000112.md
+++ b/properties/P000112.md
@@ -6,7 +6,9 @@ aliases:
 - Submetrisable
 refs:
 - doi: 10.1090/S0002-9939-1978-0482639-9
-  name: Submetrizable Spaces and Almost $\sigma$-Compact Function Spaces
+  name: Submetrizable spaces and almost $\sigma$-compact function spaces (R. McCoy)
 ---
 
 The topology contains a coarser topology which is {P53}.
+
+Equivalently, there is a continuous injective map from $X$ into some metrizable space.

--- a/theorems/T000509.md
+++ b/theorems/T000509.md
@@ -1,0 +1,16 @@
+---
+uid: T000509
+if:
+  and:
+    - P000009: true
+    - P000182: true
+then:
+  P000112: true
+refs:
+- mo: 280359
+  name: Does second countable and functionally Hausdorff imply submetrizable?
+---
+
+See Corollary in answer to {{mo:280359}}.
+
+To show the Corollary from the Theorem above it, suppose $X$ is {P182}.  Then $X\times X$ is {P131} since {P182} is preserved by finite products and {T260}.


### PR DESCRIPTION
New T509: Functionally Hausdorff + countable network ==> submetrizable.

This allows to automatically deduce that 8 more spaces are submetrizable.
