### PR TITLE
R1 and Locally pseudometrizable imply Quasi-sober

### DIFF
--- a/properties/P000192.md
+++ b/properties/P000192.md
@@ -9,4 +9,6 @@ refs:
 Every nonempty irreducible closed subset of $X$ is the closure of a point of $X$, not necessarily unique; that is, every nonempty irreducible closed subset has at least one *generic point*.
 Here, a subset of $X$ is called *irreducible* if it is {P39} with the subspace topology.
 
+Equivalently, the Kolmogorov quotient of the space is {P73}. (See {T512}.)
+
 See for example Definition 5.8.6 in the section on [Irreducible components](https://stacks.math.columbia.edu/tag/004U) from the Stacks project, or the paragraph after Definition 1.2 in {{doi:10.35834/mjms/1316032836}}.

--- a/theorems/T000519.md
+++ b/theorems/T000519.md
@@ -7,5 +7,5 @@ then:
 ---
 
 The Kolmogorov quotient of a {P134} space is {P3},
-and [Hausdorff spaces are sober](https://topology.pi-base.org/spaces?q=%24T_2%24%2B%7ESober).
+which in turn implies {P73} [(Explore)](https://topology.pi-base.org/spaces?q=%24T_2%24%2B%7ESober).
 Thus, the unquotiented space is {P192}.

--- a/theorems/T000519.md
+++ b/theorems/T000519.md
@@ -6,5 +6,4 @@ then:
   P000192: true
 ---
 
-The nonempty irreducible closed sets in a {P185} space are precisely the elements of the partition,
-and the closure of any point in a partition element is the partition element itself.
+The Kolmogorov quotient of a {P134} space is {P3}, which implies {P73} via {T193} and {T173}. Thus, the unquotiented space is {P192}.

--- a/theorems/T000519.md
+++ b/theorems/T000519.md
@@ -6,4 +6,6 @@ then:
   P000192: true
 ---
 
-The Kolmogorov quotient of a {P134} space is {P3}, which implies {P73} via {T193} and {T173}. Thus, the unquotiented space is {P192}.
+The Kolmogorov quotient of a {P134} space is {P3},
+and [Hausdorff spaces are sober](https://topology.pi-base.org/spaces?q=%24T_2%24%2B%7ESober).
+Thus, the unquotiented space is {P192}.

--- a/theorems/T000519.md
+++ b/theorems/T000519.md
@@ -1,0 +1,10 @@
+---
+uid: T000519
+if:
+  P000185: true
+then:
+  P000192: true
+---
+
+The nonempty irreducible closed sets in a {P185} space are precisely the elements of the partition,
+and the closure of any point in a partition element is the partition element itself.

--- a/theorems/T000519.md
+++ b/theorems/T000519.md
@@ -1,7 +1,7 @@
 ---
 uid: T000519
 if:
-  P000185: true
+  P000134: true
 then:
   P000192: true
 ---

--- a/theorems/T000521.md
+++ b/theorems/T000521.md
@@ -6,4 +6,6 @@ then:
   P000192: true
 ---
 
-The Kolmogorov quotient of a {P144} space is {P82}, which implies {P73} via {T328} and {T173}. Thus, the unquotiented space is {P192}.
+The Kolmogorov quotient of a {P144} space is {P82}, 
+and [Locally metrizable spaces are sober](https://topology.pi-base.org/spaces?q=Locally+metrizable%2B%7ESober).
+Thus, the unquotiented space is {P192}.

--- a/theorems/T000521.md
+++ b/theorems/T000521.md
@@ -6,6 +6,6 @@ then:
   P000192: true
 ---
 
-The Kolmogorov quotient of a {P144} space is {P82}, 
-and [Locally metrizable spaces are sober](https://topology.pi-base.org/spaces?q=Locally+metrizable%2B%7ESober).
+The Kolmogorov quotient of a {P144} space is {P82},
+which in turn implies {P73} [(Explore)](https://topology.pi-base.org/spaces?q=Locally+metrizable%2B%7ESober).
 Thus, the unquotiented space is {P192}.

--- a/theorems/T000521.md
+++ b/theorems/T000521.md
@@ -1,0 +1,9 @@
+---
+uid: T000521
+if:
+  P000144: true
+then:
+  P000192: true
+---
+
+The Kolmogorov quotient of a {P144} space is {P82}, which implies {P73} via {T328} and {T173}. Thus, the unquotiented space is {P192}.


### PR DESCRIPTION
Adds theorem T519 [Partition topology](https://topology.pi-base.org/properties/P000185) ⇒ [Quasi-sober](https://topology.pi-base.org/properties/P000192). I also added a line to the definition of Quasi-sober that it is equivalent to the Kolmogorov quotient of the space being Sober.