### PR TITLE
Adding missing traits to cofinite topology on $\omega$

### DIFF
--- a/spaces/S000015/properties/P000138.md
+++ b/spaces/S000015/properties/P000138.md
@@ -1,0 +1,10 @@
+---
+space: S000015
+property: P000138
+value: false
+refs:
+  - mo: 27785
+    name: Cardinality of the permutations of an infinite set
+---
+
+Every bijection $f:X\to X$ is a homeomorphism and by {{mo:27785}} there is $\mathfrak{c}$ many such bijections.

--- a/spaces/S000015/properties/P000142.md
+++ b/spaces/S000015/properties/P000142.md
@@ -1,0 +1,7 @@
+---
+space: S000015
+property: P000142
+value: false
+---
+
+An infinite subset $A\subseteq X$ is homeomorphic to $X$ since any bijection $A\to X$ is a homeomorphism. Since {S15|P3}, it follows that the compact Hausdorff subsets of $X$ are the finite subsets, which have the discrete topology. Therefore if $A\subseteq X$ then $A\cap K$ is open in $K$ for all Hausdorff compact $K$. Taking any $A$ which isn't open shows that $X$ is not a $k_3$-space.


### PR DESCRIPTION
Note that proof of P142 is very close to anticompact + $T_1$ + not discrete implies not $k_3$-space, but in this case the space is "anticompact for Hausdorff subspaces" only. 