### PR TITLE
Ultraconnected implies sigma-connected

### DIFF
--- a/theorems/T000320.md
+++ b/theorems/T000320.md
@@ -1,0 +1,8 @@
+---
+uid: T000320
+if:
+  P000040: true
+then:
+  P000189: true
+---
+By definition, an ultraconnected space cannot be partitioned into disjoint closed sets.


### PR DESCRIPTION
New theorem that [P40](https://topology.pi-base.org/properties/P000040) Ultraconnected implies [P189](https://topology.pi-base.org/properties/P000189) σ-connected.