### PR TITLE
Name change: Cofinite topology on omega extended by a non-isolated generic point

### DIFF
--- a/spaces/S000048/README.md
+++ b/spaces/S000048/README.md
@@ -11,7 +11,7 @@ refs:
   - wikipedia: Zariski_topology
     name: Zariski topology
 ---
-Let $X = \omega \sqcup \{p\}$. A nonempty set is open if and only if it contains $p$ and has a finite complement. Hence the subspace $\omega \subset X$ equals {S15}. Note that $p$ is a generic point of $X$ and $\{p\}$ is not open; see {P201}.
+Let $X = \omega \sqcup \{p\}$. A nonempty set is open if and only if it contains $p$ and has a finite complement. Hence the subspace $\omega \subseteq X$ equals {S15}. Note that $p$ is a generic point of $X$ and $\{p\}$ is not open; see {P201}.
 
 $X$ is homeomorphic to the set of prime ideals of the ring $\mathbb{Z}$ with basis consisting of the sets $V_x = \{P \in X : x \notin P\}$ for all $x \in \mathbb{Z}_{n\ge 0}$. The zero ideal identifies with the generic point $p \in X$. This is the Zariski topology on $\mathrm{Spec}(\mathbb{Z})$, the prime spectrum of the ring of integers. See {{wikipedia:Zariski_topology}} for the general construction of the Zariski topology on the prime spectrum of a commutative ring.
 

--- a/spaces/S000048/README.md
+++ b/spaces/S000048/README.md
@@ -1,6 +1,6 @@
 ---
 uid: S000048
-name: Cofinite topology on $\omega$ extended by a non-isolated generic point
+name: Cofinite topology on $\omega$ extended by a non-open generic point
 counterexamples_id: 56
 aliases:
   - $\mathrm{Spec}(\mathbb{Z})$
@@ -11,7 +11,7 @@ refs:
   - wikipedia: Zariski_topology
     name: Zariski topology
 ---
-Let $X = \omega \sqcup \{p\}$. A nonempty set is open if and only if it contains $p$ and has a finite complement. Note that $p$ is a generic point of $X$; see {P201}.
+Let $X = \omega \sqcup \{p\}$. A nonempty set is open if and only if it contains $p$ and has a finite complement. Note that $p$ is a generic point of $X$ and $\{p\}$ is not open; see {P201}.
 
 $X$ is homeomorphic to the set of prime ideals of the ring $\mathbb{Z}$ with basis consisting of the sets $V_x = \{P \in X : x \notin P\}$ for all $x \in \mathbb{Z}_{n\ge 0}$. The zero ideal identifies with the generic point $p \in X$. This is the Zariski topology on $\mathrm{Spec}(\mathbb{Z})$, the prime spectrum of the ring of integers. See {{wikipedia:Zariski_topology}} for the general construction of the Zariski topology on the prime spectrum of a commutative ring.
 

--- a/spaces/S000048/README.md
+++ b/spaces/S000048/README.md
@@ -1,6 +1,6 @@
 ---
 uid: S000048
-name: Closed extension of cofinite topology on $\omega$
+name: Extension of cofinite topology on $\omega$ by a generic point
 counterexamples_id: 56
 aliases:
   - $\mathrm{Spec}(\mathbb{Z})$

--- a/spaces/S000048/README.md
+++ b/spaces/S000048/README.md
@@ -11,7 +11,7 @@ refs:
   - wikipedia: Zariski_topology
     name: Zariski topology
 ---
-Let $X = \omega \sqcup \{p\}$. A nonempty set is open if and only if it contains $p$ and has a finite complement. This is the *closed extension* of {S15}.  The closed extension construction is described in general in item #20 for space #12 of {{doi:10.1007/978-1-4612-6290-9}}.
+Let $X = \omega \sqcup \{p\}$. A nonempty set is open if and only if it contains $p$ and has a finite complement. This is the *closed extension* of {S15}.  The closed extension construction is described in general in item #20 for space #12 of {{doi:10.1007/978-1-4612-6290-9}}. Note that $p$ is a generic point of $X$; see {P201}.
 
 $X$ is homeomorphic to the set of prime ideals of the ring $\mathbb{Z}$ with basis consisting of the sets $V_x = \{P \in X : x \notin P\}$ for all $x \in \mathbb{Z}_{n\ge 0}$. The zero ideal identifies with the generic point $p \in X$. This is the Zariski topology on $\mathrm{Spec}(\mathbb{Z})$, the prime spectrum of the ring of integers. See {{wikipedia:Zariski_topology}} for the general construction of the Zariski topology on the prime spectrum of a commutative ring.
 

--- a/spaces/S000048/README.md
+++ b/spaces/S000048/README.md
@@ -11,7 +11,7 @@ refs:
   - wikipedia: Zariski_topology
     name: Zariski topology
 ---
-Let $X = \omega \sqcup \{p\}$. A nonempty set is open if and only if it contains $p$ and has a finite complement. This is the *closed extension* of {S15}.  The closed extension construction is described in general in item #20 for space #12 of {{doi:10.1007/978-1-4612-6290-9}}. Note that $p$ is a generic point of $X$; see {P201}.
+Let $X = \omega \sqcup \{p\}$. A nonempty set is open if and only if it contains $p$ and has a finite complement. Note that $p$ is a generic point of $X$; see {P201}.
 
 $X$ is homeomorphic to the set of prime ideals of the ring $\mathbb{Z}$ with basis consisting of the sets $V_x = \{P \in X : x \notin P\}$ for all $x \in \mathbb{Z}_{n\ge 0}$. The zero ideal identifies with the generic point $p \in X$. This is the Zariski topology on $\mathrm{Spec}(\mathbb{Z})$, the prime spectrum of the ring of integers. See {{wikipedia:Zariski_topology}} for the general construction of the Zariski topology on the prime spectrum of a commutative ring.
 

--- a/spaces/S000048/README.md
+++ b/spaces/S000048/README.md
@@ -1,6 +1,6 @@
 ---
 uid: S000048
-name: Cofinite topology on $\omega$ extended by a generic point
+name: Closed extension of cofinite topology on $\omega$
 counterexamples_id: 56
 aliases:
   - $\mathrm{Spec}(\mathbb{Z})$

--- a/spaces/S000048/README.md
+++ b/spaces/S000048/README.md
@@ -11,7 +11,7 @@ refs:
   - wikipedia: Zariski_topology
     name: Zariski topology
 ---
-Let $X = \omega \sqcup \{p\}$. A nonempty set is open if and only if it contains $p$ and has a finite complement. Note that $p$ is a generic point of $X$ and $\{p\}$ is not open; see {P201}.
+Let $X = \omega \sqcup \{p\}$. A nonempty set is open if and only if it contains $p$ and has a finite complement. Hence the subspace $\omega \subset X$ equals {S15}. Note that $p$ is a generic point of $X$ and $\{p\}$ is not open; see {P201}.
 
 $X$ is homeomorphic to the set of prime ideals of the ring $\mathbb{Z}$ with basis consisting of the sets $V_x = \{P \in X : x \notin P\}$ for all $x \in \mathbb{Z}_{n\ge 0}$. The zero ideal identifies with the generic point $p \in X$. This is the Zariski topology on $\mathrm{Spec}(\mathbb{Z})$, the prime spectrum of the ring of integers. See {{wikipedia:Zariski_topology}} for the general construction of the Zariski topology on the prime spectrum of a commutative ring.
 

--- a/spaces/S000048/README.md
+++ b/spaces/S000048/README.md
@@ -1,6 +1,6 @@
 ---
 uid: S000048
-name: Extension of cofinite topology on $\omega$ by a generic point
+name: Cofinite topology on $\omega$ extended by a generic point
 counterexamples_id: 56
 aliases:
   - $\mathrm{Spec}(\mathbb{Z})$

--- a/spaces/S000048/README.md
+++ b/spaces/S000048/README.md
@@ -1,6 +1,6 @@
 ---
 uid: S000048
-name: Closed extension of cofinite topology on $\omega$
+name: Cofinite topology on $\omega$ extended by a non-isolated generic point
 counterexamples_id: 56
 aliases:
   - $\mathrm{Spec}(\mathbb{Z})$

--- a/spaces/S000048/properties/P000139.md
+++ b/spaces/S000048/properties/P000139.md
@@ -1,0 +1,7 @@
+---
+space: S000048
+property: P000139
+value: false
+---
+
+{S15} has no isolated points, and $p$ is assumed to be non-isolated.

--- a/spaces/S000048/properties/P000139.md
+++ b/spaces/S000048/properties/P000139.md
@@ -4,4 +4,4 @@ property: P000139
 value: false
 ---
 
-{S15} has no isolated points, and $p$ is assumed to be non-isolated.
+{S15|P139}, and $p$ is assumed to be non-isolated in $X$.


### PR DESCRIPTION
This PR is due to the new space David is adding *Extension of rationals by a focal point* in the PR https://github.com/pi-base/data/pull/1105, and the comment https://github.com/pi-base/data/pull/1105#issuecomment-2547584366

I decided not the make the previous name *Closed extension of cofinite topology on* $\omega$ into an alias to preserve alias space, but I wasn't sure what we would all think. The 'closed extension' language appears in the description with the reference to Steen-Seebach.