### PR TITLE
Clarifying the definition of S118 and adding the trait that it has a cut point

### DIFF
--- a/spaces/S000118/README.md
+++ b/spaces/S000118/README.md
@@ -8,7 +8,7 @@ refs:
   - wikipedia: Integer_broom_topology
     name: Infinite broom topology on Wikipedia
 ---
-Let $X \subset \mathbb{R}^2$ with polar coordinates $\{(n,\theta)\ |\ n \in \omega, \theta \in \{0\} \cup \{1/n\}_{n=1}^\infty\}$. Define a topology on $X$ by taking as a basis all sets of the form $U \times V$ where is an open set in the right order topology on the non-negative integers and $V$ is open in $\{0\} \cup \{1/n\}_{n=1}^\infty \subset \mathbb{R}$.
+Let $X \subset \mathbb{R}^2$ with polar coordinates $\{(n,\theta)\ |\ n \in \omega, \theta \in \{0\} \cup \{1/n\}_{n=1}^\infty\}$. Define a topology on $X$ by taking as a basis all sets of the form $U \times V$ where $U$ is an open set in the right order topology on the positive integers and $V$ is open in $\{0\} \cup \{1/n\}_{n=1}^\infty \subset \mathbb{R}$. The only neighborhood of the origin is $X$ itself.
 
 Defined as counterexample #121 ("The Integer Broom")
 in {{doi:10.1007/978-1-4612-6290-9}}.

--- a/spaces/S000118/README.md
+++ b/spaces/S000118/README.md
@@ -10,7 +10,7 @@ refs:
 ---
 Let $X \subset \mathbb{R}^2$ with polar coordinates $\{(n,\theta)\ |\ n \in \omega, \theta \in \{0\} \cup \{1/n\}_{n=1}^\infty\}$. Define a topology on $X$ by taking as a basis all sets of the form $U \times V$ where $U$ is an open set in the right order topology on the positive integers and $V$ is open in $\{0\} \cup \{1/n\}_{n=1}^\infty \subset \mathbb{R}$. The only neighborhood of the origin is $X$ itself.
 
-This space is the product of {S200} with {S20} under the quotient identifying together all points whose first component is 0.
+This space is the quotient of the product of {S200} with {S20}, where all points whose first components are 0 are identified.
 
 Defined as counterexample #121 ("The Integer Broom")
 in {{doi:10.1007/978-1-4612-6290-9}}.

--- a/spaces/S000118/README.md
+++ b/spaces/S000118/README.md
@@ -8,7 +8,7 @@ refs:
   - wikipedia: Integer_broom_topology
     name: Infinite broom topology on Wikipedia
 ---
-Let $X \subset \mathbb{R}^2$ with polar coordinates $\{(n,\theta)\ |\ n \in \omega, \theta \in \{0\} \cup \{1/n\}_{n=1}^\infty\}$. Define a topology on $X$ by taking as a basis all sets of the form $U \times V$ where $U$ is an open set in the right order topology on the positive integers and $V$ is open in $\{0\} \cup \{1/n\}_{n=1}^\infty \subset \mathbb{R}$. The only neighborhood of the origin is $X$ itself.
+Let $X \subset \mathbb{R}^2$ consist of points with polar coordinates $\{(n,\theta)\ |\ n \in \omega, \theta \in \{0\} \cup \{1/n\}_{n=1}^\infty\}$. Define a topology on $X$ by taking as a basis all sets of the form $U \times V$ where $U$ is an open set in the right order topology on the positive integers and $V$ is open in $\{0\} \cup \{1/n\}_{n=1}^\infty \subset \mathbb{R}$. The only neighborhood of the origin is $X$ itself.
 
 This space is the quotient of the product of {S200} with {S20}, where all points whose first components are 0 are identified.
 

--- a/spaces/S000118/README.md
+++ b/spaces/S000118/README.md
@@ -8,9 +8,9 @@ refs:
   - wikipedia: Integer_broom_topology
     name: Infinite broom topology on Wikipedia
 ---
-Let $X \subset \mathbb{R}^2$ consist of points with polar coordinates $\{(n,\theta)\ |\ n \in \omega, \theta \in \{0\} \cup \{1/n\}_{n=1}^\infty\}$. Define a topology on $X$ by taking as a basis all sets of the form $U \times V$ where $U$ is an open set in the right order topology on the positive integers and $V$ is open in $\{0\} \cup \{1/n\}_{n=1}^\infty \subset \mathbb{R}$. The only neighborhood of the origin is $X$ itself.
+Let $X \subset \mathbb{R}^2$ consist of points with polar coordinates $\{(n,\theta)\ \mid\ n \in \omega, \theta \in \{0\} \cup \{1/n\}_{n=1}^\infty\}$. Define a topology on $X$ by taking as a basis all sets of the form $U \times V$ where $U$ is an open set in the right order topology on the positive integers and $V$ is open in $\{0\} \cup \{1/n\}_{n=1}^\infty \subset \mathbb{R}$. The only neighborhood of the origin is $X$ itself.
 
-This space is the quotient of the product of {S200} with {S20}, where all points whose first components are 0 are identified.
+This space is the quotient of the product of {S200} with {S20} where all points whose first components are 0 are identified.
 
 Defined as counterexample #121 ("The Integer Broom")
 in {{doi:10.1007/978-1-4612-6290-9}}.

--- a/spaces/S000118/README.md
+++ b/spaces/S000118/README.md
@@ -10,5 +10,7 @@ refs:
 ---
 Let $X \subset \mathbb{R}^2$ with polar coordinates $\{(n,\theta)\ |\ n \in \omega, \theta \in \{0\} \cup \{1/n\}_{n=1}^\infty\}$. Define a topology on $X$ by taking as a basis all sets of the form $U \times V$ where $U$ is an open set in the right order topology on the positive integers and $V$ is open in $\{0\} \cup \{1/n\}_{n=1}^\infty \subset \mathbb{R}$. The only neighborhood of the origin is $X$ itself.
 
+This space is the product of {S200} with {S20} under the quotient identifying together all points whose first component is 0.
+
 Defined as counterexample #121 ("The Integer Broom")
 in {{doi:10.1007/978-1-4612-6290-9}}.

--- a/spaces/S000118/properties/P000202.md
+++ b/spaces/S000118/properties/P000202.md
@@ -1,7 +1,0 @@
----
-space: S000118
-property: P000202
-value: false
----
-
-Immediate from definition.

--- a/spaces/S000118/properties/P000202.md
+++ b/spaces/S000118/properties/P000202.md
@@ -1,0 +1,7 @@
+---
+space: S000118
+property: P000202
+value: false
+---
+
+Immediate from definition.

--- a/spaces/S000118/properties/P000204.md
+++ b/spaces/S000118/properties/P000204.md
@@ -4,4 +4,4 @@ property: P000204
 value: true
 ---
 
-The origin is a cut point since the complement of the origin can be written as a disjoint union of nonempty open sets, e.g., $([1, \infty) \cap \omega) \times (\{0\} \cup \{\frac{1}{n}\}_{n=2}^\infty)$ and $([1, \infty) \cap \omega) \times \{0\}$; and, moreover, the space itself is known to be connected (see {S118|P36}).
+The origin is a cut point since the complement of the origin can be written as a disjoint union of nonempty open sets, e.g., $([1, \infty) \cap \omega) \times (\{0\} \cup \{\frac{1}{n}\}_{n=2}^\infty)$ and $([1, \infty) \cap \omega) \times \{0\}$; and moreover, {S118|P36}.

--- a/spaces/S000118/properties/P000204.md
+++ b/spaces/S000118/properties/P000204.md
@@ -4,4 +4,4 @@ property: P000204
 value: true
 ---
 
-The origin is a cut point since the complement of the origin can be written as a disjoint union of nonempty open sets, e.g., $([1, \infty) \cap \omega) \times (\{0\} \cup \{\frac{1}{n}\}_{n=2}^\infty)$ and $([1, \infty) \cap \omega) \times \{0\}$; and, moreover, the space itself is known to be connected (see [here](https://topology.pi-base.org/spaces/S000118/properties/P000036)).
+The origin is a cut point since the complement of the origin can be written as a disjoint union of nonempty open sets, e.g., $([1, \infty) \cap \omega) \times (\{0\} \cup \{\frac{1}{n}\}_{n=2}^\infty)$ and $([1, \infty) \cap \omega) \times \{0\}$; and, moreover, the space itself is known to be connected (see {S118|P36}).

--- a/spaces/S000118/properties/P000204.md
+++ b/spaces/S000118/properties/P000204.md
@@ -1,0 +1,7 @@
+---
+space: S000118
+property: P000204
+value: true
+---
+
+The origin is a cut point since the complement of the origin can be written as a disjoint union of nonempty open sets, e.g., $([1, \infty) \cap \omega) \times (\{0\} \cup \{\frac{1}{n}\}_{n=2}^\infty)$ and $([1, \infty) \cap \omega) \times \{0\}$; and, moreover, the space itself is known to be connected (see [here](https://topology.pi-base.org/spaces/S000118/properties/P000036)).


### PR DESCRIPTION
As mentioned in #933, the definition of [S118](https://topology.pi-base.org/spaces/S000118), the integer broom, is overly vague. As written, one may reasonably understand, for example, that $\omega \times \{1\}$ is an open neighborhood of the origin that is not the entire space, despite the definition of the integer broom in *Counterexamples in Topology* explicitly stating that the only neighborhood of the origin is the entire space and using this to show $X$ is compact. Moreover, this fact is also needed to see $X$ is ultraconnected. I've added this clarification to the definition, fixed a minor typo, and changed the reference to "the right order topology on the non-negative integers" to "the right order topology on the positive integers". Technically, the final change is against the statement in *Counterexamples in Topology*. However, given that the only neighborhood of the origin should be the entire space, saying "the right order topology on the positive integers" is more accurate to what the space actually is and eliminates any potential confusions regarding the origin.

I've also added a trait that S118 has a cut point ([P204](https://topology.pi-base.org/properties/P000204)). Together with [P40](https://topology.pi-base.org/properties/P000040), ultraconnected, this implies the integer broom has a focal point, resolving another part of #933. (Side note: there are no stronger traits under currently available theorems that will imply having a cut point for S118, as can be verified by checking all the currently available theorems implying P204.)