### PR TITLE
Everywhere doubled line is not hereditarily separable

### DIFF
--- a/spaces/S000086/properties/P000180.md
+++ b/spaces/S000086/properties/P000180.md
@@ -5,4 +5,3 @@ value: false
 ---
 
 The subspace $\mathbb{R}{\times}\{1\}$ is uncountable and discrete hence not separable.
-

--- a/spaces/S000086/properties/P000180.md
+++ b/spaces/S000086/properties/P000180.md
@@ -1,7 +1,0 @@
----
-space: S000086
-property: P000180
-value: false
----
-
-The subspace $\mathbb{R}{\times}\{1\}$ is uncountable and discrete hence not separable.

--- a/spaces/S000086/properties/P000180.md
+++ b/spaces/S000086/properties/P000180.md
@@ -1,7 +1,8 @@
 ---
 space: S000086
-property: P000089
+property: P000180
 value: false
 ---
 
-For any non-zero $a$, $\langle x,i\rangle\mapsto \langle x+a,i\rangle$ is a self-homeomorphism with no fixed points.
+The subspace $\mathbb{R}{\times}\{1\}$ is uncountable and discrete hence not separable.
+

--- a/spaces/S000086/properties/P000180.md
+++ b/spaces/S000086/properties/P000180.md
@@ -1,0 +1,7 @@
+---
+space: S000086
+property: P000089
+value: false
+---
+
+For any non-zero $a$, $\langle x,i\rangle\mapsto \langle x+a,i\rangle$ is a self-homeomorphism with no fixed points.

--- a/spaces/S000086/properties/P000198.md
+++ b/spaces/S000086/properties/P000198.md
@@ -1,0 +1,7 @@
+---
+space: S000086
+property: P000198
+value: false
+---
+
+The subspace $\mathbb{R}{\times}\{1\}$ is closed uncountable and discrete.


### PR DESCRIPTION
A simple contribution to the pi-Base.

The [everywhere doubled line](https://topology.pi-base.org/spaces/S000086) is not [hereditarily separable](https://topology.pi-base.org/properties/P000180). Discussed with @prabau [here](https://github.com/pi-base/data/issues/1075#issuecomment-2558227899).