### PR TITLE
Adding two new theorems: "Almost discrete => Sober" and "Almost discrete + Compact => Spectral"

### DIFF
--- a/theorems/T000605.md
+++ b/theorems/T000605.md
@@ -5,8 +5,8 @@ if:
 then:
   P000073: true
 refs:
-  - mathse: 5012491
-    name: Answer to "Connections between almost discrete spaces and sober/spectral spaces"
+  - mathse: 5012490
+    name: Connections between almost discrete spaces and sober/spectral spaces
 ---
 
-See {{mathse:5012491}}.
+See {{mathse:5012490}}.

--- a/theorems/T000605.md
+++ b/theorems/T000605.md
@@ -1,0 +1,12 @@
+---
+uid: T000605
+if:
+  P000203: true
+then:
+  P000073: true
+refs:
+  - mathse: 5012491
+    name: Answer to "Connections between almost discrete spaces and sober/spectral spaces"
+---
+
+See {{mathse:5012491}}.

--- a/theorems/T000606.md
+++ b/theorems/T000606.md
@@ -1,0 +1,14 @@
+---
+uid: T000606
+if:
+  and:
+  - P000203: true
+  - P000016: true
+then:
+  P000075: true
+refs:
+  - mathse: 5012491
+    name: Answer to "Connections between almost discrete spaces and sober/spectral spaces"
+---
+
+See {{mathse:5012491}}.

--- a/theorems/T000606.md
+++ b/theorems/T000606.md
@@ -7,8 +7,8 @@ if:
 then:
   P000075: true
 refs:
-  - mathse: 5012491
-    name: Answer to "Connections between almost discrete spaces and sober/spectral spaces"
+  - mathse: 5012490
+    name: Connections between almost discrete spaces and sober/spectral spaces
 ---
 
-See {{mathse:5012491}}.
+See {{mathse:5012490}}.


### PR DESCRIPTION
These allow the automatic deduction of two new traits: S12 and S13 are spectral.

As far as I could tell, this PR is independent from the two theorems in #1058.