### PR TITLE
Two new theorems about monotonically normal and hereditarily collectionwise normal

### DIFF
--- a/theorems/T000663.md
+++ b/theorems/T000663.md
@@ -1,0 +1,12 @@
+---
+uid: T000663
+if:
+  and:
+  - P000197: true
+  - P000014: true
+then:
+  P000108: true
+---
+
+{P197} is a hereditary property and so is {P14}. Thus, the result follows from
+{T661}.

--- a/theorems/T000664.md
+++ b/theorems/T000664.md
@@ -1,5 +1,5 @@
 ---
-uid: T000665
+uid: T000664
 if:
   P000109: true
 then:

--- a/theorems/T000664.md
+++ b/theorems/T000664.md
@@ -1,0 +1,12 @@
+---
+uid: T000665
+if:
+  P000109: true
+then:
+  P000032: true
+refs:
+  - doi: 10.1016/C2009-0-12309-7
+    name: Handbook of Set-Theoretic Topology (Kunen & Vaughan)
+---
+
+See Theorems 1.2 and 2.3 of Chapter 17 of {{doi:10.1016/C2009-0-12309-7}}.


### PR DESCRIPTION
As discussed in #1012, this adds two new theorems:

1. Has countable spread + Completely normal => Hereditarily collectionwise normal, as suggested by @Moniker1998 in https://github.com/pi-base/data/pull/1012#issuecomment-2533412347, this resolves the hereditarily collectionwise normality of all finite spaces (as of now, there are ten finite spaces for which this is not known);
2. Monotonically normal => Countably paracompact, as noted in #927.

As promised, here is a high-level overview of the proof of "Monotonically normal => Countably paracompact", as well as a slightly simplified proof with some typo fixes:

The first part of this is reducing countably paracompact to a technical condition. I'll just reproduce the result and the outline of the proof here: If $X$ is normal and satisfies,

($\ast$) For any decreasing sequence of closed sets $D_n$ in $X$ whose intersection is empty, there exists $U_n \supset D_n$ open s.t. $\bigcap_n U_n = \varnothing$

Then $X$ is countably paracompact. (In fact, for a normal space $X$, ($\ast$) is equivalent to countable paracompactness. We only need the easy direction $(\ast)$ implying countable paracompactness here.)

The argument is that, given any countable open cover $V_n$, we can let $D_n = (\bigcup_{i\leq n} V_i)^c$. Then $D_n$ decreases to $\varnothing$, so we get the promised $U_n$. By normality, there exists open $Y_n$ with $D_n \subset Y_n \subset \overline{Y_n} \subset U_n$. Of course, the intersection of $\overline{Y_n}$ is $\varnothing$, so $Z_n = \overline{Y_n}^c$ form an open cover. Moreover,

$$\overline{Z_n} = \text{int}(\overline{Y_n})^c \subset Y_n^c \subset D_n^c = \bigcup_{i=1}^n V_i$$

So $V_n \setminus (\bigcup_{i<n} \overline{Z_i}) \supset V_n \setminus (\bigcup_{i<n} V_i)$. Thus, $V_n \setminus (\bigcup_{i<n} \overline{Z_i})$ is an open cover and clearly a refinement of $V_n$. It is locally finite, since each $Z_m$ only intersects $V_n \setminus (\bigcup_{i<n} \overline{Z_i})$ when $n \leq m$ and $Z_m$ is an open cover of $X$.

Now, the main part of the argument, namely, showing monotonically normal implies $(\ast)$. The argument uses the second definition in [P109](https://topology.pi-base.org/properties/P000109). Per Note 2 there, we can and will assume $\mu(x,U)$ is monotonic in $U$. Given a sequence of closed sets $D_n$ decreasing to $\varnothing$, we will construct $U_n \supset D_n$ with $\bigcap_n U_n = \varnothing$.

The naive first approach is as follows: Define $U_n = \bigcup_{x\in D_n} \mu(x,U_x)$ for suitable open neighborhood $U_x$ of $x$. There is an obvious choice of $U_x$ - since $D_n$ decreases to $\varnothing$, there is a minimum $i(x) \in \omega$ s.t. $x \notin D_{i(x)}$, so $D_{i(x)}^c$ is an open neighborhood of $x$. Let $W(x) = \mu(x,D_{i(x)}^c)$ and $U_n = \bigcup_{x\in D_n} W(x)$. Let's first see what can go wrong in this naive approach.

Assume $x \in \bigcap_n U_n$. Then there exists $p_n \in D_n$ for each $n$ s.t. $x \in W(p_n) = \mu(p_n,D_{i(p_n)}^c)$ for all $n$. Consider $i(\\{p_n:n\in\omega\\})$. This set cannot be finite, as otherwise we would have, for sufficiently large $N$, $p_n\notin D_N$ for all $n$. But $p_N \in D_N$ by definition. Thus, there is an infinite set $M \subset \omega$ (which is just $i(\\{p_n:n\in\omega\\})$ ), and, for each $k \in M$, a point $q_k$ with $i(q_k) = k$ (which is just some $p_n$ where $i(p_n) = k$, s.t. $x \in W(q_k) = \mu(q_k,D_k^c)$ for all $k$.

Note that when $k<j$ in $M$, we then have $\mu(q_k,D_k^c)\cap\mu(q_j,D_j^c) \neq \varnothing$, since it contains $x$. As $k<j$ and $i(q_j)=j$, we have $q_j\in D_k$, so this implies $q_k\in D_j^c$. This, by itself, is not a contradiction. After all, $q_k$ is even in $D_k^c$, which is a subset of $D_j^c$. This indicates to us a modification to $W(x)$ is needed. What if, instead of $W(x) = \mu(x,D_{i(x)}^c)$, we choose,

$$W(x) = \mu(x,D_{ i(x) }^c \setminus ( \bigcup_{ n < i(x) } D_n^c )) $$

Since $x\in D_n$ for all $n<i(x)$, $x$ is actually contained in the second argument. And this would indeed lead to the desired contradiction, since $q_k \in D_k^c$ and $k<j$. But the issue is, of course, that $D_{ i(x) }^c \setminus ( \bigcup_{ n < i(x) } D_n^c )$ needs not be open. Instead, we want to replace $\bigcup_{ n < i(x) } D_n^c$ by an appropriate closed subset - and the best supply of such things is $\overline{\mu(x,D_n^c)}$, as (see Definition 2 in [P109](https://topology.pi-base.org/properties/P000109)) we have $\overline{\mu(x,D_n^c)} \subset D_n^c$. We should judiciously choose finitely many $x\in D_n^c$ and remove the corresponding $\overline{\mu(x,D_n^c)}$. Moreover, this also means, instead of $W(x) = \mu(x,D_{i(x)}^c)$, we should actually do it twice, and define $U(x) = \mu(x,W(x))$ where $W(x)$ is $\mu(x,D_{i(x)}^c)$ with the appropriately chosen finitely many closed subsets removed. This then leads to the desired contradiction. (As it turns out, we actually need to do this more than twice, but that is mainly technical details that will be addressed in the detailed proof later.)

Now, let us discuss a bit the details as to how to choose those "finitely many closed subsets" of $\mu(x,D_{i(x)}^c)$. Note that, again for $k<j$ in $M$, now we have $\mu(q_k,W(q_k))\cap\mu(q_j,W(q_j)) \neq \varnothing$. Again, $q_j\notin W(q_k)$, so $q_k \in W(q_j) \subset \mu(q_j,D_j^c)$. Let us denote,

$$V(x) = \mu(x,D_{i(x)}^c)$$

Then $M$ satisfies, for any $k<j$ in $M$,

$$q_k \in V(x_j)$$

The above property will be our starting point of the formal proof, which we will start now:

**Definition:** For any $x\in X$, let $i(x)$ be the minimum natural number s.t. $x \notin D_{i(x)}$. Let $V_0(x) =  \mu(x,D_{i(x)}^c)$ and inductively define $V_n(x) = \mu(x, V_{n-1}(x))$.

**Definition:** For an infinite subset $Y \subset X$, we shall say it has property S if,

$$Y = \\{ q_k : k \in M \\} $$

for some infinite $M \subset \omega$; and $i(q_k) = k$ for all $k$; and for any $k<j$ in $M$, $q_k \in V_{j-k}(x_j)$. For any $Y$ with property S as above, let,

$$Y' = \\{ x \in X: x \in V_{k-i(x)}(q_k) \text{ for all }k > i(x), k \in M \\} $$

A quick observation is that $Y \subset Y'$ for all $Y$ with property S.

Enumerate all property S sets by $S_\alpha$, $\alpha < \lambda$ for some ordinal $\lambda$. We now define $W(x)$ as follows:

**Definition:** If $x$ is not in $S_\alpha'$ for any $\alpha$, let $W(x) = \mu(x,V_{i(x)}(x))$. Otherwise, let $\alpha$ be the minimum ordinal for which $x \in S_\alpha'$. Let $S_\alpha = \\{ q_k : k \in M \\} $. Then let $W(x) = \mu(x, V_{i(x)}(x) \setminus (\bigcup_{k < i(x), k \in M} \overline{V_0(q_k)} )$. Note that this is well-defined since $\overline{V_0(q_k)} \subset D_k^c$ and, as $k < i(x)$, $x \in D_k$.

Now, let $U(x) = \mu(x, W(x))$ and let,

$$U_n = \bigcup_{x \in D_n} U(x)$$

I claim that $\bigcap_n U_n = \varnothing$. Indeed, assume to the contrary that $x \in \bigcap_n U_n$. Then there exists $p_n \in D_n$ s.t. $x \in U(p_n)$ for all $n$. Again, $i( \\{ p_n: n \in \omega \\} )$ has to be infinite, as otherwise there exists sufficiently large $N$ s.t. $p_n \notin D_N$ for all $n$. In particular, $p_N \notin D_N$, which is a contradiction. Thus, we may choose $M = i( \\{ p_n: n \in \omega \\} )$, and for each $k \in M$, choose $q_k$ to be some $p_n$ s.t. $i(p_n) = k$. Moreover, we note that, for any $k < j$ in $M$, $x \in \mu(q_k, W(q_k)) \cap \mu(q_j, W(q_j))$. Since $k < j$, $q_j \in D_k$, so,

$$q_j \notin D_k^c \supset V_0(q_k) \supset V_k(q_k) \supset W(q_k)$$

Hence, $q_k \in W(q_j) \subset V_j(q_j) \subset V_{j-k}(q_j)$. Thus, the collection of all $q_k$ has property S, and is therefore of the form $S_\beta$ for some $\beta < \lambda$. As we have noted before, $S_\beta \subset S_\beta'$, so there is a minimum $\alpha < \lambda$ s.t. $S_\beta \cap S_\alpha' \neq \varnothing$. We may thus choose $q_k$ s.t. $q_k \in S_\alpha'$. Let $S_\alpha = \\{ x_n: n \in M' \\} $. By definition of $S_\alpha'$, we have $q_k \in V_{n-k}(x_n)$ for all $n \in M'$, $n > k$.

Now, if $k < j$ in $M$, $n \in M'$, $n > j$, then $q_k \in V_{n-k}(x_n)$ and $q_k \in V_{j-k}(q_j)$, so,

$$\mu(x_n, V_{n-j}(x_n)) \cap \mu(q_j, D_j^c) \supset V_{n-k}(x_n) \cap V_{j-k}(q_j) \neq \varnothing$$

Since $n > j$, $x_n \in D_j$, so we must have $q_j \in D_{n-j}(x_n)$. As this holds for arbitrary $n>j$, $n \in M'$, we thus have $q_j \in S_\alpha'$. Since $\alpha$ is the minimum ordinal for which $S_\beta \cap S_\alpha' \neq \varnothing$, $\alpha$ is thus the minimum ordinal for which $q_j \in S_\alpha'$. Note that this holds for all $j>k$, $j \in M$.

Now, choose $m \in M'$ with $m > k$ and then $j \in M$ with $j > m$. As we have seen, $q_k \in W(q_j)$. Since $\alpha$ is the minimum ordinal for which $q_j \in S_\alpha'$, by definition of $W(q_j)$, we have,

$$q_k \in W(q_j) = \mu(q_j, V_j(q_j) \setminus (\bigcup_{n < j, n \in M'} \overline{V_0(x_n)} ) \subset V_0(x_m)^c$$

However, at the same time, $q_k \in S_\alpha'$, so by definition of $S_\alpha'$, we have $q_k \in V_{m-j}(x_m) \subset V_0(x_m)$. This yields the desired contradiction. $\square$