### PR TITLE
T396: update to totally separated

### DIFF
--- a/properties/P000047.md
+++ b/properties/P000047.md
@@ -1,11 +1,17 @@
 ---
 uid: P000047
 name: Totally disconnected
+aliases:
+  - Hereditarily disconnected
 refs:
   - doi: 10.1007/978-1-4612-6290-9
     name: Counterexamples in Topology
+  - zb: "0684.54001"
+    name: General Topology (Engelking, 1989)
 ---
 
 All connected components of the space are singletons.
 
 Defined on page 32 of {{doi:10.1007/978-1-4612-6290-9}}.
+
+Some authors (for example {{zb:0684.54001}}) use "totally disconnected" to mean {P48} and "hereditarily disconnected" to mean {P47}.

--- a/properties/P000048.md
+++ b/properties/P000048.md
@@ -1,9 +1,13 @@
 ---
 uid: P000048
 name: Totally separated
+aliases:
+  - Totally disconnected
 refs:
   - doi: 10.1007/978-1-4612-6290-9
     name: Counterexamples in Topology
+  - zb: "0684.54001"
+    name: General Topology (Engelking, 1989)
 ---
 
 Given any two distinct points $x,y \in X$, there exists a clopen subset $A\subseteq X$ such that
@@ -11,4 +15,4 @@ $x\in A$ and $y\not\in A$.
 
 Defined on page 32 of {{doi:10.1007/978-1-4612-6290-9}}.
 
-Some authors use the terminology "totally disconnected" for this property.
+Some authors (for example {{zb:0684.54001}}) use "totally disconnected" to mean {P48} and "hereditarily disconnected" to mean {P47}.

--- a/properties/P000048.md
+++ b/properties/P000048.md
@@ -10,3 +10,5 @@ Given any two distinct points $x,y \in X$, there exists a clopen subset $A\subse
 $x\in A$ and $y\not\in A$.
 
 Defined on page 32 of {{doi:10.1007/978-1-4612-6290-9}}.
+
+Some authors use the terminology "totally disconnected" for this property.

--- a/theorems/T000396.md
+++ b/theorems/T000396.md
@@ -5,10 +5,10 @@ if:
     - P000147: true
     - P000009: true
 then:
-  P000047: true
+  P000048: true
 refs:
 - doi: 10.1016/0016-660x(72)90026-8
   name: A topological view of P-spaces (A. Misra)
 ---
 
-See corollary 5.2 in {{doi:10.1016/0016-660x(72)90026-8}}.
+See Corollary 5.2 in {{doi:10.1016/0016-660x(72)90026-8}} (where "totally disconnected" is used with the meaning of {P48}).


### PR DESCRIPTION
- old T396: P-space + functionally Hausdorff ==> totally disconnected
- new t396: P-space + functionally Hausdorff ==> totally separated

Added one sentence to P48 to indicate that some authors use "totally disconnected" to mean what we call "totally separated".  Engelking is one of them, plus various recent papers as well.  And they usually call "hereditarily disconnected" what we call "totally disconnected".  If you guys think we should also mention that, it can be added.
