### PR TITLE
P83: Meta-Lindelof property

### DIFF
--- a/properties/P000083.md
+++ b/properties/P000083.md
@@ -1,0 +1,15 @@
+---
+uid: P000083
+name: Meta-Lindelöf
+refs:
+- zb: "1059.54001"
+  name: Encyclopedia of general topology
+---
+
+Every open cover of $X$ has a point-countable open refinement.
+
+(A collection $\mathscr V$ of subsets of $X$ is *point-countable* if each point $x\in X$ belongs to at most countably many elements of $\mathscr V$.)
+
+Defined on page 200 of {{zb:1059.54001}}.
+
+See also <https://dantopology.wordpress.com/2022/10/29/examples-of-meta-lindelof-spaces/>.

--- a/theorems/T000024.md
+++ b/theorems/T000024.md
@@ -2,16 +2,10 @@
 uid: T000024
 if:
   and:
-  - P000031: true
+  - P000083: true
   - P000026: true
 then:
   P000018: true
-refs:
-- mr: 1416131
-  name: General topology III (Arkhangelʹskiĭ)
 ---
 
-Let $X$ be separable and metacompact. If $\{U_\alpha\}$ is an open cover with no countable subcover, let $\{V_\beta\}$ be a point finite refinement. Then $\{V_\beta\}$ is uncountable and so some point of the countable dense set is in uncountably many $V_\beta$.
-
-Asserted in 2.2 of {{mr:1416131}}
-(where Lindelof is called "finally compact").
+See Theorem 1 in <https://dantopology.wordpress.com/2022/10/29/examples-of-meta-lindelof-spaces/>.  The proof does not make use of any separation axiom.

--- a/theorems/T000024.md
+++ b/theorems/T000024.md
@@ -6,6 +6,9 @@ if:
   - P000026: true
 then:
   P000018: true
+refs:
+- mathse: 1095781
+  name: Answer to "Does separability imply the Lindelöf property?"
 ---
 
-See Theorem 1 in <https://dantopology.wordpress.com/2022/10/29/examples-of-meta-lindelof-spaces/>.  The proof does not make use of any separation axiom.
+See {{mathse:1095781}} or Theorem 1 in <https://dantopology.wordpress.com/2022/10/29/examples-of-meta-lindelof-spaces/>.

--- a/theorems/T000586.md
+++ b/theorems/T000586.md
@@ -1,0 +1,9 @@
+---
+uid: T000586
+if:
+  P000031: true
+then:
+  P000083: true
+---
+
+Evident from the definitions.

--- a/theorems/T000587.md
+++ b/theorems/T000587.md
@@ -1,0 +1,9 @@
+---
+uid: T000587
+if:
+  P000018: true
+then:
+  P000083: true
+---
+
+Evident from the definitions, as a countable cover is point-countable.


### PR DESCRIPTION
I have seen all three of "meta-Lindelöf", "metaLindelöf", "metalindelöf" used in the literature, with "meta-Lindelöf" maybe slightly more common. 
Did not add the others as aliases, because searching for "metalindelof" already returns the right thing due to the fuzzy matching.
