### PR TITLE
Fix rendering problem for Eberlein compact (P91)

### DIFF
--- a/properties/P000091.md
+++ b/properties/P000091.md
@@ -5,4 +5,4 @@ refs:
   - doi: 10.2140/pjm.1977.72.487
     name: A note on Eberlein compacts
 ---
-Any compact subspace of a $\Sigma^\*$-product of real lines.
+Any compact subspace of a $\Sigma^{\\*}$-product of real lines.

--- a/properties/P000091.md
+++ b/properties/P000091.md
@@ -5,4 +5,4 @@ refs:
   - doi: 10.2140/pjm.1977.72.487
     name: A note on Eberlein compacts
 ---
-Any compact subspace of a $\Sigma^{\\*}$-product of real lines.
+Any compact subspace of a $\Sigma^\ast$-product of real lines.


### PR DESCRIPTION
In my browsers the superscript asterisk was rendering in red and with a visible backslash.