### PR TITLE
Butterfly space (S143) is not simply connected (P200)

### DIFF
--- a/spaces/S000143/properties/P000199.md
+++ b/spaces/S000143/properties/P000199.md
@@ -4,6 +4,6 @@ property: P000199
 value: true
 ---
 
-First, suppose $p$ is a point on the $x$-axis and consider a quarter of a circle in $X$ that is tangent to the $x$-axis at the point $p$ and which travels in the counterclockwise direction.  Because each "butterfly neighborhood" of $p$ intersects the quarter-circle in a half-open circular arc containing $p$, it is easy to check that a unit-speed arc starting at $p$ and following the circle counterclockwise is be continuous.
+First, suppose $p$ is a point on the $x$-axis and consider a quarter of a circle in $X$ that is tangent to the $x$-axis at the point $p$ and which travels in the counterclockwise direction.  Because each "butterfly neighborhood" of $p$ intersects the quarter-circle in a half-open circular arc containing $p$, it is easy to check that a unit-speed arc starting at $p$ and following the circle counterclockwise is continuous.
 
 Now choose a fixed radius $R$ and assemble all such circular paths of this radius into a deformation retraction onto the horizontal line $y = R$. Extend this to a deformation retraction onto the upper half plane $y \ge R$ which equals the identity on all points such that $y \ge R$. It follows that $X$ is homotopy equivalent to a contractible space, hence is contractible.

--- a/spaces/S000143/properties/P000199.md
+++ b/spaces/S000143/properties/P000199.md
@@ -4,6 +4,6 @@ property: P000199
 value: true
 ---
 
-First, suppose $p$ is a point on the $x$-axis and consider a quarter of a circle in $X$ that is tangent to the $x$-axis at the point $p$ and which travels in the counterclockwise direction.  Because "butterfly neighborhoods" of $p$ intersect the quarter-circle in a half-open circular arc containing $p$, it is easy to check that a unit-speed arc starting at $p$ and following the circle counterclockwise will be continuous.
+First, suppose $p$ is a point on the $x$-axis and consider a quarter of a circle in $X$ that is tangent to the $x$-axis at the point $p$ and which travels in the counterclockwise direction.  Because each "butterfly neighborhood" of $p$ intersects the quarter-circle in a half-open circular arc containing $p$, it is easy to check that a unit-speed arc starting at $p$ and following the circle counterclockwise is be continuous.
 
 Now choose a fixed radius $R$ and assemble all such circular paths of this radius into a deformation retraction onto the horizontal line $y = R$. Extend this to a deformation retraction onto the upper half plane $y \ge R$ which equals the identity on all points such that $y \ge R$. It follows that $X$ is homotopy equivalent to a contractible space, hence is contractible.

--- a/spaces/S000143/properties/P000199.md
+++ b/spaces/S000143/properties/P000199.md
@@ -4,6 +4,6 @@ property: P000199
 value: true
 ---
 
-First, suppose $p$ is a point on the $x$-axis and consider a quarter of a circle in $X$ that is tangent to the $x$-axis at the point $p$ and which travels in the counterclockwise direction.  Because each "butterfly neighborhood" of $p$ intersects the quarter-circle in a half-open circular arc containing $p$, it is easy to check that a unit-speed arc starting at $p$ and following the circle counterclockwise is continuous.
+First, suppose $p$ is a point on the $x$-axis and consider a quarter of a circle in $X$ that is tangent to the $x$-axis at the point $p$ and which travels in the counterclockwise direction.  Because each "butterfly neighborhood" of $p$ intersects the quarter-circle in a half-open circular arc containing $p$, it is easy to check that an arc starting at $p$ and following the circle counterclockwise is continuous.
 
-Now choose a fixed radius $R$ and assemble all such circular paths of this radius into a deformation retraction onto the horizontal line $y = R$. Extend this to a deformation retraction onto the upper half plane $y \ge R$ which equals the identity on all points such that $y \ge R$. It follows that $X$ is homotopy equivalent to a contractible space, hence is contractible.
+Now choose a fixed radius $R$ and assemble constant speed circular paths of this radius into a deformation retraction onto the horizontal line $y = R$. Extend this to a deformation retraction onto the upper half plane $y \ge R$ which equals the identity on all points such that $y \ge R$. It follows that $X$ is homotopy equivalent to a contractible space, hence is contractible.

--- a/spaces/S000143/properties/P000199.md
+++ b/spaces/S000143/properties/P000199.md
@@ -1,9 +1,0 @@
----
-space: S000143
-property: P000199
-value: true
----
-
-First, suppose $p$ is a point on the $x$-axis and consider a quarter of a circle in $X$ that is tangent to the $x$-axis at the point $p$ and which travels in the counterclockwise direction.  Because each "butterfly neighborhood" of $p$ intersects the quarter-circle in a half-open circular arc containing $p$, it is easy to check that an arc starting at $p$ and following the circle counterclockwise is continuous.
-
-Now choose a fixed radius $R$ and assemble constant speed circular paths of this radius into a deformation retraction onto the horizontal line $y = R$. Extend this to a deformation retraction onto the upper half plane $y \ge R$ which equals the identity on all points such that $y \ge R$. It follows that $X$ is homotopy equivalent to a contractible space, hence is contractible.

--- a/spaces/S000143/properties/P000199.md
+++ b/spaces/S000143/properties/P000199.md
@@ -1,0 +1,9 @@
+---
+space: S000143
+property: P000199
+value: true
+---
+
+First, suppose $p$ is a point on the $x$-axis and consider a quarter of a circle in $X$ that is tangent to the $x$-axis at the point $p$ and which travels in the counterclockwise direction.  Because "butterfly neighborhoods" of $p$ intersect the quarter-circle in a half-open circular arc containing $p$, it is easy to check that a unit-speed arc starting at $p$ and following the circle counterclockwise will be continuous.
+
+Now choose a fixed radius $R$ and assemble all such circular paths of this radius into a deformation retraction onto the horizontal line $y = R$. Extend this to a deformation retraction onto the upper half plane $y \ge R$ which equals the identity on all points such that $y \ge R$. It follows that $X$ is homotopy equivalent to a contractible space, hence is contractible.

--- a/spaces/S000143/properties/P000200.md
+++ b/spaces/S000143/properties/P000200.md
@@ -1,0 +1,10 @@
+---
+space: S000143
+property: P000200
+value: false
+refs:
+ - mathse: 4998216
+   name: Is the butterfly space contractible?
+---
+
+See {{mathse:4998216}}.


### PR DESCRIPTION
Some things need to be edited still. It would be nice instead of handwaving that the circular paths are continuous, to handwave that the quarter-circles have standard continuous deformation retractions onto the endpoints at $y = R$, which assemble into a deformation retraction onto the line $y = R$. 

I really don't know how to handwave this any better than that though, so suggestions are welcome. I'm unlikely to ask this on MSE since it frequently ends up being an unpleasant experience there for a dozen reasons and because I feel like I already know the argument. If that's what we want to do though, we should just close this PR and somebody else can go ahead.

And the arc connected trait can be deleted since the space is Hausdorff.