### PR TITLE
S30 and S32 not embeddable into Euclidean space

### DIFF
--- a/spaces/S000030/properties/P000184.md
+++ b/spaces/S000030/properties/P000184.md
@@ -1,0 +1,11 @@
+---
+space: S000030
+property: P000184
+value: false
+refs:
+- mathse: 5009117
+  name: The Hilbert cube cannot be embedded in some Euclidean space $\mathbb R^n$
+---
+
+Every Euclidean space $\mathbb R^n$ embeds into $X$.
+Therefore, as explained in {{mathse:5009117}}, $X$ cannot itself be embedded into a fixed $\mathbb R^m$.

--- a/spaces/S000032/properties/P000184.md
+++ b/spaces/S000032/properties/P000184.md
@@ -1,0 +1,11 @@
+---
+space: S000032
+property: P000184
+value: false
+refs:
+- mathse: 5009117
+  name: The Hilbert cube cannot be embedded in some Euclidean space $\mathbb R^n$
+---
+
+Every Euclidean space $\mathbb R^n$, which is homeomorphic to $(0,1)^n$, embeds into $X$.
+Therefore, as explained in {{mathse:5009117}}, $X$ cannot itself be embedded into a fixed $\mathbb R^m$.


### PR DESCRIPTION
S30 (countable product of reals) and S32 (Hilbert cube) are not embeddable into Euclidean space.

See #1029.

@yhx-12243 I'll let you review this, as it was part of your #990.
