### PR TITLE
Small adjustments to the two Luzin sets and to the Sorgenfrey plane

### DIFF
--- a/spaces/S000076/README.md
+++ b/spaces/S000076/README.md
@@ -10,7 +10,7 @@ refs:
   - wikipedia: Sorgenfrey_plane
     name: Sorgenfrey plane on Wikipedia
 ---
-The square of a Sorgenfrey line.
+The square of {{S43}}.
 
 Defined as counterexample #84 ("Sorgenfrey's Half-Open Square Topology")
 in {{doi:10.1007/978-1-4612-6290-9}}.

--- a/spaces/S000076/README.md
+++ b/spaces/S000076/README.md
@@ -10,7 +10,7 @@ refs:
   - wikipedia: Sorgenfrey_plane
     name: Sorgenfrey plane on Wikipedia
 ---
-The square of {{S43}}.
+The square of {S43}.
 
 Defined as counterexample #84 ("Sorgenfrey's Half-Open Square Topology")
 in {{doi:10.1007/978-1-4612-6290-9}}.

--- a/spaces/S000147/README.md
+++ b/spaces/S000147/README.md
@@ -15,7 +15,7 @@ refs:
 An uncountable subset of the reals such that its intersection with
 every nowhere dense subset of the reals (equivalently,
 every meager subset of the reals) is countable.
-The article {{zb:0389.54004}} is available at the [Topology Proceedings webpage](https://topology.nipissingu.ca/tp/reprints/v01/tp01021s.pdf).
+For background information, see the article {{zb:0389.54004}}, available at the [Topology Proceedings webpage](https://topology.nipissingu.ca/tp/reprints/v01/tp01021s.pdf).
 
 Note that the construction of such a set requires additional axioms beyond $ZFC$.
 

--- a/spaces/S000147/README.md
+++ b/spaces/S000147/README.md
@@ -15,7 +15,7 @@ refs:
 An uncountable subset of the reals such that its intersection with
 every nowhere dense subset of the reals (equivalently,
 every meager subset of the reals) is countable.
-The article {{zb:0389.54004}} is available at the [Topology Proceedings webpage]{https://topology.nipissingu.ca/tp/reprints/v01/tp01021s.pdf}.
+The article {{zb:0389.54004}} is available at the [Topology Proceedings webpage](https://topology.nipissingu.ca/tp/reprints/v01/tp01021s.pdf).
 
 Note that the construction of such a set requires additional axioms beyond $ZFC$.
 

--- a/spaces/S000147/README.md
+++ b/spaces/S000147/README.md
@@ -6,8 +6,8 @@ aliases:
 ambiguous_construction: true
 # additional_axioms: CH
 refs:
-  - mr: 450063
-    name: Luzin spaces
+  - zb: 0389.54004
+    name: Luzin spaces (K. Kunen)
   - doi: 10.1016/S0166-8641(96)00075-2
     name: The combinatorics of open covers II (Just et al)
 ---
@@ -15,10 +15,9 @@ refs:
 An uncountable subset of the reals such that its intersection with
 every nowhere dense subset of the reals (equivalently,
 every meager subset of the reals) is countable.
+The article {{zb:0389.54004}} is available at the [Topology Proceedings webpage]{https://topology.nipissingu.ca/tp/reprints/v01/tp01021s.pdf}.
 
 Note that the construction of such a set requires additional axioms beyond $ZFC$.
 
 Here we use the $CH$ construction from Lemma 2.6 of {{doi:10.1016/S0166-8641(96)00075-2}}
 in order to guarantee the failure of {P150}.
-See Theorem 2.8 and the implication $\mathsf S_1(\Omega,\Omega) \implies \mathsf U_{\mathrm{fin}}(\Gamma,\Omega)$
-from Figure 3, both from {{doi:10.1016/S0166-8641(96)00075-2}}.

--- a/spaces/S000147/README.md
+++ b/spaces/S000147/README.md
@@ -1,6 +1,6 @@
 ---
 uid: S000147
-name: (CH) A Luzin subset of the reals (Scheepers 1999)
+name: (CH) A Luzin subset of the reals (The special Lusin set $L$)
 aliases:
   - Lusin set
 ambiguous_construction: true
@@ -8,8 +8,8 @@ ambiguous_construction: true
 refs:
   - mr: 450063
     name: Luzin spaces
-  - mr: 1458261
-    name: Lusin sets (Scheepers)
+  - doi: 10.1016/S0166-8641(96)00075-2
+    name: The combinatorics of open covers II (Just et al)
 ---
 
 An uncountable subset of the reals such that its intersection with
@@ -18,5 +18,7 @@ every meager subset of the reals) is countable.
 
 Note that the construction of such a set requires additional axioms beyond $ZFC$.
 
-Here we use the $CH$ construction from Theorem 4 of {{mr:1458261}}
+Here we use the $CH$ construction from Lemma 2.6 of {{doi:10.1016/S0166-8641(96)00075-2}}
 in order to guarantee the failure of {P150}.
+See Theorem 2.8 and the implication $\mathsf S_1(\Omega,\Omega) \implies \mathsf U_{\mathrm{fin}}(\Gamma,\Omega)$
+from Figure 3, both from {{doi:10.1016/S0166-8641(96)00075-2}}.

--- a/spaces/S000147/properties/P000150.md
+++ b/spaces/S000147/properties/P000150.md
@@ -3,9 +3,9 @@ space: S000147
 property: P000150
 value: false
 refs:
-- mr: 1458261
-  name: Lusin sets (Scheepers)
+  - doi: 10.1016/S0166-8641(96)00075-2
+    name: The combinatorics of open covers II (Just et al)
 ---
 
-Shown in the proof of Theorem 4 of {{mr:1458261}}
-for this particular construction.
+See Theorem 2.8 and the implication $\mathsf S_1(\Omega,\Omega) \implies \mathsf U_{\mathrm{fin}}(\Gamma,\Omega)$
+from Figure 3, both from {{doi:10.1016/S0166-8641(96)00075-2}}.

--- a/spaces/S000148/README.md
+++ b/spaces/S000148/README.md
@@ -1,6 +1,6 @@
 ---
 uid: S000148
-name: (CH) A Luzin subset of the reals (Just et al 1996)
+name: (CH) A Luzin subset of the reals (The generic Lusin set $H$)
 aliases:
   - Lusin subset of the reals
 ambiguous_construction: true

--- a/spaces/S000148/README.md
+++ b/spaces/S000148/README.md
@@ -15,7 +15,7 @@ refs:
 An uncountable subset of the reals such that its intersection with
 every nowhere dense subset of the reals (equivalently,
 every meager subset of the reals) is countable.
-The article {{zb:0389.54004}} is available at the [Topology Proceedings webpage](https://topology.nipissingu.ca/tp/reprints/v01/tp01021s.pdf).
+For background information, see the article {{zb:0389.54004}}, available at the [Topology Proceedings webpage](https://topology.nipissingu.ca/tp/reprints/v01/tp01021s.pdf).
 
 Note that the construction of such a set requires additional axioms beyond $ZFC$.
 

--- a/spaces/S000148/README.md
+++ b/spaces/S000148/README.md
@@ -15,7 +15,7 @@ refs:
 An uncountable subset of the reals such that its intersection with
 every nowhere dense subset of the reals (equivalently,
 every meager subset of the reals) is countable.
-The article {{zb:0389.54004}} is available at the [Topology Proceedings webpage]{https://topology.nipissingu.ca/tp/reprints/v01/tp01021s.pdf}.
+The article {{zb:0389.54004}} is available at the [Topology Proceedings webpage](https://topology.nipissingu.ca/tp/reprints/v01/tp01021s.pdf).
 
 Note that the construction of such a set requires additional axioms beyond $ZFC$.
 

--- a/spaces/S000148/README.md
+++ b/spaces/S000148/README.md
@@ -6,8 +6,8 @@ aliases:
 ambiguous_construction: true
 # additional_axioms: CH
 refs:
-  - mr: 450063
-    name: Luzin spaces
+  - zb: 0389.54004
+    name: Luzin spaces (K. Kunen)
   - doi: 10.1016/S0166-8641(96)00075-2
     name: The combinatorics of open covers II (Just et al)
 ---
@@ -15,6 +15,7 @@ refs:
 An uncountable subset of the reals such that its intersection with
 every nowhere dense subset of the reals (equivalently,
 every meager subset of the reals) is countable.
+The article {{zb:0389.54004}} is available at the [Topology Proceedings webpage]{https://topology.nipissingu.ca/tp/reprints/v01/tp01021s.pdf}.
 
 Note that the construction of such a set requires additional axioms beyond $ZFC$.
 


### PR DESCRIPTION
- I've added a link to the Sorgenfrey line in the definition of the Sorgenfrey plane.
- I've updated the two Luzin sets after looking at the original references. The Scheepers 1999 reference discusses these K_Omega covers which don't have to be open covers of a space; their closures have to cover the space. The originally referenced Theorem 4 mentions clopen covers resulting from a construction in a previous paper. Since the K_Omega covers need not be open covers, I've updated the reference to Just et all 1996 where they explicitly prove that the set they construct fails to have the omega-Rothberger property.