### PR TITLE
Non-Rothberger spaces

### DIFF
--- a/spaces/S000019/properties/P000068.md
+++ b/spaces/S000019/properties/P000068.md
@@ -1,0 +1,8 @@
+---
+space: S000019
+property: P000068
+value: false
+---
+
+It is easy to check being {P68} passes to closed subspaces. Since $[0,1]$ is a closed subspace which is
+homeomorphic to {S158} and {S158|P68}, the result follows.

--- a/spaces/S000054/properties/P000068.md
+++ b/spaces/S000054/properties/P000068.md
@@ -1,0 +1,8 @@
+---
+space: S000054
+property: P000068
+value: false
+---
+
+It is easy to check being {P68} passes to the Kolmogorov quotient. Since the Kolmogorov quotient of the space is
+{S25} and {S25|P68}, the result follows.

--- a/spaces/S000055/properties/P000068.md
+++ b/spaces/S000055/properties/P000068.md
@@ -1,0 +1,8 @@
+---
+space: S000055
+property: P000068
+value: false
+---
+
+It is easy to check being {P68} passes to coaser topologies. Since the topology on the space is finer than
+{S25} and {S25|P68}, the result follows.

--- a/spaces/S000055/properties/P000068.md
+++ b/spaces/S000055/properties/P000068.md
@@ -4,5 +4,5 @@ property: P000068
 value: false
 ---
 
-It is easy to check being {P68} passes to coaser topologies. Since the topology on the space is finer than
+It is easy to check being {P68} passes to coarser topologies. Since the topology on the space is finer than
 {S25} and {S25|P68}, the result follows.

--- a/spaces/S000056/properties/P000068.md
+++ b/spaces/S000056/properties/P000068.md
@@ -1,0 +1,8 @@
+---
+space: S000056
+property: P000068
+value: false
+---
+
+It is easy to check being {P68} passes to coaser topologies. Since the topology on the space is finer than
+{S25} and {S25|P68}, the result follows.

--- a/spaces/S000056/properties/P000068.md
+++ b/spaces/S000056/properties/P000068.md
@@ -4,5 +4,5 @@ property: P000068
 value: false
 ---
 
-It is easy to check being {P68} passes to coaser topologies. Since the topology on the space is finer than
+It is easy to check being {P68} passes to coarser topologies. Since the topology on the space is finer than
 {S25} and {S25|P68}, the result follows.

--- a/spaces/S000058/properties/P000068.md
+++ b/spaces/S000058/properties/P000068.md
@@ -1,0 +1,8 @@
+---
+space: S000058
+property: P000068
+value: false
+---
+
+It is easy to check being {P68} passes to coaser topologies. Since the topology on the space is finer than
+{S25} and {S25|P68}, the result follows.

--- a/spaces/S000058/properties/P000068.md
+++ b/spaces/S000058/properties/P000068.md
@@ -4,5 +4,5 @@ property: P000068
 value: false
 ---
 
-It is easy to check being {P68} passes to coaser topologies. Since the topology on the space is finer than
+It is easy to check being {P68} passes to coarser topologies. Since the topology on the space is finer than
 {S25} and {S25|P68}, the result follows.

--- a/spaces/S000059/properties/P000068.md
+++ b/spaces/S000059/properties/P000068.md
@@ -1,0 +1,8 @@
+---
+space: S000059
+property: P000068
+value: false
+---
+
+It is easy to check being {P68} passes to coaser topologies. Since the topology on the space is finer than
+{S25} and {S25|P68}, the result follows.

--- a/spaces/S000059/properties/P000068.md
+++ b/spaces/S000059/properties/P000068.md
@@ -4,5 +4,5 @@ property: P000068
 value: false
 ---
 
-It is easy to check being {P68} passes to coaser topologies. Since the topology on the space is finer than
+It is easy to check being {P68} passes to coarser topologies. Since the topology on the space is finer than
 {S25} and {S25|P68}, the result follows.

--- a/spaces/S000061/properties/P000068.md
+++ b/spaces/S000061/properties/P000068.md
@@ -1,0 +1,8 @@
+---
+space: S000061
+property: P000068
+value: false
+---
+
+It is easy to check being {P68} passes to coaser topologies. Since the topology on the space is finer than
+{S25} and {S25|P68}, the result follows.

--- a/spaces/S000061/properties/P000068.md
+++ b/spaces/S000061/properties/P000068.md
@@ -4,5 +4,5 @@ property: P000068
 value: false
 ---
 
-It is easy to check being {P68} passes to coaser topologies. Since the topology on the space is finer than
+It is easy to check being {P68} passes to coarser topologies. Since the topology on the space is finer than
 {S25} and {S25|P68}, the result follows.

--- a/spaces/S000062/properties/P000068.md
+++ b/spaces/S000062/properties/P000068.md
@@ -1,0 +1,8 @@
+---
+space: S000062
+property: P000068
+value: false
+---
+
+It is easy to check being {P68} passes to coaser topologies. Since the topology on the space is finer than
+{S25} and {S25|P68}, the result follows.

--- a/spaces/S000062/properties/P000068.md
+++ b/spaces/S000062/properties/P000068.md
@@ -4,5 +4,5 @@ property: P000068
 value: false
 ---
 
-It is easy to check being {P68} passes to coaser topologies. Since the topology on the space is finer than
+It is easy to check being {P68} passes to coarser topologies. Since the topology on the space is finer than
 {S25} and {S25|P68}, the result follows.

--- a/spaces/S000063/properties/P000068.md
+++ b/spaces/S000063/properties/P000068.md
@@ -1,0 +1,8 @@
+---
+space: S000063
+property: P000068
+value: false
+---
+
+It is easy to check being {P68} passes to coaser topologies. Since the topology on the space is finer than
+{S25} and {S25|P68}, the result follows.

--- a/spaces/S000063/properties/P000068.md
+++ b/spaces/S000063/properties/P000068.md
@@ -4,5 +4,5 @@ property: P000068
 value: false
 ---
 
-It is easy to check being {P68} passes to coaser topologies. Since the topology on the space is finer than
+It is easy to check being {P68} passes to coarser topologies. Since the topology on the space is finer than
 {S25} and {S25|P68}, the result follows.

--- a/spaces/S000065/properties/P000068.md
+++ b/spaces/S000065/properties/P000068.md
@@ -1,0 +1,8 @@
+---
+space: S000065
+property: P000068
+value: false
+---
+
+It is easy to check being {P68} passes to closed subspaces. Since $[0,\frac{1}{2}]$ is a closed subspace which is
+homeomorphic to {S158} and {S158|P68}, the result follows.

--- a/spaces/S000066/properties/P000068.md
+++ b/spaces/S000066/properties/P000068.md
@@ -1,5 +1,5 @@
 ---
-space: S000068
+space: S000066
 property: P000068
 value: false
 ---

--- a/spaces/S000066/properties/P000068.md
+++ b/spaces/S000066/properties/P000068.md
@@ -1,0 +1,8 @@
+---
+space: S000068
+property: P000068
+value: false
+---
+
+It is easy to check being {P68} passes to closed subspaces. Since $\{(x,y) \in \mathbb{R}^2: x^2 + y^2 = 1\}$ is a closed subspace which is
+homeomorphic to {S170} and {S170|P68}, the result follows.

--- a/spaces/S000069/properties/P000068.md
+++ b/spaces/S000069/properties/P000068.md
@@ -4,5 +4,5 @@ property: P000068
 value: false
 ---
 
-It is easy to check being {P68} passes to coaser topologies. Since the topology on the space is finer than
+It is easy to check being {P68} passes to coarser topologies. Since the topology on the space is finer than
 {S176} and {S176|P68}, the result follows.

--- a/spaces/S000069/properties/P000068.md
+++ b/spaces/S000069/properties/P000068.md
@@ -1,0 +1,8 @@
+---
+space: S000069
+property: P000068
+value: false
+---
+
+It is easy to check being {P68} passes to coaser topologies. Since the topology on the space is finer than
+{S176} and {S176|P68}, the result follows.

--- a/spaces/S000073/properties/P000068.md
+++ b/spaces/S000073/properties/P000068.md
@@ -1,0 +1,8 @@
+---
+space: S000073
+property: P000068
+value: false
+---
+
+It is easy to check being {P68} passes to closed subspaces. Since {S170} embeds as a closed subspace of
+{S73} and {S170|P68}, the result follows.

--- a/spaces/S000075/properties/P000068.md
+++ b/spaces/S000075/properties/P000068.md
@@ -1,0 +1,8 @@
+---
+space: S000075
+property: P000068
+value: false
+---
+
+It is easy to check being {P68} passes to closed subspaces. Since {S170} embeds as a closed subspace of
+{S73} and {S170|P68}, the result follows.

--- a/spaces/S000083/properties/P000068.md
+++ b/spaces/S000083/properties/P000068.md
@@ -1,0 +1,8 @@
+---
+space: S000083
+property: P000068
+value: false
+---
+
+It is easy to check being {P68} passes to closed subspaces. Since $[1,2]$ is a closed subspace which is
+homeomorphic to {S158} and {S158|P68}, the result follows.

--- a/spaces/S000084/properties/P000068.md
+++ b/spaces/S000084/properties/P000068.md
@@ -1,0 +1,8 @@
+---
+space: S000084
+property: P000068
+value: false
+---
+
+It is easy to check being {P68} passes to closed subspaces. Since $[1,2]$ is a closed subspace which is
+homeomorphic to {S158} and {S158|P68}, the result follows.

--- a/spaces/S000094/properties/P000068.md
+++ b/spaces/S000094/properties/P000068.md
@@ -4,6 +4,6 @@ property: P000068
 value: false
 ---
 
-It is easy to check being {P68} passes to closed subspaces and coaser topologies. Note that the subset
+It is easy to check being {P68} passes to closed subspaces and coarser topologies. Note that the subset
 $\{(x,0): \frac{1}{2}\leq x \leq 1\}$ is closed, and the topology on it is homeomorphic to a topology finer than
 {S158}. As {S158|P68}, the result follows.

--- a/spaces/S000094/properties/P000068.md
+++ b/spaces/S000094/properties/P000068.md
@@ -1,0 +1,9 @@
+---
+space: S000094
+property: P000068
+value: false
+---
+
+It is easy to check being {P68} passes to closed subspaces and coaser topologies. Note that the subset
+$\{(x,0): \frac{1}{2}\leq x \leq 1\}$ is closed, and the topology on it is homeomorphic to a topology finer than
+{S158}. As {S158|P68}, the result follows.

--- a/spaces/S000095/properties/P000068.md
+++ b/spaces/S000095/properties/P000068.md
@@ -1,0 +1,8 @@
+---
+space: S000095
+property: P000068
+value: false
+---
+
+It is easy to check being {P68} passes to closed subspaces. Since $C_1$ is a closed subspace which is
+homeomorphic to {S170} and {S170|P68}, the result follows.

--- a/spaces/S000112/README.md
+++ b/spaces/S000112/README.md
@@ -6,7 +6,7 @@ refs:
   - doi: 10.1007/978-1-4612-6290-9
     name: Counterexamples in Topology
 ---
-Let $L_1$ be the line $x=1$, $L_2$ the line $x=-1$ and $R_n$ the boundary of the rectangle centered at $(0,0)$ with height $2n$ and width $\frac{2n}{n+1}$. Let $X = L_1 \cup L_2 \cup \bigcup_{n \in \omega} R_n$ with the subspace topology inherited from $\mathbb{R}^2$.
+Let $L_1$ be the line $x=1$, $L_2$ the line $x=-1$ and $R_n$ the boundary of the rectangle centered at $(0,0)$ with height $2n$ and width $\frac{2n}{n+1}$. Let $X = L_1 \cup L_2 \cup \bigcup_{n \ge 1} R_n$ with the subspace topology inherited from $\mathbb{R}^2$.
 
 Defined as counterexample #115 ("Nested Rectangles")
 in {{doi:10.1007/978-1-4612-6290-9}}.

--- a/spaces/S000112/properties/P000139.md
+++ b/spaces/S000112/properties/P000139.md
@@ -1,0 +1,7 @@
+---
+space: S000112
+property: P000139
+value: false
+---
+
+Each point is contained in either a straight line or the boundary of a rectangle. Neither has isolated points.

--- a/spaces/S000113/properties/P000116.md
+++ b/spaces/S000113/properties/P000116.md
@@ -9,7 +9,6 @@ refs:
 
 By Theorem 3.11 of {{doi:10.1007/978-1-4612-4190-4}}, and because {S114|P116}, it suffices
 to show {S113} is $G_\delta$ in {S176}. The closure of the space in the plane
-is {S114}, which is $G_\delta$ in the plane as {S176|P132}.
 The complement of the space in {S114} is $\{(0,y):y\in[-1,0)\cup(0,1]\}$, which is $F_\sigma$ as,
 
 $$\{(0,y):y\in[-1,0)\cup(0,1]\} = \bigcup_{n=1}^\infty (\{0\} \times ([-1,-1/n] \cup [1/n,1]))$$

--- a/spaces/S000113/properties/P000116.md
+++ b/spaces/S000113/properties/P000116.md
@@ -1,0 +1,15 @@
+---
+space: S000113
+property: P000116
+value: true
+refs:
+- doi: 10.1007/978-1-4612-4190-4
+  name: Classical Descriptive Set Theory (Kechris)
+---
+
+By Theorem 3.11 of {{doi:10.1007/978-1-4612-4190-4}}, and because {S176|P116}, it suffices
+to show {S113} is $G_\delta$ in {S176}. The closure of the space in the plane
+is {S114}, which is $G_\delta$ in the plane as {S176|P132}.
+The complement of the space in {S114} is $\{(0,y):y\in[-1,0)\cup(0,1]\}$, which is $F_\sigma$ as,
+
+$$\{(0,y):y\in[-1,0)\cup(0,1]\} = \bigcup_{n=1}^\infty (\{0\} \times ([-1,-1/n] \cup [1/n,1]))$$

--- a/spaces/S000113/properties/P000116.md
+++ b/spaces/S000113/properties/P000116.md
@@ -8,7 +8,7 @@ refs:
 ---
 
 By Theorem 3.11 of {{doi:10.1007/978-1-4612-4190-4}}, and because {S114|P116}, it suffices
-to show {S113} is $G_\delta$ in {S176}. The closure of the space in the plane
+to show {S113} is $G_\delta$ in {S114}.
 The complement of the space in {S114} is $\{(0,y):y\in[-1,0)\cup(0,1]\}$, which is $F_\sigma$ as,
 
 $$\{(0,y):y\in[-1,0)\cup(0,1]\} = \bigcup_{n=1}^\infty (\{0\} \times ([-1,-1/n] \cup [1/n,1]))$$

--- a/spaces/S000113/properties/P000116.md
+++ b/spaces/S000113/properties/P000116.md
@@ -7,7 +7,7 @@ refs:
   name: Classical Descriptive Set Theory (Kechris)
 ---
 
-By Theorem 3.11 of {{doi:10.1007/978-1-4612-4190-4}}, and because {S176|P116}, it suffices
+By Theorem 3.11 of {{doi:10.1007/978-1-4612-4190-4}}, and because {S114|P116}, it suffices
 to show {S113} is $G_\delta$ in {S176}. The closure of the space in the plane
 is {S114}, which is $G_\delta$ in the plane as {S176|P132}.
 The complement of the space in {S114} is $\{(0,y):y\in[-1,0)\cup(0,1]\}$, which is $F_\sigma$ as,

--- a/spaces/S000129/properties/P000068.md
+++ b/spaces/S000129/properties/P000068.md
@@ -1,0 +1,8 @@
+---
+space: S000129
+property: P000068
+value: false
+---
+
+It is easy to check being {P68} passes to closed subspaces. Since $\{(x,y) \in \mathbb{R}^2: x^2 + y^2 = 1\}$ is a closed subspace which is
+homeomorphic to {S170} and {S170|P68}, the result follows.

--- a/spaces/S000130/properties/P000068.md
+++ b/spaces/S000130/properties/P000068.md
@@ -1,0 +1,8 @@
+---
+space: S000062
+property: P000068
+value: false
+---
+
+It is easy to check being {P68} passes to coaser topologies. Since the topology on the space is finer than
+{S25} and {S25|P68}, the result follows.

--- a/spaces/S000130/properties/P000068.md
+++ b/spaces/S000130/properties/P000068.md
@@ -1,5 +1,5 @@
 ---
-space: S000062
+space: S000130
 property: P000068
 value: false
 ---

--- a/spaces/S000130/properties/P000068.md
+++ b/spaces/S000130/properties/P000068.md
@@ -4,5 +4,5 @@ property: P000068
 value: false
 ---
 
-It is easy to check being {P68} passes to coaser topologies. Since the topology on the space is finer than
+It is easy to check being {P68} passes to coarser topologies. Since the topology on the space is finer than
 {S25} and {S25|P68}, the result follows.

--- a/spaces/S000139/properties/P000068.md
+++ b/spaces/S000139/properties/P000068.md
@@ -1,0 +1,8 @@
+---
+space: S000139
+property: P000068
+value: false
+---
+
+It is easy to check being {P68} passes to closed subspaces. Since {S139}
+contains a closed subspace homeomorphic to {S170} and {S170|P68}, the result follows.

--- a/spaces/S000143/properties/P000068.md
+++ b/spaces/S000143/properties/P000068.md
@@ -1,0 +1,8 @@
+---
+space: S000143
+property: P000068
+value: false
+---
+
+It is easy to check being {P68} passes to closed subspaces. Since {S170} embeds as a closed subspace of
+{S143} and {S170|P68}, the result follows.

--- a/spaces/S000192/properties/P000068.md
+++ b/spaces/S000192/properties/P000068.md
@@ -1,0 +1,8 @@
+---
+space: S000192
+property: P000068
+value: false
+---
+
+It is easy to check being {P68} passes to coaser topologies. Since the topology on the space is finer than
+{S65} and {S65|P68}, the result follows.

--- a/spaces/S000192/properties/P000068.md
+++ b/spaces/S000192/properties/P000068.md
@@ -4,5 +4,5 @@ property: P000068
 value: false
 ---
 
-It is easy to check being {P68} passes to coaser topologies. Since the topology on the space is finer than
+It is easy to check being {P68} passes to coarser topologies. Since the topology on the space is finer than
 {S65} and {S65|P68}, the result follows.

--- a/spaces/S000198/properties/P000068.md
+++ b/spaces/S000198/properties/P000068.md
@@ -1,0 +1,8 @@
+---
+space: S000198
+property: P000068
+value: false
+---
+
+It is easy to check being {P68} passes to closed subspaces. Since {S198}
+contains {S25} as a closed subspace and {S25|P68}, the result follows.

--- a/spaces/S000206/properties/P000068.md
+++ b/spaces/S000206/properties/P000068.md
@@ -1,0 +1,8 @@
+---
+space: S000206
+property: P000068
+value: false
+---
+
+It is easy to check being {P68} passes to coaser topologies. Since the topology on the space is finer than
+{S25} and {S25|P68}, the result follows.

--- a/spaces/S000206/properties/P000068.md
+++ b/spaces/S000206/properties/P000068.md
@@ -4,5 +4,5 @@ property: P000068
 value: false
 ---
 
-It is easy to check being {P68} passes to coaser topologies. Since the topology on the space is finer than
+It is easy to check being {P68} passes to coarser topologies. Since the topology on the space is finer than
 {S25} and {S25|P68}, the result follows.


### PR DESCRIPTION
This was alluded to in https://github.com/pi-base/data/pull/961#issuecomment-2505919897. A large amount of spaces in pi-Base can be shown to be non-[Rothberger](https://topology.pi-base.org/properties/P000068), using three obvious facts:

1. $X$ is Rothberger iff its Kolmogorov quotient is
2. Rothberger property passes to closed subspaces
3. Rothberger property passes to coarser topologies

This PR is the result of combing through all spaces for which Rothberger property is unknown and adding the traits whenever a space can be shown to be non-Rothberger by easy applications of the three facts above. Two exceptions are [S112](https://topology.pi-base.org/spaces/S000112), which I opted to show it has no isolated point (I also clarified the definition, as the definition in *Counterexamples in Topology* makes it clear $R_0$ is not supposed to be part of the space), and [S113](https://topology.pi-base.org/spaces/S000113), which I opted to show Polish. Both are quite simple to show and stronger than non-Rothberger, under known traits and theorems.