### PR TITLE
Strengthen T568

### DIFF
--- a/spaces/S000145/properties/P000136.md
+++ b/spaces/S000145/properties/P000136.md
@@ -1,8 +1,0 @@
----
-space: S000145
-property: P000136
-value: true
----
-
-Suppose by contradiction that $A$ is an infinite compact subset of $X$.  Write $A=B\cup C$ with $B,C$ infinite and disjoint.  These two sets cannot both belong to $\mathscr U$.  Say $B\notin\mathscr U$.  The set $B$ is closed in $X$, hence closed in $A$ and compact.
-Every nonempty $D\subseteq B$ is also not in $\mathscr U$, hence closed in $X$.  So $B$ has the discrete topology.  But an infinite discrete space cannot be compact.

--- a/theorems/T000568.md
+++ b/theorems/T000568.md
@@ -6,9 +6,6 @@ if:
   - P000039: true
 then:
   P000136: true
-refs:
-- zb: "1400.39025"
-  name: Connected door spaces and topological solutions of equations (Wu, Wang, Zhang)
 ---
 Suppose by contradiction that $A$ is an infinite compact subset of $X$.  Write $A=B\cup C$ with $B,C$ infinite and disjoint.
 Because $X$ is {P39}, it is not possible that each of $B$ and $C$ contains a nonempty open subset of $X$.

--- a/theorems/T000568.md
+++ b/theorems/T000568.md
@@ -8,6 +8,6 @@ then:
   P000136: true
 ---
 Suppose by contradiction that $A$ is an infinite compact subset of $X$.  Write $A=B\cup C$ with $B,C$ infinite and disjoint.
-Because $X$ is {P39}, it is not possible that each of $B$ and $C$ contains a nonempty open subset of $X$.
+Because $X$ is {P39}, it is not possible that $B$ and $C$ each contain a nonempty open subset of $X$.
 So at least one of the two sets, say $B$, has all its subsets closed in $X$ by the {P126} property.
 Therefore $B$ has the discrete topology.  But $B$ is also closed in $A$, hence compact, which is not possible.

--- a/theorems/T000568.md
+++ b/theorems/T000568.md
@@ -4,12 +4,12 @@ if:
   and:
   - P000126: true
   - P000039: true
-  - P000090: true
 then:
-  P000094: true
+  P000136: true
 refs:
 - zb: "1400.39025"
   name: Connected door spaces and topological solutions of equations (Wu, Wang, Zhang)
 ---
-Per Theorem 1 of {{zb:1400.39025}}, a space satisfying the antecedent has an included point topology $\mathcal T=\{U\subseteq X\mid p\in U\}\cup\{\varnothing\}$ for some $p\in X$.
-Such a space admits a basis of finite sets $\{\{x,p\}\mid x\in X\}$.
+Per Theorem 1 of {{zb:1400.39025}}, a space $X$ satisfying the antecedent has a topology $\mathcal T$ such that $\mathscr U=\mathcal T\setminus\{\varnothing\}$ is an ultrafilter on $X$.
+Suppose by contradiction that $A$ is an infinite compact subset of $X$.  Write $A=B\cup C$ with $B,C$ infinite and disjoint.  These two sets cannot both belong to $\mathscr U$.  Say $B\notin\mathscr U$.  The set $B$ is closed in $X$, hence closed in $A$ and compact.
+Every nonempty $D\subseteq B$ is also not in $\mathscr U$, hence closed in $X$.  So $B$ has the discrete topology.  But an infinite discrete space cannot be compact.

--- a/theorems/T000568.md
+++ b/theorems/T000568.md
@@ -10,6 +10,7 @@ refs:
 - zb: "1400.39025"
   name: Connected door spaces and topological solutions of equations (Wu, Wang, Zhang)
 ---
-Per Theorem 1 of {{zb:1400.39025}}, a space $X$ satisfying the antecedent has a topology $\mathcal T$ such that $\mathscr U=\mathcal T\setminus\{\varnothing\}$ is an ultrafilter on $X$.
-Suppose by contradiction that $A$ is an infinite compact subset of $X$.  Write $A=B\cup C$ with $B,C$ infinite and disjoint.  These two sets cannot both belong to $\mathscr U$.  Say $B\notin\mathscr U$.  The set $B$ is closed in $X$, hence closed in $A$ and compact.
-Every nonempty $D\subseteq B$ is also not in $\mathscr U$, hence closed in $X$.  So $B$ has the discrete topology.  But an infinite discrete space cannot be compact.
+Suppose by contradiction that $A$ is an infinite compact subset of $X$.  Write $A=B\cup C$ with $B,C$ infinite and disjoint.
+Because $X$ is {P39}, it is not possible that each of $B$ and $C$ contains a nonempty open subset of $X$.
+So at least one of the two sets, say $B$, has all its subsets closed in $X$ by the {P126} property.
+Therefore $B$ has the discrete topology.  But $B$ is also closed in $A$, hence compact, which is not possible.


### PR DESCRIPTION
This improves T568, adapting the proof for anticompact from #831.