### PR TITLE
T622: Ultraconnected compact spaces have a focal point

### DIFF
--- a/theorems/T000622.md
+++ b/theorems/T000622.md
@@ -1,0 +1,14 @@
+---
+uid: T000622
+if:
+  and:
+  - P000040: true
+  - P000016: true
+  - P000137: false
+then:
+  P000202: true
+---
+
+Since $X$ is {P40}, the family of nonempty closed sets in $X$ has the finite intersection property.
+As $X$ is {P16}, that family has nonempty intersection.
+Any point in that intersection belongs to every nonempty closed set.


### PR DESCRIPTION
New T622: Ultraconnected + compact + not empty ==> has a focal point.

That seemed simple enough to not warrant a mathse post.

Will provide a simple derivation that S100 is not compact (upcoming in #948).

Also will derive that S118 (integer broom) has a focal point.