### PR TITLE
P109: Monotonically normal

### DIFF
--- a/properties/P000014.md
+++ b/properties/P000014.md
@@ -10,8 +10,11 @@ refs:
     name: Normal space on Wikipedia
 ---
 
-A space for which any subspace is {P13} (under the subspace topology). 
-Equivalently, any two separated sets (sets for which each misses the other's closure)
+Every subspace of $X$ is {P13}.
+
+Equivalently, every open subspace of $X$ is {P13}.
+
+Equivalently, any two *separated sets* (sets for which each misses the other's closure)
 can be placed into disjoint open sets.
 
-Defined on page 11 of {{doi:10.1007/978-1-4612-6290-9}} (as \(T_5\)).
+Defined on page 11 of {{doi:10.1007/978-1-4612-6290-9}} (as $T_5$).

--- a/properties/P000108.md
+++ b/properties/P000108.md
@@ -4,8 +4,8 @@ name: Hereditarily collectionwise normal
 refs:
   - wikipedia: Collectionwise_normal_space
     name: Collectionwise normal space on Wikipedia
-  - zb: "0684.54001"
-    name: General Topology (Engelking, 1989)
+  - mathse: 4737011
+    name: Definition of hereditarily collectionwise normal spaces using separated families
 ---
 
 Every subspace of $X$ is {P88}.
@@ -19,4 +19,4 @@ there exists a pairwise disjoint family of open sets $(U_i)_{i \in I}$ with $F_i
 $F_i \cap \operatorname{cl}_X(\bigcup_{j \ne i}F_j) = \empty$,
 that is, if the family of the $F_i$ is discrete in its union.)
 
-The equivalence of the conditions above is Problem 5.5.1(a) in {{zb:0684.54001}}.
+For the equivalence of the conditions above, see {{mathse:4737011}}.

--- a/properties/P000108.md
+++ b/properties/P000108.md
@@ -1,0 +1,22 @@
+---
+uid: P000108
+name: Hereditarily collectionwise normal
+refs:
+  - wikipedia: Collectionwise_normal_space
+    name: Collectionwise normal space on Wikipedia
+  - zb: "0684.54001"
+    name: General Topology (Engelking, 1989)
+---
+
+Every subspace of $X$ is {P88}.
+
+Equivalently, every open subspace of $X$ is {P88}.
+
+Equivalently, for every *separated family* $(F_i)_{i \in I}$  of subsets of $X$,
+there exists a pairwise disjoint family of open sets $(U_i)_{i \in I}$ with $F_i \subseteq U_i$ for all $i$.
+
+(The family $(F_i)_i$ is called a *separated family* if for each $i$, 
+$F_i \cap \operatorname{cl}_X(\bigcup_{j \ne i}F_j) = \empty$,
+that is, if the family of the $F_i$ is discrete in its union.)
+
+The equivalence of the conditions above is Problem 5.5.1(a) in {{zb:0684.54001}}.

--- a/properties/P000109.md
+++ b/properties/P000109.md
@@ -1,0 +1,66 @@
+---
+uid: P000109
+name: Monotonically normal
+refs:
+  - zb: "0269.54009"
+    name: Monotonically normal spaces (Heath, Lutzer, Zenor)
+  - wikipedia: Monotonically_normal_space
+    name: Monotonically normal space on Wikipedia
+  - zb: "1327.54003"
+    name: Mary Ellen Rudin and monotone normality (Bennett & Lutzer)
+  - zb: "0257.54018"
+    name: A study of monotonically normal spaces (Borges)
+---
+
+There are several equivalent definitions.
+See {{wikipedia:Monotonically_normal_space}} for a few more.
+
+**Definition (1)**: (see Definition 2.1 in {{zb:0269.54009}})
+
+The space is {P2} and there is a function $G$ that assigns to each
+ordered pair $(A,B)$ of disjoint closed sets in $X$ an open set $G(A,B)$ such that:
+- (i) $A\subseteq G(A,B)\subseteq \overline{G(A,B)}\subseteq X\setminus B$;
+- (ii) $G(A,B)\subseteq G(A',B')$ whenever $A\subseteq A'$ and $B'\subseteq B$.
+
+The operator $G$ is called a *monotone normality operator*.
+
+One can always choose $G$ to satisfy the property
+
+$\quad G(A,B)\cap G(B,A)=\emptyset,$
+
+by replacing each $G(A,B)$ by $G(A,B)\setminus\overline{G(B,A)}$.
+
+----
+**Definition (2)**: (see Theorem 2.2(e) in {{zb:1327.54003}} and references there)
+
+The space is {P2} and there is a function $\mu$ that assigns to each pair $(x,U)$ with $U$ open in $X$ and $x\in U$ an open set $\mu(x,U)$ such that:
+- (i) $x\in\mu(x,U)$;
+- (ii) if $\mu(x,U)\cap\mu(y,V)\ne\emptyset$, then $x\in V$ or $y\in U$.
+
+Such a function $\mu$ automatically satisfies
+
+$\quad x\in\mu(x,U)\subseteq\overline{\mu(x,U)}\subseteq U$.
+
+*Note 1*: It is sufficient to assume the function $\mu$ is defined for $U$ belonging to a base for the topology.
+
+*Note 2*: It is not necessarily the case that $\mu(x,U)$ satisfies monotonicity in $U$,
+that is, $\mu(x,U)\subseteq\mu(x,U')$ if $x\in U\subseteq U'$.
+But one can construct a modified function
+
+$\quad \nu(x,U)=\bigcup\{\mu(x,W):W\text{ open, }x\in W\subseteq U\}$,
+
+which does satisfy (i), (ii), and monotonicity in $U$.
+
+----
+**Equivalence between the two definitions**: (see {{zb:0257.54018}})
+
+Given $G$ from Definition (1) with the condition $G(A,B)\cap G(B,A)=\emptyset$,
+the function $\mu(x,U)=G(\{x\},X\setminus U)$ satisfies Definition (2).
+
+Given $\mu$ from Definition (2) and the associated function $\nu$,
+the function $G(A,B)=\bigcup\{\nu(x,X\setminus B):x\in A\}$ satisfies Definition (1).
+
+----
+#### Meta-properties
+
+- This property is hereditary (easy consequence of Definition (2)).

--- a/theorems/T000629.md
+++ b/theorems/T000629.md
@@ -3,15 +3,11 @@ uid: T000629
 if:
   P000154: true
 then:
-  P000088: true
+  P000109: true
 refs:
-  - zb: "0189.53103"
-    name: A direct proof that a linearly ordered space is hereditarily collectionwise normal (Steen)
-  - mathse: 322974
-    name: Answer to "Why are ordered spaces normal? [collecting proofs]"
+  - zb: "0269.54009"
+    name: Monotonically normal spaces (Heath, Lutzer, Zenor)
 ---
 
-{{zb:0189.53103}} shows that every {P133} is hereditarily collectionwise normal.
-See also {{mathse:322974}}.
-
-The result follows, since a {P154} is a subspace of a {P133}.
+See Corollary 5.6 in {{zb:0269.54009}}.
+Also [here](http://at.yorku.ca/b/ask-a-topologist/2003/0383.htm) for the case of a {P133}.

--- a/theorems/T000665.md
+++ b/theorems/T000665.md
@@ -1,0 +1,9 @@
+---
+uid: T000665
+if:
+  P000108: true
+then:
+  P000088: true
+---
+
+By definition.

--- a/theorems/T000666.md
+++ b/theorems/T000666.md
@@ -1,0 +1,9 @@
+---
+uid: T000666
+if:
+  P000108: true
+then:
+  P000014: true
+---
+
+By {T213}, every subspace of $X$ is {P13}.

--- a/theorems/T000667.md
+++ b/theorems/T000667.md
@@ -1,0 +1,11 @@
+---
+uid: T000667
+if:
+  P000109: true
+then:
+  P000008: true
+---
+
+If $X$ is {P109}, it is {P13} from part (i) of Definition (1),
+and is also {P2}, hence {P7}.
+But monotone normality is hereditary.  Therefore $X$ is {P8}.

--- a/theorems/T000668.md
+++ b/theorems/T000668.md
@@ -1,0 +1,12 @@
+---
+uid: T000668
+if:
+  P000109: true
+then:
+  P000108: true
+refs:
+  - zb: "0269.54009"
+    name: Monotonically normal spaces (Heath, Lutzer, Zenor)
+---
+
+See Theorem 3.1 in {{zb:0269.54009}}.

--- a/theorems/T000669.md
+++ b/theorems/T000669.md
@@ -14,4 +14,6 @@ The space is {P2}.
 For $x\in U$ with $U$ open in $X$,
 define $\mu(x,U)$ to be some open ball $B(x,\epsilon)$, $\epsilon>0$,
 such that $B(x,2\epsilon)\subseteq U$.
-The triangle inequality shows that $\mu(x,U)$ satisfies Definition (2) of {P109}.
+If $B(x,\epsilon_1)\cap B(y,\epsilon_2)\ne\emptyset$ with $\epsilon_2\le\epsilon_1$,
+necessarily $y\in B(x,2\epsilon_1)$ by the triangle inequality.
+So $\mu(x,U)$ satisfies Definition (2) of {P109}.

--- a/theorems/T000669.md
+++ b/theorems/T000669.md
@@ -1,0 +1,17 @@
+---
+uid: T000669
+if:
+  P000053: true
+then:
+  P000109: true
+---
+
+Let $(X,d)$ be a metric space.
+Write $B(x,\epsilon)$ for the open ball centered at $x$ with radius $\epsilon$.
+
+The space is {P2}.
+
+For $x\in U$ with $U$ open in $X$,
+define $\mu(x,U)$ to be some open ball $B(x,\epsilon)$, $\epsilon>0$,
+such that $B(x,2\epsilon)\subseteq U$.
+The triangle inequality shows that $\mu(x,U)$ satisfies Definition (2) of {P109}.


### PR DESCRIPTION
Two new properties:
- P108: Hereditarily collectionwise normal
- P109: Monotonically normal

together with related theorems.  This covers most theorems proposed in #927.

I have assumed T1 as part of the property, as it is needed for the equivalence of definitions (1) and (2) of monotonic normality, and it seems to be always assumed in papers.