### PR TITLE
Semimetrizable/symmetrizable meta-properties

### DIFF
--- a/properties/P000102.md
+++ b/properties/P000102.md
@@ -15,8 +15,8 @@ refs:
 For a set $X$, a function $d:X^2\to[0,\infty)$ is called a *symmetric*
 if it satisfies reflexivity ($d(x,y)=0\Leftrightarrow x=y$) and symmetry
 ($d(x,y)=d(y,x)$). A space $X$ is called *semimetrizable* if
-there is a symmetric $d:X^2\to[0,\infty)$ such that the neighborhood balls
-$B(x,\varepsilon)=\{y\in X:d(x,y)<\varepsilon\}$ for $\varepsilon>0$
+there is a symmetric $d:X^2\to[0,\infty)$ such that the balls
+$B_d(x,\varepsilon)=\{y\in X:d(x,y)<\varepsilon\}$ for $\varepsilon>0$
 form a neighborhood basis at each point $x\in X$. Such a symmetric is called a *semimetric*.
 (Note that {{zb:0116.14303}} demonstrates that
 these neighborhood balls need not be open sets.)
@@ -24,6 +24,11 @@ these neighborhood balls need not be open sets.)
 Equivalently:
 - There exists a symmetric $d$ such that $p$ lies in the closure of some $Y\subseteq X$ iff $d(p,Y)=\inf\{d(p,y):y\in Y\}=0$.
 Such a symmetric is automatically a semimetric.
-- $X$ is {P2}. And, for each $x \in X$, there is a non-increasing sequence of open sets $\{G_n(x):n<\omega\}$ forming a local neighborhood basis for $x$. Moreover, if for some sequence $x_n$ in $X$, $y\in X$ belongs to $G_n(x_n)$ for all $n$, then $x_n\to y$. In particular, $X$ is {P28}. This equivalence is shown in Theorem 3.2 of {{zb:0113.16501}}.
+- (i) $X$ is {P2}; (ii) for each $x \in X$, there is a non-increasing sequence of open sets $\{G_n(x):n<\omega\}$ forming a local neighborhood basis for $x$; (iii) if for some sequence $x_n$ in $X$, $y\in X$ belongs to $G_n(x_n)$ for all $n$, then $x_n\to y$. This equivalence is shown in Theorem 3.2 of {{zb:0113.16501}}.
 
 Defined in e.g. {{zb:0113.16501}} and {{doi:10.2991/978-94-6239-216-8}}. Note that some sources, e.g., {{doi:10.2307/2370790}}, use the term semimetric to refer to a symmetric and the term semimetrizable to refer to {P104}.
+
+----
+#### Meta-properties
+
+- This property is hereditary.  Compare with {P104}.

--- a/properties/P000104.md
+++ b/properties/P000104.md
@@ -14,10 +14,15 @@ For a set $X$, a function $d:X^2\to[0,\infty)$ is called a *symmetric*
 if it satisfies reflexivity ($d(x,y)=0\Leftrightarrow x=y$) and symmetry
 ($d(x,y)=d(y,x)$). A space $X$ is called *symmetrizable* if
 there is a symmetric such that a subset $U \subseteq X$ is open iff for each $x \in U$,
-there is some $\varepsilon > 0$ with $B(x,\varepsilon)=\{y\in X:d(x,y)<\varepsilon\}$
+there is some $\varepsilon > 0$ with $B_d(x,\varepsilon)=\{y\in X:d(x,y)<\varepsilon\}$
 being contained in $U$.
 
 Equivalently, there exists a symmetric $d$ such that $Y \subseteq X$ is closed iff $d(p,Y)=\inf\{d(p,y):y\in Y\} > 0$ for all $p \in X \setminus Y$.
 
 Defined in {{doi:10.2991/978-94-6239-216-8}}. Note that some sources, e.g., {{doi:10.2307/2370790}}, use the term semimetric
 (see {P102}) to refer to a symmetric and the term semimetrizable to refer to {P104}.
+
+----
+#### Meta-properties
+
+- This property is not hereditary. (Example: {S156|P104} and {S23|P104}.) Compare with {P102}.

--- a/properties/P000187.md
+++ b/properties/P000187.md
@@ -14,5 +14,7 @@ During each round $n<\omega$, P1 chooses some neighborhood $U_n$ of $x$,
 then P2 chooses some point $p_n\in U_n$. P1 wins provided the sequence
 $p_n$ converges to $x$; P2 wins otherwise.
 
-Note that this property is hereditary: any space contained in a {P187} space
-is also {P187}.
+----
+#### Meta-properties
+
+- This property is hereditary.

--- a/theorems/T000616.md
+++ b/theorems/T000616.md
@@ -4,9 +4,6 @@ if:
   P000102: true
 then:
   P000028: true
-refs:
-- zb: "0116.14303"
-  name: A regular semi-metric space for which there is no semimetric under which all spheres are open. (Heath)
 ---
 
-A consequence of the characterization given in {{zb:0116.14303}}.
+The balls $B_d(x,1/n)$ for $n=1,2,\dots$ form a neighborhood base at the point $x$.


### PR DESCRIPTION
Adding some meta-properties for semimetrizable/symmetrizable, as discussed in #1165.

Also minor cleanup in the README for semimetrizable, and simplification for T616 (semimetrizable => first countable).

And better formatting for meta-properties of W-space.