### PR TITLE
S154 definition.

### DIFF
--- a/spaces/S000154/README.md
+++ b/spaces/S000154/README.md
@@ -12,7 +12,7 @@ refs:
     name: Fort space
 ---
 Let \(X=\mathbb{R}\cup\{\infty\}\).
-Define $U \subset X$ to open if its complement is finite or includes \(\infty\).
+Define $U \subset X$ to be open if its complement is finite or does not include \(\infty\).
 
 Defined as counterexample #24 ("Uncountable Fort Space")
 in {{doi:10.1007/978-1-4612-6290-9}}.

--- a/spaces/S000154/README.md
+++ b/spaces/S000154/README.md
@@ -11,8 +11,9 @@ refs:
   - wikipedia: Fort_space
     name: Fort space
 ---
-Let \(X=\mathbb{R}\cup\{\infty\}\).
-Define $U \subset X$ to be open if its complement is finite or does not include \(\infty\).
+Let $X=\mathbb R\cup\{\infty\}$. Every point of $\mathbb R$ is isolated and the open neighborhoods of the point $\infty$ are the cofinite subsets of $X$ containing that point.
+
+This space is the one-point compactification of an uncountable discrete space (compare with {S22} and {S20}).
 
 Defined as counterexample #24 ("Uncountable Fort Space")
 in {{doi:10.1007/978-1-4612-6290-9}}.


### PR DESCRIPTION
I got confused after reading the description of this space. That previous way, the space would be discrete.

$\\{\infty\\}$ would be open. And if $x \in X \setminus \\{\infty\\}$, then $\\{x\\} = (X \setminus \\{\infty\\}) \cap (\\{\infty, x\\})$, which is open.

In the first edition of Counterexamples in Topology, it is defined that way. Is it updated in the second edition?

Nevermind, I had misread it. It clearly meant that the complement* included $\\{infty\\}$.