### PR TITLE
Fix build problem (problems in T584)

### DIFF
--- a/theorems/T000584.md
+++ b/theorems/T000584.md
@@ -1,9 +1,9 @@
 ---
 uid: T000584
 if:
-  and
-   - P000129: true
-   - P000137: false
+  and:
+  - P000129: true
+  - P000137: false
 then:
   P000199: true
 ---


### PR DESCRIPTION
There was a build problem due to incorrectly formatted T584 (missing colon after "and").  I could not check it by cloning the branch from #832 for some reason (will ask at next zoom meeting).

@StevenClontz can you approve?

@GeoffreySangston FYI