### PR TITLE
First countable aleph_0 spaces are metrizable

### DIFF
--- a/theorems/T000515.md
+++ b/theorems/T000515.md
@@ -1,0 +1,14 @@
+---
+uid: T000515
+if:
+  and:
+    - P000179: true
+    - P000028: true
+then:
+  P000053: true
+refs:
+- zb: "0148.16701"
+  name: $\aleph_0$-spaces (E. Michael)
+---
+
+See result (B) in {{zb:0148.16701}} (<https://www.jstor.org/stable/24901448>).

--- a/theorems/T000516.md
+++ b/theorems/T000516.md
@@ -1,0 +1,14 @@
+---
+uid: T000516
+if:
+  and:
+    - P000179: true
+    - P000023: true
+then:
+  P000053: true
+refs:
+- zb: "0148.16701"
+  name: $\aleph_0$-spaces (E. Michael)
+---
+
+See result (C) in {{zb:0148.16701}} (<https://www.jstor.org/stable/24901448>).

--- a/theorems/T000516.md
+++ b/theorems/T000516.md
@@ -3,7 +3,7 @@ uid: T000516
 if:
   and:
     - P000179: true
-    - P000023: true
+    - P000028: true
 then:
   P000053: true
 refs:
@@ -11,4 +11,4 @@ refs:
   name: $\aleph_0$-spaces (E. Michael)
 ---
 
-See result (C) in {{zb:0148.16701}} (<https://www.jstor.org/stable/24901448>).
+See result (B) in {{zb:0148.16701}} (<https://www.jstor.org/stable/24901448>).

--- a/theorems/T000517.md
+++ b/theorems/T000517.md
@@ -1,9 +1,9 @@
 ---
-uid: T000515
+uid: T000517
 if:
   and:
     - P000179: true
-    - P000028: true
+    - P000023: true
 then:
   P000053: true
 refs:
@@ -11,4 +11,4 @@ refs:
   name: $\aleph_0$-spaces (E. Michael)
 ---
 
-See result (B) in {{zb:0148.16701}} (<https://www.jstor.org/stable/24901448>).
+See result (C) in {{zb:0148.16701}} (<https://www.jstor.org/stable/24901448>).


### PR DESCRIPTION
- T515: $\aleph_0$-space + first countable ==> metrizable
- T516: $\aleph_0$-space + weakly locally compact ==> metrizable

It is in fact more generally true that [ $\aleph$-space + first countable ==> metrizable].  This is due to O'Meara and shown for example in Theorem 11.4 of Gruenhage's survey article https://zbmath.org/0555.54015.  But the proof there seems quite involved, making use of many concepts not known to pi-base.  So I'd prefer not to add it to pi-base at the moment.  Hope that can be an incentive to gradually add more properties so that this would become understandable, to me at least :-)