### PR TITLE
add P202 aliases

### DIFF
--- a/properties/P000202.md
+++ b/properties/P000202.md
@@ -1,9 +1,14 @@
 ---
 uid: P000202
 name: Has a point with a unique neighborhood
+aliases:
+  - Has a focal point
+  - Has a point specializing every point
 refs:
 - wikipedia: Specialization_(pre)order
   name: Specialization (pre)order on Wikipedia
+- zb: "1071.18002"
+  name: Sketches of an elephant. A topos theory compendium (Johnstone)
 ---
 
 There exists a point $p\in X$ whose only neighborhood is the entire space.
@@ -15,3 +20,4 @@ Equivalently:
 - The topology is coarser than or equal to an excluded point topology (e.g. {S12}).
 
 Compare with {P201} and {P203}.
+See Section C1.5 page 523 of {{zb:1071.18002}} using the terminology "focal point".

--- a/properties/P000202.md
+++ b/properties/P000202.md
@@ -19,5 +19,6 @@ Equivalently:
 - $p$ is a specialization of every point. See {{wikipedia:Specialization_(pre)order}}.
 - The topology is coarser than or equal to an excluded point topology (e.g. {S12}).
 
-Compare with {P201} and {P203}.
 See Section C1.5 page 523 of {{zb:1071.18002}} using the terminology "focal point".
+
+Compare with {P201} and {P203}.


### PR DESCRIPTION
Closes #920

Gives a dual alias "focal point" to our "[generic point](https://topology.pi-base.org/properties/P000201)", as well as using "specialized" to reflect "generic" in an alias.

Since "focal point" is not super common in general topology, I think keeping the current main name is appropriate.