### PR TITLE
Add aliases to S139 and S201

### DIFF
--- a/spaces/S000139/README.md
+++ b/spaces/S000139/README.md
@@ -4,11 +4,14 @@ name: Countable bouquet of circles
 aliases:
 - $\mathbb R$ with $\mathbb Z$ collapsed to a point
 - Countable wedge sum of circles
+- Rose with infinitely many petals
 refs:
   - mathse: 4844916
     name: Answer to "Can a Fréchet-Urysohn hemicompact Hausdorff space fail to be locally compact?"
   - wikipedia: Wedge_sum
     name: Wedge sum on Wikipedia
+  - wikipedia: Rose_(topology)
+    name: Rose (topology) on Wikipedia
 ---
 
 Let $X=\mathbb R/\mathbb Z$ to be the quotient of $\mathbb R$ (with its Euclidean topology) obtained by identifying all the points of $\mathbb Z$ to a single point $\infty$.

--- a/spaces/S000139/README.md
+++ b/spaces/S000139/README.md
@@ -4,7 +4,7 @@ name: Countable bouquet of circles
 aliases:
 - $\mathbb R$ with $\mathbb Z$ collapsed to a point
 - Countable wedge sum of circles
-- Rose with infinitely many petals
+- Rose with countably infinite petals
 refs:
   - mathse: 4844916
     name: Answer to "Can a Fréchet-Urysohn hemicompact Hausdorff space fail to be locally compact?"

--- a/spaces/S000139/README.md
+++ b/spaces/S000139/README.md
@@ -19,4 +19,4 @@ Let $X=\mathbb R/\mathbb Z$ to be the quotient of $\mathbb R$ (with its Euclidea
 Alternatively, this space can be characterized as the *wedge sum*
 (see {{wikipedia:Wedge_sum}}) of countably-many circles,
 also known as a *bouquet of countably many circles*.
-Not to be confused with {S201}.
+Not to be confused with {S201}, which has a coarser topology.

--- a/spaces/S000201/README.md
+++ b/spaces/S000201/README.md
@@ -17,4 +17,4 @@ that is, the union of circles of radius $\frac{1}{n}$ centered at $(\frac{1}{n},
 integers $n$.
 
 Defined as "infinite earring" in section 71 of {{zb:0951.54001}}.
-Not to be confused with {S139}.
+Not to be confused with {S139}, which has a finer topology.

--- a/spaces/S000201/README.md
+++ b/spaces/S000201/README.md
@@ -16,5 +16,7 @@ $$X=\bigcup_{n=1}^{\infty}\left\{(x,y)\in\mathbb{R}^2:\left(x-\frac{1}{n}\right)
 that is, the union of circles of radius $\frac{1}{n}$ centered at $(\frac{1}{n},0)$ for positive
 integers $n$.
 
-Defined as "infinite earring" in section 71 of {{zb:0951.54001}}.
 Not to be confused with {S139}, which has a finer topology.
+
+Defined as "infinite earring" in section 71 of {{zb:0951.54001}}.
+Appears as Example 1.25 in {{Hatcher}} under the name "Shrinking wedge of circles"; however, note that it is not actually an example of a "wedge sum" as defined in e.g. {{wikipedia:Wedge_sum}}, {{doi:10.1007/978-1-4612-4576-6}}.

--- a/spaces/S000201/README.md
+++ b/spaces/S000201/README.md
@@ -19,4 +19,4 @@ integers $n$.
 Not to be confused with {S139}, which has a finer topology.
 
 Defined as "infinite earring" in section 71 of {{zb:0951.54001}}.
-Appears as Example 1.25 in {{Hatcher}} under the name "Shrinking wedge of circles"; however, note that it is not actually an example of a "wedge sum" as defined in e.g. {{wikipedia:Wedge_sum}}, {{doi:10.1007/978-1-4612-4576-6}}.
+Appears as Example 1.25 in {{zb:1044.55001}} (available [here](https://pi.math.cornell.edu/~hatcher/AT/ATpage.html)) under the name "Shrinking wedge of circles"; however, note that it is not actually an example of a "wedge sum" as defined in e.g. {{wikipedia:Wedge_sum}}, {{doi:10.1007/978-1-4612-4576-6}}.

--- a/spaces/S000201/README.md
+++ b/spaces/S000201/README.md
@@ -3,6 +3,7 @@ uid: S000201
 name: Infinite earring
 aliases:
 - Hawaiian earring
+- Shrinking wedge of circles
 refs:
 - wikipedia: Hawaiian_earring
   name: Hawaiian earring on Wikipedia


### PR DESCRIPTION
At #818, some alternate names for [S139](https://topology.pi-base.org/spaces/S000139) and [S201](https://topology.pi-base.org/spaces/S000201) were mentioned, and I figured it would be good to add them. I also added a few words to each description about how one has a finer topology than the other.