### PR TITLE
Strengthening T451 to Indiscrete + Cardinality $\geq c$ => Locally arc connected

### DIFF
--- a/theorems/T000451.md
+++ b/theorems/T000451.md
@@ -5,10 +5,10 @@ if:
   - P000129: true
   - P000058: false
 then:
-  P000038: true
+  P000043: true
 refs:
   - mathse: 3844039
     name: What topological properties are trivially/vacuously satisfied by any indiscrete space?
 ---
 
-Any function into an indiscrete space is continuous, and cardinality $\ge \mathfrak c$ permits injectivity from $[0,1]$.
+Any function into an indiscrete space is continuous, and cardinality $\ge \mathfrak c$ permits injectivity from $[0,1]$, so $X$ is {P38}. Now, just note that the only nonempty open set in an indiscrete space is the entire space.


### PR DESCRIPTION
As noted in https://github.com/pi-base/data/pull/1112#issuecomment-2549560705, it is currently unknown to pi-Base that [S194](https://topology.pi-base.org/spaces/S000194), the indiscrete topology on reals, is locally arc connected. The current T451 only implies it is arc connected. This PR changes it to locally arc connected. The original T451 can still be deduced, because of the new theorem [T676](https://topology.pi-base.org/theorems/T000676), Has a focal point + Locally arc connected => Arc connected, added in #1112, and because a nonempty indiscrete space has a focal point, which is already known to pi-Base.