### PR TITLE
Add: Hereditarily connected + not empty => contractible

### DIFF
--- a/theorems/T000584.md
+++ b/theorems/T000584.md
@@ -1,11 +1,9 @@
 ---
 uid: T000584
 if:
-  and:
-  - P000129: true
-  - P000137: false
-then:
   P000199: true
+then:
+  P000137: false
 ---
 
-Suppose $X \neq \emptyset$, and let $p \in X$. Define a homotopy $F : X \times [0, 1] \to X$ from the identity map to the constant map with value $p$ as follows. For all $x \in X$ and $t \in (0, 1]$, $F(x, 0) = x$ and $F(x, t) = p$. $F$ is continuous because any function into an indiscrete space is continuous. 
+The empty space is not homotopy equivalent to a one-point space.

--- a/theorems/T000585.md
+++ b/theorems/T000585.md
@@ -1,9 +1,14 @@
 ---
 uid: T000585
 if:
-  P000199: true
+  and:
+  - P000196: true
+  - P000137: false
 then:
-  P000137: false
+  P000199: true
+refs:
+- mathse: 5000498
+  name: Are hereditarily connected spaces and ultraconnected spaces contractible?
 ---
 
-The empty space is not homotopy equivalent to a one-point space.
+See {{mathse:5000498}}.


### PR DESCRIPTION
As discussed in #925.

New T585: Hereditarily connected + not empty ==> contractible.

Removed old T584 [indiscrete + not empty ==> contractible], which can be deduced from the new result.

(I reshuffled the old T585 [contractible ==> not empty] to become T584.  That's just cosmetic, so the basic results for Contractible show up first in https://topology.pi-base.org/properties/P000199/theorems.  Sorry about any confusion.)