### PR TITLE
S21 is not a k-space

### DIFF
--- a/spaces/S000021/properties/P000140.md
+++ b/spaces/S000021/properties/P000140.md
@@ -1,0 +1,10 @@
+---
+space: S000021
+property: P000140
+value: false
+refs:
+  - doi: 10.1285/I15900932V11P273
+    name: The Mackey dual of a Banach space
+---
+
+A direct consequence of the assertion at the beginning of Section 5 of {{doi:10.1285/I15900932V11P273}}, that a Banach space equipped with its weak topology cannot be a $k$-space unless it is finite-dimensional.


### PR DESCRIPTION
As mentioned in issue #928, [S21](https://topology.pi-base.org/spaces/S000021), the weak topology on separable Hilbert space, is not a $k$-space - more precisely, $k_1$-space ([P140](https://topology.pi-base.org/properties/P000140)). Note that $k_1$, $k_2$, and $k_3$ are equivalent for Hausdorff spaces.