### PR TITLE
Add property that there is a point whose only neighborhood is X

### DIFF
--- a/properties/P000202.md
+++ b/properties/P000202.md
@@ -1,0 +1,14 @@
+---
+uid: P000202
+name: Has a point with a trivial neighborhood filter
+refs:
+  - wikipedia: Specialization_(pre)order
+    name: Specialization (pre)order on Wikipedia
+---
+
+There exists a point $p\in X$ whose only neighborhood is the full space $X$.
+
+Equivalently:
+
+- $p$ is contained in all nonempty closed sets.
+- $p$ is a specialization of every point. See {{wikipedia:Specialization_(pre)order}}.

--- a/theorems/T000552.md
+++ b/theorems/T000552.md
@@ -2,10 +2,9 @@
 uid: T000552
 if:
   and:
-  - P000146: true
-  - P000036: true
+  - P000202: true
   - P000086: true
 then:
   P000129: true
 ---
-Any clopen partition of a {P36} space $X$ must contain $X$, so every open cover admitting a clopen partition as refinement must contain $X$. Thus, the union of all open sets except for $X$ cannot equal $X$ (as that would be an open cover not containing $X$), so some points have $X$ as their only neighborhood. By homogeneity, this must then be true of all points, i.e. the space is {P129}.
+If one point in a homogeneous space has $X$ as its only neighborhood, then the same is true of every point, so the space is indiscrete.

--- a/theorems/T000556.md
+++ b/theorems/T000556.md
@@ -4,7 +4,9 @@ if:
   and:
   - P000146: true
   - P000036: true
+  - P000137: false
 then:
-  P000020: true
+  P000202: true
 ---
-Any clopen partition of a {P36} space $X$ must contain $X$, so to admit clopen refinements every open cover must contain $X$. Thus, the union of all open sets except for $X$ cannot equal $X$ (as that would be an open cover not containing $X$), so any sequence converges to all points outside of that union (whose only neighborhood is $X$).
+Any clopen partition of a {P36} space $X$ must include $X$, so to admit clopen refinements every open cover must include $X$.
+Thus, the union of all open sets except for $X$ cannot equal $X$ (as that would be an open cover not containing $X$), so all points outside of that union have $X$ as their only neighborhood.

--- a/theorems/T000598.md
+++ b/theorems/T000598.md
@@ -1,0 +1,8 @@
+---
+uid: T000598
+if:
+  P000202: true
+then:
+  P000040: true
+---
+Every closed set must contain any point whose only neighborhood is $X$.

--- a/theorems/T000599.md
+++ b/theorems/T000599.md
@@ -1,0 +1,8 @@
+---
+uid: T000599
+if:
+  P000202: true
+then:
+  P000146: true
+---
+If the only neighborhood of a point is $X$, any open cover must include $X$ and therefore admits a refinement to the open partition $\{X\}$.

--- a/theorems/T000600.md
+++ b/theorems/T000600.md
@@ -1,0 +1,8 @@
+---
+uid: T000600
+if:
+  P000202: true
+then:
+  P000020: true
+---
+Any sequence converges to all points whose only neighborhood is $X$.

--- a/theorems/T000601.md
+++ b/theorems/T000601.md
@@ -1,0 +1,14 @@
+---
+uid: T000601
+if:
+  P000202: true
+then:
+  P000199: true
+refs:
+- mathse: 4993007
+  name: Is a path-connected space with a dispersion point necessarily contractible?
+---
+
+By assumption, there exists a point $p \in X$ whose only neighborhood is $X$. We argue that $F : X \times [0, 1] \to X$, defined by $$F(x, t) = \begin{cases} x & \text{if }t < 1\\ p & \text{if }t = 1\end{cases}$$ is continuous, hence is a homotopy between the identity map of $X$ and a constant map. Suppose $A \subset X$ is open. If $p \in A$, then $A = X$ and $F^{-1}(A) = X \times [0, 1]$. Otherwise, if $p \notin A$, then $F^{-1}(A) = A \times [0,1)$. Since $F^{-1}(A)$ is closed in both cases, it follows that $F$ is continuous.
+
+This construction appears at the end of David Gao's answer to {{mathse:4993007}}. This also appears as Lemma 2.3.2 in Peter May's [Finite spaces and larger contexts](https://math.uchicago.edu/~may/FINITE/FINITEBOOK/FINITEBOOKCollatedDraft.pdf).


### PR DESCRIPTION
Adds a property as discussed in #847. I think the main point of discussion left to be had is regarding the name of the property and listing of equivalent characterizations. I opted for "Has a point with a trivial neighborhood filter" as the name, but there were other ideas raised. Another idea that just came to mind would be something along the lines of "has a universal [closure point](https://en.wikipedia.org/wiki/Adherent_point)" in that such points are also closure points of any nonempty set.