### PR TITLE
Part 3 of #1018: Right open-ray topology on $[0,1]$

### DIFF
--- a/spaces/S000158/README.md
+++ b/spaces/S000158/README.md
@@ -1,9 +1,9 @@
 ---
 uid: S000158
-name: Unit interval
+name: Unit interval $[0,1]$
 refs:
   - zb: "1052.54001"
     name: General Topology (Willard)
 ---
-The subspace \(I=[0,1]=\{t\in \mathbb R : 0\leq x \leq 1\}\) of the
-Euclidean real line \(\mathbb{R}\).
+
+The subspace $I=[0,1]=\{t\in \mathbb R : 0\leq x \leq 1\}$ of {S25} $\mathbb{R}$.

--- a/spaces/S000159/README.md
+++ b/spaces/S000159/README.md
@@ -7,3 +7,5 @@ refs:
 ---
 
 $X$ has underlying set $[0,1]$ and the open sets are exactly $X$ and $(a,1]$ for $0 \leq a \leq 1$.
+
+This space is described in part 3 of {{mathse:5007860}}.

--- a/spaces/S000159/README.md
+++ b/spaces/S000159/README.md
@@ -1,6 +1,9 @@
 ---
 uid: S000159
 name: Right "open-ray" topology on the unit interval
+refs:
+  - mathse: 5007860
+    name: Answer to "For a compact sober "highly non-$T_1$" space, how much "highly connectedness" is needed to imply it's a spectral space?"
 ---
 
 $X$ has underlying set $[0,1]$ and the open sets are exactly $X$ and $(a,1]$ for $0 \leq a \leq 1$.

--- a/spaces/S000159/README.md
+++ b/spaces/S000159/README.md
@@ -1,0 +1,6 @@
+---
+uid: S000159
+name: Right "open-ray" topology on the unit interval
+---
+
+$X$ has underlying set $[0,1]$ and the open sets are exactly $X$ and $(a,1]$ for $0 \leq a \leq 1$.

--- a/spaces/S000159/README.md
+++ b/spaces/S000159/README.md
@@ -1,6 +1,6 @@
 ---
 uid: S000159
-name: Right "open-ray" topology on the unit interval
+name: Right "open-ray" topology on $[0,1]$
 refs:
   - mathse: 5007860
     name: Answer to "For a compact sober "highly non-$T_1$" space, how much "highly connectedness" is needed to imply it's a spectral space?"
@@ -8,4 +8,4 @@ refs:
 
 $X$ has underlying set $[0,1]$ and the open sets are exactly $X$ and $(a,1]$ for $0 \leq a \leq 1$.
 
-This space is described in part 3 of {{mathse:5007860}}.
+This space is used in part 3 of {{mathse:5007860}}.

--- a/spaces/S000159/properties/P000027.md
+++ b/spaces/S000159/properties/P000027.md
@@ -1,0 +1,7 @@
+---
+space: S000159
+property: P000027
+value: true
+---
+ 
+$X$ and $(a,1]$ for rational $0 \leq a \leq 1$ clearly form a basis for the topology.

--- a/spaces/S000159/properties/P000027.md
+++ b/spaces/S000159/properties/P000027.md
@@ -4,4 +4,4 @@ property: P000027
 value: true
 ---
  
-$X$ and $(a,1]$ for rational $0 \leq a \leq 1$ clearly form a basis for the topology.
+$X$ and the sets $(a,1]$ for rational $0 \leq a \leq 1$ form a basis for the topology.

--- a/spaces/S000159/properties/P000038.md
+++ b/spaces/S000159/properties/P000038.md
@@ -1,0 +1,8 @@
+---
+space: S000159
+property: P000038
+value: true
+---
+ 
+The topology on $X$ is coarser than that of {S158}, so the formal identity map from {S158} to
+{S159} restricts to an arc between any two given points in $X$.

--- a/spaces/S000159/properties/P000038.md
+++ b/spaces/S000159/properties/P000038.md
@@ -1,8 +1,0 @@
----
-space: S000159
-property: P000038
-value: true
----
- 
-The topology on $X$ is coarser than that of {S158}, so the formal identity map from {S158} to
-{S159} restricts to an arc between any two given distinct points in $X$.

--- a/spaces/S000159/properties/P000038.md
+++ b/spaces/S000159/properties/P000038.md
@@ -5,4 +5,4 @@ value: true
 ---
  
 The topology on $X$ is coarser than that of {S158}, so the formal identity map from {S158} to
-{S159} restricts to an arc between any two given points in $X$.
+{S159} restricts to an arc between any two given distinct points in $X$.

--- a/spaces/S000159/properties/P000043.md
+++ b/spaces/S000159/properties/P000043.md
@@ -6,5 +6,4 @@ value: true
 
 The topology on $X$ is coarser than that of {S158}, so the formal identity map from {S158} to
 {S159} restricts to an arc between any two given distinct points in $X$.
-More generally, all open sets are of the form $X$ or $(a,1]$ for $0 \leq a \leq 1$, which are all {P38} by
-essentially the same argument.
+Therefore, since all nonempty open sets in $X$ are order-convex, they are {P38}.

--- a/spaces/S000159/properties/P000043.md
+++ b/spaces/S000159/properties/P000043.md
@@ -1,0 +1,8 @@
+---
+space: S000159
+property: P000043
+value: true
+---
+ 
+All open sets are of the form $X$ or $(a,1]$ for $0 \leq a \leq 1$. By essentially the same proof as
+{S159|P38}, they are all arc connected.

--- a/spaces/S000159/properties/P000043.md
+++ b/spaces/S000159/properties/P000043.md
@@ -3,6 +3,8 @@ space: S000159
 property: P000043
 value: true
 ---
- 
-All open sets are of the form $X$ or $(a,1]$ for $0 \leq a \leq 1$. By essentially the same proof as
-{S159|P38}, they are all arc connected.
+
+The topology on $X$ is coarser than that of {S158}, so the formal identity map from {S158} to
+{S159} restricts to an arc between any two given distinct points in $X$.
+More generally, all open sets are of the form $X$ or $(a,1]$ for $0 \leq a \leq 1$, which are all {P38} by
+essentially the same argument.

--- a/spaces/S000159/properties/P000073.md
+++ b/spaces/S000159/properties/P000073.md
@@ -1,0 +1,10 @@
+---
+space: S000159
+property: P000073
+value: true
+refs:
+  - mathse: 5007860
+    name: Answer to "For a compact sober "highly non-$T_1$" space, how much "highly connectedness" is needed to imply it's a spectral space?
+---
+ 
+See part 3 of {{mathse:5007860}}.

--- a/spaces/S000159/properties/P000075.md
+++ b/spaces/S000159/properties/P000075.md
@@ -1,0 +1,10 @@
+---
+space: S000159
+property: P000075
+value: false
+refs:
+  - mathse: 5007860
+    name: Answer to "For a compact sober "highly non-$T_1$" space, how much "highly connectedness" is needed to imply it's a spectral space?
+---
+ 
+See part 3 of {{mathse:5007860}}.

--- a/spaces/S000159/properties/P000130.md
+++ b/spaces/S000159/properties/P000130.md
@@ -5,5 +5,5 @@ value: true
 ---
  
 Given a point $x\in X$, every neighborhood of $x$ contains a neighborhood of $x$
-of the form $[a,1]$ for some $a\in[0,1]$.
+of the form $[a,1]$ for some $a\in[0,1)$.
 Any such set $[a,1]$ is {P202} with $a$ as focal point, hence {P16}.

--- a/spaces/S000159/properties/P000130.md
+++ b/spaces/S000159/properties/P000130.md
@@ -1,0 +1,9 @@
+---
+space: S000159
+property: P000130
+value: true
+---
+ 
+If $x = 0$, then $\{X\}$ is a neighborhood basis at $x$ and {S159|P16}.
+If $0 < x \leq 1$, then $[a,1]$ for $0 < a < x$ form a neighborhood basis at $x$. Any such $[a,1]$ is
+{P202}, namely $a$, so it is {P16}.

--- a/spaces/S000159/properties/P000130.md
+++ b/spaces/S000159/properties/P000130.md
@@ -4,6 +4,6 @@ property: P000130
 value: true
 ---
  
-If $x = 0$, then $\{X\}$ is a neighborhood basis at $x$ and {S159|P16}.
-If $0 < x \leq 1$, then $[a,1]$ for $0 < a < x$ form a neighborhood basis at $x$. Any such $[a,1]$ is
-{P202}, namely $a$, so it is {P16}.
+Given a point $x\in X$, every neighborhood of $x$ contains a neighborhood of $x$
+of the form $[a,1]$ for some $a\in[0,1]$.
+Any such set $[a,1]$ is {P202} with $a$ as focal point, hence {P16}.

--- a/spaces/S000159/properties/P000139.md
+++ b/spaces/S000159/properties/P000139.md
@@ -1,0 +1,7 @@
+---
+space: S000159
+property: P000139
+value: false
+---
+ 
+Easily seen from the construction that no open set is a singleton.

--- a/spaces/S000159/properties/P000139.md
+++ b/spaces/S000159/properties/P000139.md
@@ -4,4 +4,4 @@ property: P000139
 value: false
 ---
  
-Easily seen from the construction that no open set is a singleton.
+No open set is a singleton.

--- a/spaces/S000159/properties/P000196.md
+++ b/spaces/S000159/properties/P000196.md
@@ -1,0 +1,7 @@
+---
+space: S000159
+property: P000196
+value: true
+---
+ 
+Easily seen from the construction.

--- a/spaces/S000159/properties/P000196.md
+++ b/spaces/S000159/properties/P000196.md
@@ -4,4 +4,4 @@ property: P000196
 value: true
 ---
  
-Easily seen from the construction.
+By construction.

--- a/spaces/S000159/properties/P000202.md
+++ b/spaces/S000159/properties/P000202.md
@@ -4,4 +4,4 @@ property: P000202
 value: true
 ---
  
-Easily seen from the construction that the only neighborhood of $0$ is $X$.
+The only neighborhood of $0$ is $X$.

--- a/spaces/S000159/properties/P000202.md
+++ b/spaces/S000159/properties/P000202.md
@@ -1,0 +1,7 @@
+---
+space: S000159
+property: P000202
+value: true
+---
+ 
+Easily seen from the construction that the only neighborhood of $0$ is $X$.


### PR DESCRIPTION
This is part 3 of #1018, which adds the right open-ray topology on $[0,1]$. This is an example of a hereditarily connected, compact, and sober space which is not spectral, showing that the cardinality condition in the new theorem proposed in #1097 is necessary.