### PR TITLE
Consistent mathse/mo references

### DIFF
--- a/properties/P000131.md
+++ b/properties/P000131.md
@@ -6,10 +6,12 @@ refs:
     name: General Topology (Willard)
   - wikipedia: Lindelöf_space
     name: Lindelöf space
+  - mathse: 494918
+    name: Showing that if every open subspace is Lindelöf, then the space is hereditarily Lindelöf.
 ---
 
 A space for which every subspace is {P18}.  Equivalently, a space in which every open set is {P18}.
 
-The equivalence between the two is shown for example in <https://math.stackexchange.com/questions/494918>.
+The equivalence between the two is shown for example in {{mathse:494918}}.
 
 Defined in 16E of {{zb:1052.54001}}.

--- a/spaces/S000028/properties/P000066.md
+++ b/spaces/S000028/properties/P000066.md
@@ -3,8 +3,8 @@ space: S000028
 property: P000066
 value: false
 refs:
-- mathse: 4727296
-  name: Is every Lindelöf space Menger?
+- mathse: 4727297
+  name: Answer to "Is every Lindelöf space Menger?"
 ---
 
-See [this Math Stackexchange answer](https://math.stackexchange.com/a/4727297/176482) and [this entry in Dan Ma's topology blog](https://dantopology.wordpress.com/2020/02/18/the-space-of-irrational-numbers-is-not-menger/).
+See {{mathse:4727297}} and [this entry in Dan Ma's topology blog](https://dantopology.wordpress.com/2020/02/18/the-space-of-irrational-numbers-is-not-menger/).

--- a/spaces/S000029/properties/P000100.md
+++ b/spaces/S000029/properties/P000100.md
@@ -5,8 +5,10 @@ value: true
 refs:
 - doi: 10.2307/2312998
   name: When are Compact and Closed Equivalent?
+- mathse: 2524171
+  name: Are compact subsets closed in the one-point compactification of $\mathbb Q$?
 ---
 
 See Example 1, p. 43 in {{doi:10.2307/2312998}}.
 
-Also <https://math.stackexchange.com/questions/2524171/>
+Also {{mathse:2524171}}.

--- a/spaces/S000037/README.md
+++ b/spaces/S000037/README.md
@@ -4,10 +4,10 @@ name: $\omega_1+1$ with endpoint doubled
 aliases:
   - Successor to the first uncountable ordinal with endpoint doubled
 refs:
-  - mathse: 4267169
-    name: Relationship between weak Hausdorff and US properties
+  - mathse: 4268177
+    name: Answer to "Relationship between weak Hausdorff and US properties"
 ---
 
 Let $\omega_1$ be the first uncountable ordinal.  Take $\omega_1+1=[0,\omega_1]$ with its usual order topology and then split the maximum point into two points, similar to the construction of {S65}.  In other words, take $X=[0,\omega_1]\cup\{\omega'_1\}$ where sets of the form $(\beta,\omega_1)\cup\{\omega'_1\}$ with $\beta<\omega_1$ form a neighborhood basis at $\omega'_1$.
 
-See Example 1 in [this answer](https://math.stackexchange.com/a/4268177) to {{mathse:4267169}}.
+See Example 1 in {{mathse:4268177}}.

--- a/spaces/S000037/properties/P000099.md
+++ b/spaces/S000037/properties/P000099.md
@@ -3,8 +3,8 @@ space: S000037
 property: P000099
 value: true
 refs:
-- mathse: 4267169
-  name: Relationship between weak Hausdorff and US properties
+- mathse: 4268177
+  name: Answer to "Relationship between weak Hausdorff and US properties"
 ---
 
-See Example 1 in [this answer](https://math.stackexchange.com/a/4268177) to {{mathse:4267169}}.
+See Example 1 in {{mathse:4268177}}.

--- a/spaces/S000074/properties/P000132.md
+++ b/spaces/S000074/properties/P000132.md
@@ -7,4 +7,4 @@ refs:
   name: Moore plane/Niemytzki plane and the closed G-delta subspaces
 ---
 
-Shown in <https://math.stackexchange.com/questions/2711463>.
+Shown in {{mathse:2711463}}.

--- a/spaces/S000153/properties/P000086.md
+++ b/spaces/S000153/properties/P000086.md
@@ -5,8 +5,8 @@ value: true
 refs:
 - mathse: 1641524
   name: Homogeneous space minus a point
-- mo: 314611
-  name: Is every uncountable, homogeneous connected T2-space isomorphic to a subspace of R^ω?
+- mo: 314665
+  name: Answer to "Is every uncountable, homogeneous connected T2-space isomorphic to a subspace of $\mathbb R^\omega$?"
 ---
 
-See {{mathse:1641524}}.  Also, [this answer](https://mathoverflow.net/a/314665) to {{mo:314611}}.
+See {{mathse:1641524}}.  Also, {{mo:314665}}.

--- a/spaces/S000165/README.md
+++ b/spaces/S000165/README.md
@@ -6,4 +6,6 @@ refs:
     name: Answer to ""All retracts are closed" and "all compacts are closed""
 ---
 
-The one-point compactification $X$ of {S23}.  See [this answer](https://mathoverflow.net/a/435257) to {{mo:435257}}.
+The one-point compactification $X$ of {S23}.
+
+See {{mo:435257}}.

--- a/spaces/S000165/properties/P000143.md
+++ b/spaces/S000165/properties/P000143.md
@@ -9,4 +9,4 @@ refs:
 
 Let $0$ be the non-isolated point of the {S23}.  The subspace $A=X\setminus\{0\}$ is homeomorphic to the one-point compactification of a discrete space (i.e., {S20}), which is compact and Hausdorff.  But $A$ is not closed in $X$.
 
-See {{mathse:435257}}.
+See {{mo:435257}}.

--- a/spaces/S000165/properties/P000143.md
+++ b/spaces/S000165/properties/P000143.md
@@ -9,4 +9,4 @@ refs:
 
 Let $0$ be the non-isolated point of the {S23}.  The subspace $A=X\setminus\{0\}$ is homeomorphic to the one-point compactification of a discrete space (i.e., {S20}), which is compact and Hausdorff.  But $A$ is not closed in $X$.
 
-See [this answer](https://mathoverflow.net/a/435257) to {{mo:435257}}.
+See {{mathse:435257}}.

--- a/spaces/S000182/README.md
+++ b/spaces/S000182/README.md
@@ -2,8 +2,10 @@
 uid: S000182
 name: Disjoint union of continuum many copies of $\mathbb{Q}$
 refs:
-  - mathse: 3198478
-    name: Meager topological spaces of uncountable size
+  - mathse: 3947741
+    name: Answer to "Meager topological spaces of uncountable size"
 ---
 
-The disjoint union $X = \bigsqcup_{i\in I}\mathbb{Q}$, $|I| = \mathfrak{c}$, of continuum many copies of {S27}. See [this answer](https://math.stackexchange.com/a/3947741) to {{mathse:3198478}}.
+The disjoint union $X = \bigsqcup_{i\in I}\mathbb{Q}$, $|I| = \mathfrak{c}$, of continuum many copies of {S27}.
+
+See {{mathse:3947741}}.

--- a/spaces/S000192/README.md
+++ b/spaces/S000192/README.md
@@ -15,4 +15,4 @@ the sense of {S25}), $\infty_E$ has basic neighborhoods of the form
 $(a,\infty)\setminus E$, and $\infty_D$ has basic neighorhoods of the form
 $(a,\infty)\setminus D$.
 
-Constructed by M W in their MathOverflow answer {{mo:460346}}.
+Constructed by M W in {{mo:460346}}.

--- a/theorems/T000005.md
+++ b/theorems/T000005.md
@@ -5,8 +5,8 @@ if:
 then:
   P000111: true
 refs:
-- mathse: 4492531
-  name: Does locally compact and σ-compact non-Hausdorff space imply hemicompact?
+- mathse: 4569500
+  name: Answer to "Does locally compact and σ-compact non-Hausdorff space imply hemicompact?"
 ---
 
-See the proof of the theorem in [this answer](https://math.stackexchange.com/a/4569500) to {{mathse:4492531}}.
+See the proof of the theorem in {{mathse:4569500}}.

--- a/theorems/T000186.md
+++ b/theorems/T000186.md
@@ -9,4 +9,4 @@ refs:
   name: Locally countable implies countably tight?
 ---
 
-As shown in {{mathse:3809662}}. <https://math.stackexchange.com/questions/3809662>
+As shown in {{mathse:3809662}}.


### PR DESCRIPTION
As pointed out in #913, we need to use consistent mathse/mo references with the double brace syntax `{{mathse:...}}` together with an entry in the `refs:` section.
