### PR TITLE
Minor cleanup of door traits

### DIFF
--- a/spaces/S000014/properties/P000126.md
+++ b/spaces/S000014/properties/P000126.md
@@ -1,8 +1,0 @@
----
-space: S000014
-property: P000126
-value: true
----
-
-For every $A\subseteq X$, either $0\not\in A$ and $A$ is open,
-or $0\not\in X\setminus A$ and $X\setminus A$ is open (so $A$ is closed).

--- a/spaces/S000188/properties/P000126.md
+++ b/spaces/S000188/properties/P000126.md
@@ -1,8 +1,0 @@
----
-space: S000188
-property: P000126
-value: true
----
-
-{S10|P126}.
-Hence so is $X$, as the topological sum of a {P52} space and a {P126} space.

--- a/theorems/T000447.md
+++ b/theorems/T000447.md
@@ -6,6 +6,5 @@ then:
   P000001: true
 ---
 
-If $X$ is a non-$T_0$ space, then there exist distinct points $x,y\in X$ which have the same open neighborhoods.
-Then any selfmap $f: X\rightarrow X$ that maps into the set $\\{x, y\\}$ is continuous as $f^{-1}(U)$ is either $X$ or $\varnothing$ for any open set $U\subseteq X$.
-We may then easily select such maps without fixed points by requiring that $f(x)=y$ and $f(y)=x$.
+Suppose $X$ is not {P1}, with two topologically indistinguishable points $a$ and $b$.
+Then the map $f:X\to X$ defined by $f(x)=a$ for $x\ne a$ and $f(a)=b$ is continuous and does not have a fixed point.


### PR DESCRIPTION
Remove redundant P126 (door) trait for two spaces.

Also was going to fix the wrong formatting for https://topology.pi-base.org/theorems/T000447, but I ended up bypassing the problem by writing a simpler proof.
