### PR TITLE
Add two theorems to prove Markov Rothberger

### DIFF
--- a/theorems/T000612.md
+++ b/theorems/T000612.md
@@ -1,0 +1,13 @@
+---
+uid: T000612
+if:
+  and:
+  - P000090: true
+  - P000018: true
+then:
+  P000152: true
+---
+
+For an {P90} space, the set of smallest neighborhoods of points is an open cover.
+By {P18}, there is a countable subcover of these.
+This is in turn a cover by the smallest neighborhoods of a countable set of points, so {P152} holds.

--- a/theorems/T000613.md
+++ b/theorems/T000613.md
@@ -1,0 +1,9 @@
+---
+uid: T000613
+if:
+  P000202: true
+then:
+  P000152: true
+---
+
+A singleton whose only neighborhood is the entire space is a countable set as needed for {P152}.


### PR DESCRIPTION
6 additional spaces can now be shown to be Markov Rothberger.

Closes #877 