### PR TITLE
Almost discrete spaces are hereditarily collectionwise normal

### DIFF
--- a/theorems/T000575.md
+++ b/theorems/T000575.md
@@ -3,13 +3,16 @@ uid: T000575
 if:
   P000203: true
 then:
-  P000014: true
+  P000108: true
 refs:
 - doi: 10.1016/0166-8641(92)90123-H
   name: Almost discrete SV-spaces (Henrikson, Wilson)
 ---
-First, any almost discrete space is {P13}: if $A$ and $B$ are disjoint closed sets, then at least one of them, say $A$, does not contain the nonisolated point. Then $A$ is clopen, and thus $A$ and $B$ are separated by open sets.
+First, any almost discrete space $X$ is {P13}: if $A$ and $B$ are disjoint closed sets, then at least one of them, say $A$, does not contain the nonisolated point. Then $A$ is clopen, and thus $A$ and $B$ are separated by open sets.
 
-A subspace of an almost discrete space is either almost discrete or discrete and so is also normal. Hence any almost discrete space is completely normal.
+Note also {T574}. {P146}, of course, implies {P30}. Thus, by {T453}, $X$ is fully normal,
+which in turn implies it is {P88}. (See {T214} and {T648}.)
 
-See lemma 2.1(i) of {{doi:10.1016/0166-8641(92)90123-H}}.
+A subspace of an almost discrete space is either almost discrete or discrete and so is always {P88} [(Explore)](https://topology.pi-base.org/spaces?q=Discrete+%2B+not+Collectionwise+normal). Hence any almost discrete space is {P108}.
+
+See also Lemma 2.1(i) of {{doi:10.1016/0166-8641(92)90123-H}}.


### PR DESCRIPTION
This PR strengthens the previous T575, "Almost discrete => Completely normal", to "Almost discrete => Hereditarily collectionwise normal". This allows pi-Base to automatically deduce, for example, that S13 is hereditarily collectionwise normal, which is currently unknown.