### PR TITLE
Symmetric as alias for R_0

### DIFF
--- a/properties/P000135.md
+++ b/properties/P000135.md
@@ -2,6 +2,7 @@
 uid: P000135
 name: $R_0$
 aliases:
+  - Symmetric
   - R0
 refs:
   - wikipedia: T1_space
@@ -10,9 +11,10 @@ refs:
     name: Handbook of Analysis and its Foundations (Schechter)
 ---
 
-Any of the following equivalent properties holds:
+Given any two topologically distinguishable points, each has a neighborhood not including the other point. (Two points are *topologically distinguishable* if there is an open set containing one of the points and not the other.)
 
-- Given any two topologically distinguishable points each has a neighborhood not including the other point. (Two points are topologically distinguishable if there is an open set containing one of the points and not the other.)
+Equivalently, any of the following equivalent properties holds:
+
 - The Kolmogorov quotient of the space is {P2}.
 - Every neighborhood of a point $x\in X$ contains $\operatorname{cl}\{x\}$.
 - Every open set is a union of closed sets.
@@ -21,4 +23,4 @@ Any of the following equivalent properties holds:
 
 See {{wikipedia:T1_space}} for a more extensive list.
 
-Also defined in definition 16.6, p. 438 of {{mr:1417259}} as "symmetric space". The $R_0$ terminology seems preferable to avoid confusion with symmetric spaces from Riemannian geometry.
+Also defined in definition 16.6, p. 438 of {{mr:1417259}} as "symmetric space". Not to be confused with symmetric spaces from Riemannian geometry.


### PR DESCRIPTION
$R_0$ (https://topology.pi-base.org/properties/P000135) already had "symmetric space" as an alternate name in the text.  Making it an alias for better accessibility.
