### PR TITLE
S46 does not have P201

### DIFF
--- a/spaces/S000046/properties/P000201.md
+++ b/spaces/S000046/properties/P000201.md
@@ -4,4 +4,4 @@ property: P000201
 value: false
 ---
 
-The intersection of $S_n$ in the definition of the topology is easily seen to be empty. Since $S_n$ are all nonempty open sets, there is no point contained in all nonempty open sets, i.e., the space has no generic point.
+The intersection of the $S_n$ in the definition of the topology is easily seen to be empty. Since the $S_n$ are all nonempty open sets, there is no point contained in all nonempty open sets, i.e., the space has no generic point.

--- a/spaces/S000046/properties/P000201.md
+++ b/spaces/S000046/properties/P000201.md
@@ -1,0 +1,7 @@
+---
+space: S000046
+property: P000201
+value: false
+---
+
+The intersection of $S_n$ in the definition of the topology is easily seen to be empty. Since $S_n$ are all nonempty open sets, there is no point contained in all nonempty open sets, i.e., the space has no generic point.


### PR DESCRIPTION
As in title, the interlocking interval topology ([S46](https://topology.pi-base.org/spaces/S000046)) does not have a generic point, i.e., it does not have [P201](https://topology.pi-base.org/properties/P000201). This is a part of #933.