### PR TITLE
Part 5 of #1018: Adding two new hereditarily connected spectral spaces

### DIFF
--- a/spaces/S000166/README.md
+++ b/spaces/S000166/README.md
@@ -1,0 +1,6 @@
+---
+uid: S000166
+name: Left ray topology on $\omega+1$
+---
+
+$X$ has underlying set $\omega+1$. The open sets are exactly $X$ and $[0,a)$ for $a \in X$. Equivalently, this is the Alexandrov topology for the reverse ordering on $\omega+1$.

--- a/spaces/S000166/README.md
+++ b/spaces/S000166/README.md
@@ -6,4 +6,4 @@ refs:
     name: Alexandrov topology on Wikipedia
 ---
 
-$X$ has underlying set $\omega+1$. The open sets are exactly $X$ and $[0,a)$ for $a \in X$. Equivalently, this is the Alexandrov topology for the reverse ordering on $\omega+1$.
+$X$ has underlying set $\omega+1$. The open sets are exactly $X$ and $[0,a)$ for $a \in X$. Equivalently, the open sets are exactly downwards closed subsets of $X$. This is the Alexandrov topology for the reverse ordering on $\omega+1$.

--- a/spaces/S000166/README.md
+++ b/spaces/S000166/README.md
@@ -1,6 +1,9 @@
 ---
 uid: S000166
 name: Left ray topology on $\omega+1$
+refs:
+  - wikipedia: Alexandrov_topology
+    name: Alexandrov topology on Wikipedia
 ---
 
 $X$ has underlying set $\omega+1$. The open sets are exactly $X$ and $[0,a)$ for $a \in X$. Equivalently, this is the Alexandrov topology for the reverse ordering on $\omega+1$.

--- a/spaces/S000166/properties/P000073.md
+++ b/spaces/S000166/properties/P000073.md
@@ -1,0 +1,7 @@
+---
+space: S000166
+property: P000073
+value: true
+---
+
+By construction, any nonempty closed set is of the form $[a,\omega]$ for $a \in X$, which has a unique generic point $a$.

--- a/spaces/S000166/properties/P000090.md
+++ b/spaces/S000166/properties/P000090.md
@@ -1,0 +1,7 @@
+---
+space: S000166
+property: P000090
+value: true
+---
+
+By definition.

--- a/spaces/S000166/properties/P000181.md
+++ b/spaces/S000166/properties/P000181.md
@@ -1,0 +1,7 @@
+---
+space: S000166
+property: P000181
+value: true
+---
+
+By construction.

--- a/spaces/S000166/properties/P000196.md
+++ b/spaces/S000166/properties/P000196.md
@@ -1,0 +1,7 @@
+---
+space: S000166
+property: P000196
+value: true
+---
+
+Easily seen from the construction.

--- a/spaces/S000166/properties/P000202.md
+++ b/spaces/S000166/properties/P000202.md
@@ -1,0 +1,7 @@
+---
+space: S000166
+property: P000202
+value: true
+---
+
+Easily seen from the construction that the only neighborhood of $\omega$ is $X$.

--- a/spaces/S000166/properties/P000208.md
+++ b/spaces/S000166/properties/P000208.md
@@ -1,0 +1,7 @@
+---
+space: S000166
+property: P000208
+value: false
+---
+
+$\{[0,n)\}_n$ is a strictly increasing sequence of open sets.

--- a/spaces/S000167/README.md
+++ b/spaces/S000167/README.md
@@ -1,0 +1,6 @@
+---
+uid: S000167
+name: Right "open-ray" topology on $\omega+1+\omega^\ast$
+---
+
+$X$ has underlying totally ordered set $(\omega+1)+\omega^\ast$, where the second $+$ is concatenation, $\omega+1$ is equipped with its usual order as an ordinal, and $\omega^\ast$ is $\omega$ with the reverse order. The open sets are exactly $X$ and $(a,\to)$ for $a \in X$.

--- a/spaces/S000167/properties/P000051.md
+++ b/spaces/S000167/properties/P000051.md
@@ -1,0 +1,7 @@
+---
+space: S000167
+property: P000051
+value: false
+---
+
+It is easy to see that $\omega \subset X$ has subspace topology {S200}, and {S200|P139}.

--- a/spaces/S000167/properties/P000073.md
+++ b/spaces/S000167/properties/P000073.md
@@ -1,0 +1,7 @@
+---
+space: S000167
+property: P000073
+value: true
+---
+
+By construction, any nonempty closed set is of the form $[0,a]$ for $a \in X$, which has a unique generic point $a$.

--- a/spaces/S000167/properties/P000090.md
+++ b/spaces/S000167/properties/P000090.md
@@ -1,0 +1,7 @@
+---
+space: S000167
+property: P000090
+value: false
+---
+
+Easily seen from the construction that $\omega$ does not have a smallest neighborhood.

--- a/spaces/S000167/properties/P000139.md
+++ b/spaces/S000167/properties/P000139.md
@@ -1,0 +1,7 @@
+---
+space: S000167
+property: P000139
+value: true
+---
+
+$0^\ast \in \omega^\ast$ is isolated, since $\{0^\ast\} = (1^\ast,\to)$.

--- a/spaces/S000167/properties/P000181.md
+++ b/spaces/S000167/properties/P000181.md
@@ -1,0 +1,7 @@
+---
+space: S000167
+property: P000181
+value: true
+---
+
+By construction.

--- a/spaces/S000167/properties/P000196.md
+++ b/spaces/S000167/properties/P000196.md
@@ -1,0 +1,7 @@
+---
+space: S000167
+property: P000196
+value: true
+---
+
+Easily seen from the construction.

--- a/spaces/S000167/properties/P000202.md
+++ b/spaces/S000167/properties/P000202.md
@@ -1,0 +1,7 @@
+---
+space: S000167
+property: P000202
+value: true
+---
+
+Easily seen from the construction that the only neighborhood of $0$ is $X$.

--- a/spaces/S000167/properties/P000208.md
+++ b/spaces/S000167/properties/P000208.md
@@ -1,0 +1,7 @@
+---
+space: S000167
+property: P000208
+value: false
+---
+
+$(n^\ast,\to) \subset \omega^\ast$ for $n < \omega$ form a strictly increasing sequence of open sets.


### PR DESCRIPTION
This is part 5 of #1018, which adds two new spaces: left ray topology on $\omega+1$ and right open ray topology on $\omega+1+\omega^\ast$. The first is an example of a hereditarily connected, compact, sober, and countably infinite space which is not Noetherian, showing that the new theorem proposed in #1097 is independent from [T528](https://topology.pi-base.org/theorems/T000528). However, the space is Alexandrov, so the space being spectral also follows from [T554](https://topology.pi-base.org/theorems/T000554).

The second space is hereditarily connected, compact, sober, and countably infinite. And it is neither Alexandrov nor Noetherian, demonstrating the new theorem proposed in #1097 is simultaneously independent from T528 and T554. Basically, these two examples together with the one in #1101 show the various possible combinations for a hereditarily connected, compact, sober, and countably infinite space. The second space being spectral is currently not automatically deducible by pi-Base, but will be once the theorem from #1097 is added. (This is the first example in which the said theorem is necessary to deduce spectral.)

I'm adding these two spaces in a single PR because the traits for them are all very simple and similar to each other (and are all similar to the traits of the space proposed in #1101), so it shouldn't be much of a problem to review them together.