### PR TITLE
GO-space + ~totally disconnected => has compacta of cardinality >= c

### DIFF
--- a/theorems/T000527.md
+++ b/theorems/T000527.md
@@ -1,0 +1,14 @@
+---
+uid: T000527
+if:
+  and:
+    - P000154: true
+    - P000136: true
+then:
+  P000047: true
+refs:
+- wikipedia: Linear_continuum
+  name: Linear continuum on Wikipedia
+---
+
+Let $Y$ be a {P36} subset with more than one point. By {T131}, it is a linear continuum (i.e., a {P36} {P133}) with respect to the order in the definition of {P154}, meaning that every nontrivial closed interval of $Y$, which has cardinality $\ge\mathfrak{c}$ by {T80} and {T309}, is {P16}.


### PR DESCRIPTION
There is no such property as "has compacta of cardinality $\ge\mathfrak{c}$" in the database, so it must be replaced (sadly) by the weaker property ~anticompact.

I stated in a positive way GO-space + anticompact $\Rightarrow$ totally disconnected, but I would prefer the other way GO-space + ~totally disconnected $\Rightarrow$ ~anticompact: as I stated above, the "~anticompact" can be replaced by "has compacta of cardinality >= c". Your opinions?