### PR TITLE
S144: Diamond poset with 4 elements

### DIFF
--- a/spaces/S000144/README.md
+++ b/spaces/S000144/README.md
@@ -1,0 +1,15 @@
+---
+uid: S000144
+name: Diamond poset $2\times 2$ with Alexandrov topology
+aliases:
+  - Four-element Boolean algebra with Alexandrov topology
+refs:
+  - wikipedia: Alexandrov_topology
+    name: Alexandrov topology on Wikipedia
+  - doi: 10.1016/j.jcta.2015.03.010
+    name: Diamond-free families (Griggs, Li & Lu)
+---
+
+Let $P=(\{0,a,b,1\},\le)$ be the four-element poset with $0$ as minimum element, $1$ as maximum element, and the remaining elements $a$ and $b$ incomparable.  This poset is order-isomorphic to the Boolean algebra with four elements.  The space $X$ is $P$ with the corresponding Alexandrov topology, whose open sets are the upper sets for $\le$.
+
+The name "diamond poset" is used for example in {{doi:10.1016/j.jcta.2015.03.010}}.

--- a/spaces/S000144/properties/P000001.md
+++ b/spaces/S000144/properties/P000001.md
@@ -1,0 +1,10 @@
+---
+space: S000144
+property: P000001
+value: true
+refs:
+- wikipedia: Alexandrov_topology
+  name: Alexandrov topology on Wikipedia
+---
+
+By construction of the Alexandrov topology from a poset.

--- a/spaces/S000144/properties/P000039.md
+++ b/spaces/S000144/properties/P000039.md
@@ -1,0 +1,7 @@
+---
+space: S000144
+property: P000039
+value: true
+---
+
+The maximum point $1$ belongs to every nonempty open set.

--- a/spaces/S000144/properties/P000040.md
+++ b/spaces/S000144/properties/P000040.md
@@ -1,0 +1,7 @@
+---
+space: S000144
+property: P000040
+value: true
+---
+
+The minimum point $0$ belongs to every nonempty closed set.

--- a/spaces/S000144/properties/P000078.md
+++ b/spaces/S000144/properties/P000078.md
@@ -1,0 +1,7 @@
+---
+space: S000144
+property: P000078
+value: true
+---
+
+By construction.

--- a/spaces/S000144/properties/P000176.md
+++ b/spaces/S000144/properties/P000176.md
@@ -1,0 +1,7 @@
+---
+space: S000144
+property: P000176
+value: true
+---
+
+By construction.

--- a/spaces/S000144/properties/P000196.md
+++ b/spaces/S000144/properties/P000196.md
@@ -1,0 +1,7 @@
+---
+space: S000144
+property: P000196
+value: false
+---
+
+The subset $\{a,b\}$ is not connected.


### PR DESCRIPTION
S144: Diamond poset with 4 elements and Alexandrov topology.

Provides an example of hyperconnected and ultraconnected space that is not hereditarily connected:
https://topology.pi-base.org/spaces?q=Hyperconnected%2BUltraconnected%2B%7EHereditarily+connected

I did not add the property "Cardinality $\geq 5$", because we don't have any theorem that needs it for now.

Door = false for this space. I did not add it, because I have a feeling that it will fall out of some later theorems regarding "almost discrete" and ultraconnected, as @danflapjax indicated.

---

Closes #814