### PR TITLE
Adding T631 for closed point

### DIFF
--- a/theorems/T000631.md
+++ b/theorems/T000631.md
@@ -11,6 +11,4 @@ refs:
     name: Cut-point spaces (Honari & Bahrampour)
 ---
 
-We show that a cut point $p \in X$ is either an isolated point or a closed point. By definition of cut point, $X$ is connected, and $X \backslash \{p\} = A \cup B$ for disjoint nonempty clopen sets $A$ and $B$. Hence there is a open set $V$ such that $A = V \cap (X \backslash \{p\}) = V \backslash \{p\}$, and there is a closed set $F$ such that $A = F \cap (X \backslash \{p\}) = F \backslash \{p\}$. Since $X$ is connected, $V \neq F$. Thus, either $F \backslash V = \{p\}$ or $V \backslash F = \{p\}$. In the first case $p$ is a closed point, and in the second case $p$ is an isolated point.
-
-This argument is from Theorem 3.2 of {{doi:10.1090/S0002-9939-99-04839-X}}. 
+See Theorem 3.2 of {{doi:10.1090/S0002-9939-99-04839-X}}. 

--- a/theorems/T000631.md
+++ b/theorems/T000631.md
@@ -1,0 +1,16 @@
+---
+uid: T000631
+if:
+  and:
+  - P000204: true
+  - P000107: false
+then:
+  P000139: true
+refs:
+  - doi: 10.1090/S0002-9939-99-04839-X
+    name: Cut-point spaces (Honari & Bahrampour)
+---
+
+We show that a cut point $p \in X$ is either an isolated point or a closed point. By definition of cut point, $X$ is connected, and $X \backslash \{p\} = A \cup B$ for disjoint nonempty clopen sets $A$ and $B$. Hence there is a open set $V$ such that $A = V \cap (X \backslash \{p\}) = V \backslash \{p\}$, and there is a closed set $F$ such that $A = F \cap (X \backslash \{p\}) = F \backslash \{p\}$. Since $X$ is connected, $V \neq F$. Thus, either $F \backslash V = \{p\}$ or $V \backslash F = \{p\}$. In the first case $p$ is a closed point, and in the second case $p$ is an isolated point.
+
+This argument is from Theorem 3.2 of {{doi:10.1090/S0002-9939-99-04839-X}}. 


### PR DESCRIPTION
As discussed in #965, this adds T631, Has a cut point + ~Has a closed point => Has an isolated point. The code was already written by @GeoffreySangston, I only copy-pasted his code and made one minor edit (noting $A$ and $B$ are *nonempty* clopen).

This closes #942 as the result there will get automatically deduced. This is the final part of #940.