### PR TITLE
Introduce S209 Circle with two origins

### DIFF
--- a/spaces/S000209/README.md
+++ b/spaces/S000209/README.md
@@ -1,0 +1,10 @@
+---
+uid: S000209
+name: Circle with two origins
+---
+
+Choose a point $0 \in S^1$ to be called the origin, and replace $0$ with two origins $0_1$ and $0_2$. Basic open neighborhoods of a point $x \neq 0$ are Euclidean open neighborhoods of $x$ not containing $0$. Basic open neighborhoods of each origin $0_i$ are of the form $(U\setminus\{0\})\cup\{0_i\}$ with $U$ a Euclidean open neighborhood of $0$.
+
+Let $\{1, 2\}$ have the discrete topology. $X$ is homeomorphic to the quotient space of $S^1 \times \{1, 2\}$ obtained by identifying $\langle \theta, 1 \rangle$ and $\langle \theta, 2 \rangle$ exactly when $\theta \not\equiv 0 \mod 2\pi$.
+
+$X$ is homeomorphic to the one-point compactification of {S83}.

--- a/spaces/S000209/README.md
+++ b/spaces/S000209/README.md
@@ -1,10 +1,13 @@
 ---
 uid: S000209
 name: Circle with two origins
+refs:
+  - wikipedia: Alexandroff_extension
+    name: Alexandroff extension on Wikipedia
 ---
 
 Choose a point $0 \in S^1$ to be called the origin, and replace $0$ with two origins $0_1$ and $0_2$. Basic open neighborhoods of a point $x \neq 0$ are Euclidean open neighborhoods of $x$ not containing $0$. Basic open neighborhoods of each origin $0_i$ are of the form $(U\setminus\{0\})\cup\{0_i\}$ with $U$ a Euclidean open neighborhood of $0$.
 
-Let $\{1, 2\}$ have the discrete topology. $X$ is homeomorphic to the quotient space of $S^1 \times \{1, 2\}$ obtained by identifying $\langle \theta, 1 \rangle$ and $\langle \theta, 2 \rangle$ exactly when $\theta \not\equiv 0 \mod 2\pi$.
+Let $\{1, 2\}$ have the discrete topology. $X$ is homeomorphic to the quotient space of $S^1 \times \{1, 2\}$ obtained by identifying $\langle \theta, 1 \rangle$ and $\langle \theta, 2 \rangle$ exactly when $\theta {\not\equiv} 0 \mod 2\pi$.
 
-$X$ is homeomorphic to the one-point compactification of {S83}.
+$X$ is homeomorphic to the Alexandroff extension of {S83}.

--- a/spaces/S000209/properties/P000016.md
+++ b/spaces/S000209/properties/P000016.md
@@ -1,0 +1,7 @@
+---
+space: S000209
+property: P000016
+value: true
+---
+
+$X$ is homeomorphic to the one-point compactification of {S83}.

--- a/spaces/S000209/properties/P000016.md
+++ b/spaces/S000209/properties/P000016.md
@@ -2,6 +2,9 @@
 space: S000209
 property: P000016
 value: true
+refs:
+  - wikipedia: Alexandroff_extension
+    name: Alexandroff extension on Wikipedia
 ---
 
-$X$ is homeomorphic to the one-point compactification of {S83}.
+$X$ is homeomorphic to the Alexandroff extension of {S83}.

--- a/spaces/S000209/properties/P000038.md
+++ b/spaces/S000209/properties/P000038.md
@@ -4,4 +4,4 @@ property: P000038
 value: true
 ---
 
-The map $[0, 2\pi] \to X$ defined by $t \mapsto \langle t, 1 \rangle$ if $t < 2\pi$ and $2\pi \mapsto \langle 2\pi, 2\rangle$ is an injective and continuous. It is clear by restricting this to sub-intervals and reparameterizing that every pair of points is connected by an injective path.
+The map $[0, 2\pi] \to X$ defined by $t \mapsto \langle t, 1 \rangle$ if $t < 2\pi$ and $2\pi \mapsto \langle 2\pi, 2\rangle$ is injective and continuous. It is clear by restricting this map to sub-intervals and reparameterizing the results that every pair of points is connected by an injective path.

--- a/spaces/S000209/properties/P000038.md
+++ b/spaces/S000209/properties/P000038.md
@@ -1,0 +1,7 @@
+---
+space: S000209
+property: P000038
+value: true
+---
+
+The map $[0, 2\pi] \to X$ defined by $t \mapsto \langle t, 1 \rangle$ if $t < 2\pi$ and $2\pi \mapsto \langle 2\pi, 2\rangle$ is an injective and continuous. It is clear by restricting this to sub-intervals and reparameterizing that every pair of points is connected by an injective path.

--- a/spaces/S000209/properties/P000101.md
+++ b/spaces/S000209/properties/P000101.md
@@ -1,0 +1,7 @@
+---
+space: S000209
+property: P000101
+value: false
+---
+
+Same argument as {S83|P101}.

--- a/spaces/S000209/properties/P000123.md
+++ b/spaces/S000209/properties/P000123.md
@@ -1,0 +1,7 @@
+---
+space: S000209
+property: P000123
+value: true
+---
+
+Each point is contained in an open set homeomorphic to $S^1$, namely $X\setminus\{0_1\}$ or $X\setminus\{0_2\}$, and {S170|P123}.

--- a/spaces/S000209/properties/P000169.md
+++ b/spaces/S000209/properties/P000169.md
@@ -1,0 +1,7 @@
+---
+space: S000209
+property: P000169
+value: false
+---
+
+Same argument as {S83|P169}.

--- a/spaces/S000209/properties/P000200.md
+++ b/spaces/S000209/properties/P000200.md
@@ -1,0 +1,10 @@
+---
+space: S000209
+property: P000200
+value: false
+refs:
+  - zb: "1044.55001"
+    name: Algebraic Topology (Hatcher)
+---
+
+The map sending the origins to $0_1$ and fixing all other points is a retraction onto {S170}. Since {S170|P200}, it follows by Proposition 1.17 of {{zb:1044.55001}} that $X$ is not simply connected.

--- a/spaces/S000209/properties/P000204.md
+++ b/spaces/S000209/properties/P000204.md
@@ -1,0 +1,7 @@
+---
+space: S000209
+property: P000204
+value: false
+---
+
+For any $p \in X$, $X \backslash \{p\}$ is either homeomorphic to {S83} or {S170}.


### PR DESCRIPTION
Part of https://github.com/pi-base/data/issues/675

This space will be a good counterexample for distinguishing injectively path connected from arc connected, when that gets changed + added. 

Just going to leave it to the currently added traits for this PR (unless any others are requested, also requesting the removal of any traits for now is fine too). The main thing for this PR is getting the right description mostly in order.