### PR TITLE
T673: Tychonoff P-spaces are cozero complemented

### DIFF
--- a/theorems/T000673.md
+++ b/theorems/T000673.md
@@ -9,6 +9,6 @@ then:
 ---
 
 Every clopen set in a topological space is a cozero set.
-On the other hand, if $X$ is {P147}, every zero set is clopen, and so is every cozero set.
+On the other hand, if $X$ is {P147}, since every zero set is an intersection of countably many open sets, every zero set is clopen, and so is every cozero set.
 So given a cozero set $U$ in $X$, its complement $X\setminus U$ is also a cozero set,
 and their union is obviously dense in $X$.

--- a/theorems/T000673.md
+++ b/theorems/T000673.md
@@ -1,0 +1,14 @@
+---
+uid: T000673
+if:
+  and:
+  - P000147: true
+  - P000006: true
+then:
+  P000061: true
+---
+
+Every clopen set in a topological space is a cozero set.
+On the other hand, if $X$ is {P147}, every zero set is clopen, and so is every cozero set.
+So given a cozero set $U$ in $X$, its complement $X\setminus U$ is also a cozero set,
+and their union is obviously dense in $X$.


### PR DESCRIPTION
New T673: P-space + Tychonoff => cozero complemented.

See issue #1048.

Implies that S22 (Fortissimo space on the real numbers) is cozero complemented.

Note: I used "zero set" and "cozero set" without hyphen, as that seems to be more common terminology.
