### PR TITLE
T629: fix typos

### DIFF
--- a/theorems/T000629.md
+++ b/theorems/T000629.md
@@ -11,7 +11,7 @@ refs:
     name: Answer to "Why are ordered spaces normal? [collecting proofs]"
 ---
 
-{{zb:0189.53103}} shows that every {{P133}} is hereditarily collectionwise normal.
+{{zb:0189.53103}} shows that every {P133} is hereditarily collectionwise normal.
 See also {{mathse:322974}}.
 
-The result follows, since a {{P154}} is a subspace of a {{P133}}.
+The result follows, since a {P154} is a subspace of a {P133}.


### PR DESCRIPTION
Fixing typos (single curly braces for internal links).

See #977.