### PR TITLE
S9 and S85 are not hereditarily separable

### DIFF
--- a/spaces/S000009/properties/P000180.md
+++ b/spaces/S000009/properties/P000180.md
@@ -1,0 +1,6 @@
+---
+space: S000009
+property: P000180
+value: false
+---
+$\mathbb R\setminus\{0\}$ is discrete, and {S3|P26}.

--- a/spaces/S000085/properties/P000180.md
+++ b/spaces/S000085/properties/P000180.md
@@ -1,0 +1,6 @@
+---
+space: S000085
+property: P000180
+value: false
+---
+The set of origins is a discrete subspace of cardinality $2^\mathfrak c$, which is not separable.


### PR DESCRIPTION
Adds that [S9](https://topology.pi-base.org/spaces/S000009) Particular Point Topology on the Real Numbers and [S85](https://topology.pi-base.org/spaces/S000085) Line with uncountably many origins are not [P180](https://topology.pi-base.org/properties/P000180) Hereditarily separable.