### PR TITLE
Sober/Quasi-sober revision

### DIFF
--- a/properties/P000073.md
+++ b/properties/P000073.md
@@ -8,9 +8,12 @@ refs:
     name: Topology via logic (S. Vickers)
 ---
 
-Every nonempty {P39} closed subspace of $X$ is
-{P201}, witnessed by exactly one generic point.
+Every nonempty irreducible (= {P39}) closed subset of $X$ is the closure of exactly one point of $X$;
+that is, every nonempty irreducible closed subset has a unique *generic point*.
 
-(Spaces that may have multiple generic points are {P192}.)
+See {P201} for several equivalent formulations.
 
-See {{wikipedia:Sober_space}} and also the section on [Irreducible components](https://stacks.math.columbia.edu/tag/004U) from the Stacks project.
+See {{wikipedia:Sober_space}} and also 
+the section on [Irreducible components](https://stacks.math.columbia.edu/tag/004U) from the Stacks project.
+
+Note: Without the uniqueness of the generic points, the corresponding property is {P192}.

--- a/properties/P000192.md
+++ b/properties/P000192.md
@@ -6,9 +6,14 @@ refs:
   name: Sober spaces and sober sets (Echi & Lazaar)
 ---
 
-Every nonempty {P39} closed subspace of $X$ is
-{P201}.
+Every nonempty irreducible (= {P39}) closed subset of $X$ is the closure of a point of $X$, not necessarily unique;
+that is, every nonempty irreducible closed subset has at least one *generic point*.
+
+See {P201} for several equivalent formulations.
 
 Equivalently, the Kolmogorov quotient of the space is {P73}. (See {T512}.)
 
-See for example Definition 5.8.6 in the section on [Irreducible components](https://stacks.math.columbia.edu/tag/004U) from the Stacks project, or the paragraph after Definition 1.2 in {{doi:10.35834/mjms/1316032836}}.
+See for example Definition 5.8.6 in the section on [Irreducible components](https://stacks.math.columbia.edu/tag/004U) from the Stacks project,
+or the paragraph after Definition 1.2 in {{doi:10.35834/mjms/1316032836}}.
+
+Note: With an additional uniqueness condition on the generic points, the corresponding property is {P73}.


### PR DESCRIPTION
Revising the description of Sober/Quasi-sober as discussed in #969.

I have replaced the sentence
 `(Spaces that may have multiple generic points are {P192}.)`
with something else, as it seemed to incorrectly imply that one needs multiple generic points for quasi-compact.  Most quasi-compact spaces don't even have generic points.

@StevenClontz  @david20000813 