### PR TITLE
Rudin's Dowker space is a P-space and not realcompact

### DIFF
--- a/spaces/S000138/properties/P000147.md
+++ b/spaces/S000138/properties/P000147.md
@@ -1,0 +1,7 @@
+---
+space: S000138
+property: P000147
+value: true
+---
+
+Let $U_n = \{g\in X : h_n < g \leq f\}$ be neighbourhoods of $f$ where $h_n\in \prod_{k\in\omega} (\omega_{k+1}+1)$ and define $h(k) := \sup_n h_n(k)$. Then $h(k) < f(k)$ for all $k$ since $\text{cf}(f(k)) > \omega$, so $U = \{g\in X : h < g \leq f\}$ is a neighbourhood of $f$ with $U\subseteq \bigcap_{n=1}^\infty U_n$. 

--- a/spaces/S000138/properties/P000147.md
+++ b/spaces/S000138/properties/P000147.md
@@ -2,6 +2,9 @@
 space: S000138
 property: P000147
 value: true
+refs:
+- doi: 10.4064/fm-73-2-179-186
+  name: A normal space X for which X×I is not normal (M.E. Rudin)
 ---
 
-Let $U_n = \{g\in X : h_n < g \leq f\}$ be neighbourhoods of $f$ where $h_n\in \prod_{k\in\omega} (\omega_{k+1}+1)$ and define $h(k) := \sup_n h_n(k)$. Then $h(k) < f(k)$ for all $k$ since $\text{cf}(f(k)) > \omega$, so $U = \{g\in X : h < g \leq f\}$ is a neighbourhood of $f$ with $U\subseteq \bigcap_{n=1}^\infty U_n$. 
+See lemma 4 in {{doi:10.4064/fm-73-2-179-186}}.

--- a/spaces/S000138/properties/P000162.md
+++ b/spaces/S000138/properties/P000162.md
@@ -1,0 +1,10 @@
+---
+space: S000138
+property: P000162
+value: false
+refs:
+- doi: 10.4064/fm-73-2-179-186
+  name: A normal space X for which X×I is not normal (M.E. Rudin)
+---
+
+See IV.4 of {{doi:10.4064/fm-73-2-179-186}}.


### PR DESCRIPTION
Resolves https://topology.pi-base.org/spaces/S000138/properties/P000147

Note that there is no trait that could be added from which this one could be deduced, and that wouldn't be deducible from this and already existing properties of S138.
