### PR TITLE
Line with two origins has fundamental group Z

### DIFF
--- a/spaces/S000083/properties/P000200.md
+++ b/spaces/S000083/properties/P000200.md
@@ -1,0 +1,10 @@
+---
+space: S000083
+property: P000200
+value: false
+refs:
+- mo: 25472
+  name: Fundamental group of the line with the double origin.
+---
+
+$\pi_1(X) \cong \mathbb{Z}$. See {{mo:25472}}.


### PR DESCRIPTION
There are several nice answers on the linked MO page.

In this PR I could also go ahead and add simply connected = false to [line with countably many origins](https://topology.pi-base.org/spaces/S000084) and [line with uncountably many origins](https://topology.pi-base.org/spaces/S000085) using (S83 | P200) and Hatcher Proposition 1.17, since inclusions $\mathrm{S83} \hookrightarrow \mathrm{S84}$ and $\mathrm{S83} \hookrightarrow \mathrm{S85}$ have retractions. Though I think I'd prefer just doing that in a separate PR since those are similar and slightly different from this one.

This will be the first non-simply connected pathconnected space besides the circle:
[π-Base, Search for `~Simply connected + Path connected`](https://topology.pi-base.org/spaces?q=%7ESimply+connected+%2B+Path+connected)