### PR TITLE
T170 simplification

### DIFF
--- a/theorems/T000170.md
+++ b/theorems/T000170.md
@@ -7,20 +7,12 @@ if:
 then:
   P000034: true
 refs:
-  - doi: 10.1007/978-1-4612-6290-9
-    name: Counterexamples in Topology
   - mathse: 4862626
     name: Answer to "Fully normal implies paracompact without a $T_1$ assumption?"
   - mathse: 4969398
     name: Answer to "Showing that $R_1$ paracompact spaces are regular."
   - zb: "0684.54001"
     name: General Topology (Engelking, 1989)
----
-
-Figure 7 of {{doi:10.1007/978-1-4612-6290-9}} yields {P3} ∧ {P30} ⇒ {P35}, so the Kolmogorov quotient is {P35}.
-
-Then it is easily seen that {P34} is not affected by Kolmogorov quotient, therefore {P134} ∧ {P30} ⇒ {P34}.
-
 ---
 
 Follows from {{mathse:4969398}} ({P134} and {P30} imply {P11}), {{zb:0684.54001}} Theorem 5.1.5 ({P30} and {P11} imply {P13}) and {{mathse:4862626}} ({P13} and {P30} imply {P34}).


### PR DESCRIPTION
The removed reference just had a statement without justification.  The other cited references already provide a full argument.