### PR TITLE
Countably paracompact + hyperconnected => countably compact

### DIFF
--- a/theorems/T000670.md
+++ b/theorems/T000670.md
@@ -1,0 +1,16 @@
+---
+uid: T000670
+if:
+  and:
+  - P000032: true
+  - P000039: true
+then:
+  P000019: true
+---
+
+Let $\mathscr U$ be a countable open cover of $X$.
+Let $\mathscr V$ be a locally finite open refinement of $\mathscr U$ covering $X$.
+Given a point $x\in X$, there is an open neighborhood $W$ of $x$ that intersects only finitely many members of $\mathscr V$.
+But since $X$ is {P39}, $W$ intersects all (nonempty) members of $\mathscr V$;
+hence $\mathscr V$ is finite.
+That is sufficient to conclude that $\mathscr U$ has a finite subcover.


### PR DESCRIPTION
New T670: Countably paracompact + hyperconnected => countably compact.

As discussed in #1032.

This allows to also derive: [ Paracompact + hyperconnected => compact ].
[π-Base, Search for `Paracompact + Hyperconnected + ~Compact`](https://topology.pi-base.org/spaces?q=Paracompact+%2B+Hyperconnected+%2B+%7ECompact)

As a consequence, S145 (Free ultrafilter topology on $\omega$) is not countably paracompact and not paracompact (previously unknown).