### PR TITLE
Strengthening T622 to Ultraconnected + Shrinking + not Empty => Has a focal point

### DIFF
--- a/theorems/T000622.md
+++ b/theorems/T000622.md
@@ -13,6 +13,6 @@ Assume to the contrary that $X$ is not {P202}. The intersection of $\overline{\{
 for all $x \in X$ coincides with the intersection of all nonempty closed sets, so it is the set of all focal points of $X$,
 whence empty by assumption. Thus, $\{\overline{\{x\}}^c: x \in X\}$ is an open cover of $X$. As $X$ is {P193}, there
 is an open cover $\{V_x\}_{x \in X}$ of $X$ s.t. $\overline{V_x} \subseteq \overline{\{x\}}^c$ for all $x$. Now, fix $x_0 \in X$.
-Then there exists $x \in X$ s.t. $x_0 \in V_x \subseteq \overline{V_x} \subseteq \overline{\{x\}}^c$. In particular,
-$\overline{\{x_0\}} \subseteq \overline{\{x\}}^c$, i.e., $\overline{\{x_0\}} \cap \overline{\{x\}} = \varnothing$, which
-contradicts $X$ being {P40}.
+There exists $x \in X$ s.t. $x_0 \in V_x \subseteq \overline{V_x} \subseteq \overline{\{x\}}^c$.
+Then $\overline{V_x}$ and $\overline{\{x\}}$ are nonempty disjoint closed sets,
+which contradicts $X$ being {P40}.

--- a/theorems/T000622.md
+++ b/theorems/T000622.md
@@ -3,12 +3,16 @@ uid: T000622
 if:
   and:
   - P000040: true
-  - P000016: true
+  - P000193: true
   - P000137: false
 then:
   P000202: true
 ---
 
-Since $X$ is {P40}, the family of nonempty closed sets in $X$ has the finite intersection property.
-As $X$ is {P16}, that family has nonempty intersection.
-Any point in that intersection belongs to every nonempty closed set.
+Assume to the contrary that $X$ is not {P202}. The intersection of $\overline{\{x\}}$
+for all $x \in X$ coincides with the intersection of all nonempty closed sets, so it is the set of all focal points of $X$,
+whence empty by assumption. Thus, $\{\overline{\{x\}}^c: x \in X\}$ is an open cover of $X$. As $X$ is {P193}, there
+is an open cover $\{V_x\}_{x \in X}$ of $X$ s.t. $\overline{V_x} \subseteq \overline{\{x\}}^c$ for all $x$. Now, fix $x_0 \in X$.
+Then there exists $x \in X$ s.t. $x_0 \in V_x \subseteq \overline{V_x} \subseteq \overline{\{x\}}^c$. In particular,
+$\overline{\{x_0\}} \subseteq \overline{\{x\}}^c$, i.e., $\overline{\{x_0\}} \cap \overline{\{x\}} = \varnothing$, which
+contradicts $X$ being {P40}.


### PR DESCRIPTION
As stated in title.

Note that this is indeed a strengthening of the original T622: Ultraconnected + Compact + not Empty => Has a focal point, as compact implies submetacompact, ultraconnected implies normal (there are some redundant theorems here: T72 says ultraconnected implies collectionwise normal and T656 says ultraconnected implies strongly collectionwise normal), and submetacompact and normal imply shrinking ([T545](https://topology.pi-base.org/theorems/T000545)). I'll also observe here that the shrinking condition cannot be further weakened to countably paracompact ([T543](https://topology.pi-base.org/theorems/T000543)). Indeed, the left ray topology on $\omega_1$ (equivalently, the Alexandrov topology on the reverse ordering of $\omega_1$) is even countably compact, since any countable open cover must contain $X$ itself, and it is hereditarily connected and thus ultraconnected, but it has no focal point.

(I should also note that a direct proof of "Ultraconnected + Submetacompact + not Empty => Has a focal point" can also be obtained along similar lines. In fact, the open cover in the proof of the new T622 cannot have an open refinement that's point finite at even one point.)