### PR TITLE
add S199 quasi-sober, edit sober definition

### DIFF
--- a/properties/P000073.md
+++ b/properties/P000073.md
@@ -8,7 +8,9 @@ refs:
     name: Topology via logic (S. Vickers)
 ---
 
-Every nonempty irreducible closed subset of $X$ is the closure of exactly one point of $X$; that is, every nonempty irreducible closed subset has a unique *generic point*.
-Here, a subset of $X$ is called *irreducible* if it is {P39} with the subspace topology.
+Every non-{P137} {P39} closed subspace of $X$ is
+{P201}, witnessed by exactly one generic point.
+
+(Spaces that may have multiple generic points are {P192}.)
 
 See {{wikipedia:Sober_space}} and also the section on [Irreducible components](https://stacks.math.columbia.edu/tag/004U) from the Stacks project.

--- a/properties/P000073.md
+++ b/properties/P000073.md
@@ -8,7 +8,7 @@ refs:
     name: Topology via logic (S. Vickers)
 ---
 
-Every non-{P137} {P39} closed subspace of $X$ is
+Every nonempty {P39} closed subspace of $X$ is
 {P201}, witnessed by exactly one generic point.
 
 (Spaces that may have multiple generic points are {P192}.)

--- a/properties/P000192.md
+++ b/properties/P000192.md
@@ -6,7 +6,7 @@ refs:
   name: Sober spaces and sober sets (Echi & Lazaar)
 ---
 
-Every non-{P137} {P39} closed subspace of $X$ is
+Every nonempty {P39} closed subspace of $X$ is
 {P201}.
 
 Equivalently, the Kolmogorov quotient of the space is {P73}. (See {T512}.)

--- a/spaces/S000199/properties/P000192.md
+++ b/spaces/S000199/properties/P000192.md
@@ -7,3 +7,5 @@ value: true
 Every non-empty closed subspace is of the form $[n,\rightarrow)$ for some
 $n<\omega$, a copy of {S199} itself.
 The result follows by {S199|P201}.
+(To see this directly, note that $\{0\}$ is dense in {S199}
+as it is contained in every non-empty proper open set of the form $(\leftarrow,n]$.)

--- a/spaces/S000199/properties/P000192.md
+++ b/spaces/S000199/properties/P000192.md
@@ -1,0 +1,9 @@
+---
+space: S000199
+property: P000192
+value: true
+---
+
+Every non-empty closed subspace is of the form $[n,\rightarrow)$ for some
+$n<\omega$, a copy of {S199} itself.
+The result follows by {S199|P201}.


### PR DESCRIPTION
I could have proven S199 sober, but we get it for free as we already know the space is $T_0$.

Suggested by @david20000813 in https://github.com/pi-base/data/pull/934#issuecomment-2497019867