### PR TITLE
The divisor topology (S49) is contractible (P199)

### DIFF
--- a/spaces/S000049/properties/P000199.md
+++ b/spaces/S000049/properties/P000199.md
@@ -1,0 +1,10 @@
+---
+space: S000049
+property: P000199
+value: true
+refs:
+- mathse: 4999893
+  name: Is the divisor topology from Steen-Seebach contractible?
+---
+
+See {{mathse:4999893}}.


### PR DESCRIPTION
I asked and answered this at [MSE](https://math.stackexchange.com/q/4999893/444923). The post didn't get that many views so we might want to scrutinize it a bit before merging.

Another thing to keep in mind is maybe ultraconnected implies contractible, in which case this trait will be redundant. I think this is false, but I'm not sure, and didn't try that hard yet to prove it.