### PR TITLE
Add missing traits to either-or topology

### DIFF
--- a/spaces/S000014/properties/P000049.md
+++ b/spaces/S000014/properties/P000049.md
@@ -1,0 +1,7 @@
+---
+space: S000014
+property: P000049
+value: false
+---
+
+If $x\in (-1, 1)\setminus \{0\}$ then $\{x\}$ is open but $\overline{\{x\}} = \{x, 0\}$ is not open.

--- a/spaces/S000014/properties/P000203.md
+++ b/spaces/S000014/properties/P000203.md
@@ -1,0 +1,7 @@
+---
+space: S000014
+property: P000203
+value: true
+---
+
+Every point is isolated except for $0$.


### PR DESCRIPTION
While this PR only adds two traits, every trait currently unknown but deducible in ZFC will be added once #1058 is merged