### PR TITLE
Two additional strongly Choquet theorems

### DIFF
--- a/theorems/T000617.md
+++ b/theorems/T000617.md
@@ -3,12 +3,7 @@ uid: T000617
 if:
   P000201: true
 then:
-  P000064: true
-refs:
-  - wikipedia: Baire_space
-    name: Baire space on Wikipedia
+  P000206: true
 ---
 
-One of the characterizations of Baire spaces (see {{wikipedia:Baire_space}}) is that every nonempty open set is nonmeager.
-
-Suppose $p$ is a generic point of $X$ and let $U$ be a nonempty open set.  Then $p\in U$, and $p$ is not contained in any nowhere dense subset of $U$ since $\{p\}$ is dense in $U$.  Therefore $U$ is nonmeager.
+Regardless of how Player 2 plays, the intersection of $U_n$ will always contain any generic point of the space.

--- a/theorems/T000647.md
+++ b/theorems/T000647.md
@@ -1,0 +1,11 @@
+---
+uid: T000647
+if:
+  and:
+  - P000094: true
+  - P000137: false
+then:
+  P000206: true
+---
+
+During round 0, Player 2 chooses any finite neighborhood $V_0$ of $x_0$ that is contained in $U_0$. Then $\{U_n\}_{n \geq 1}$ is a decreasing sequence of nonempty finite sets, so it must have nonempty intersection.


### PR DESCRIPTION
After looking at the spaces not known to be either strongly Choquet or not, I've come up with two new theorems for the newly added property. The first is a strengthening of the original T617, Has a generic point => Baire, which can be strengthened to Has a generic point => strongly Choquet, as strongly Choquet => Baire (T135). The second shows nonempty locally finite spaces are strongly Choquet. This will again complete all traits for finite spaces (as some finite spaces are not known to be strongly Choquet or not now). The arguments for both are quite easy, so I've decided to directly add them to pi-Base instead of going through an MSE question.