### PR TITLE
Real numbers extended by a point with co-countable open neighborhoods has a countable k-network.

### DIFF
--- a/spaces/S000140/properties/P000183.md
+++ b/spaces/S000140/properties/P000183.md
@@ -1,0 +1,12 @@
+---
+space: S000140
+property: P000183
+value: true
+refs:
+- mathse: 4854178
+  name: What are the compactness properties of $\mathbb{R}$, extended by a point with co-countable open neighborhoods?
+---
+
+A subset $K$ of $X$ is compact if and only if $K \cap \mathbb{R}$ is compact in the Euclidean topology on $\mathbb{R}$ (see {{mathse:4854178}}).
+
+Let $\mathcal{N}$ be a countable $k$-network of $\mathbb{R}$ with the Euclidean topology, $\mathcal{N} \cup \{\infty\}$ is a countable $k$-network of $X$.

--- a/spaces/S000140/properties/P000183.md
+++ b/spaces/S000140/properties/P000183.md
@@ -11,6 +11,6 @@ refs:
 
 The compact subsets of $X=\mathbb R\cup\{\infty\}$ are precisely the sets of the form $K$ or $K\cup\{\infty\}$ with $K$ compact in $\mathbb R$ (see {{mathse:4854178}}).
 
-Let $\mathcal{N}$ be a countable $k$-network of $\mathbb{R}$ with the Euclidean topology, for example a countable base for the topology.  Then it is easy to check that the countable collection consisting of all the elements of $\mathcal N$ and the singleton $\{\infty\}$ is a $k$-network for $X$.
+Let $\mathcal{N}$ be a countable $k$-network of $\mathbb{R}$ with the Euclidean topology, for example a countable base for the topology. Then it is easy to check that the countable collection consisting of all the elements of $\mathcal N$ and the singleton $\{\infty\}$ is a $k$-network for $X$.
 
 See {{mathse:4972337}}.

--- a/spaces/S000140/properties/P000183.md
+++ b/spaces/S000140/properties/P000183.md
@@ -5,8 +5,12 @@ value: true
 refs:
 - mathse: 4854178
   name: What are the compactness properties of $\mathbb{R}$, extended by a point with co-countable open neighborhoods?
+- mathse: 4972337
+  name: Pseudocharacter of $T_1$ spaces with a countable k-network
 ---
 
-A subset $K$ of $X$ is compact if and only if $K \cap \mathbb{R}$ is compact in the Euclidean topology on $\mathbb{R}$ (see {{mathse:4854178}}).
+The compact subsets of $X=\mathbb R\cup\{\infty\}$ are precisely the sets of the form $K$ or $K\cup\{\infty\}$ with $K$ compact in $\mathbb R$ (see {{mathse:4854178}}).
 
-Let $\mathcal{N}$ be a countable $k$-network of $\mathbb{R}$ with the Euclidean topology, $\mathcal{N} \cup \{\infty\}$ is a countable $k$-network of $X$.
+Let $\mathcal{N}$ be a countable $k$-network of $\mathbb{R}$ with the Euclidean topology, for example a countable base for the topology.  Then it is easy to check that the countable collection consisting of all the elements of $\mathcal N$ and the singleton $\{\infty\}$ is a $k$-network for $X$.
+
+See {{mathse:4972337}}.


### PR DESCRIPTION
Has a countable $k$-network + $T_1$ doesn't imply countable pseudocharacter.