### PR TITLE
Expand definitions of locally (path) connected

### DIFF
--- a/properties/P000041.md
+++ b/properties/P000041.md
@@ -2,10 +2,29 @@
 uid: P000041
 name: Locally connected
 refs:
+  - zb: "1342.30054"
+    name: The Mazurkiewicz distance and sets that are finitely connected at the boundary (Björn, Björn, Shanmugalingam)
+  - wikipedia: Locally_connected_space
+    name: Locally connected space on Wikipedia
   - doi: 10.1007/978-1-4612-6290-9
     name: Counterexamples in Topology
 ---
 
-The space has a basis consisting of (open) {P36} sets.
+The topology of $X$ has a base consisting of {P36} open sets.
+
+This is equivalent to each of the following:
+
+* The connected components of every open set are open.
+
+* $X$ is *locally connected at $x$* for every $x\in X$;
+that is, each $x$ has a neighborhood base consisting of open connected sets.
+
+* $X$ is *connected im kleinen at $x$* for every $x\in X$;
+that is, each $x$ has a neighborhood base consisting of (not necessarily open) connected sets.
+
+Note: In general, local connectedness at a point $x$ is not equivalent to connectedness im kleinen at $x$.
+But the corresponding global statements (where the condition holds at every point) are equivalent.
+
+For terminology and the equivalence between the conditions above, see section 2 of {{zb:1342.30054}} and {{wikipedia:Locally_connected_space}}, plus the references therein.
 
 Defined on page 30 of {{doi:10.1007/978-1-4612-6290-9}}.

--- a/properties/P000042.md
+++ b/properties/P000042.md
@@ -2,10 +2,29 @@
 uid: P000042
 name: Locally path connected
 refs:
+  - zb: "1342.30054"
+    name: The Mazurkiewicz distance and sets that are finitely connected at the boundary (Björn, Björn, Shanmugalingam)
+  - wikipedia: Locally_connected_space
+    name: Locally connected space on Wikipedia
   - doi: 10.1007/978-1-4612-6290-9
     name: Counterexamples in Topology
 ---
 
-The space has a basis consisting of (open) {P37} sets.
+The topology of $X$ has a base consisting of {P37} open sets.
+
+This is equivalent to each of the following:
+
+* The path components of every open set are open.
+
+* $X$ is *locally path connected at $x$* for every $x\in X$;
+that is, each $x$ has a neighborhood base consisting of open path connected sets.
+
+* $X$ is *path connected im kleinen at $x$* for every $x\in X$;
+that is, each $x$ has a neighborhood base consisting of (not necessarily open) path connected sets.
+
+Note: In general, local path connectedness at a point $x$ is not equivalent to path connectedness im kleinen at $x$.
+But the corresponding global statements (where the condition holds at every point) are equivalent.
+
+For terminology and the equivalence between the conditions above, see section 2 of {{zb:1342.30054}} and {{wikipedia:Locally_connected_space}}, plus the references therein.
 
 Defined on page 30 of {{doi:10.1007/978-1-4612-6290-9}}.


### PR DESCRIPTION
Add equivalent formulations for P41 (locally connected) and P42 (locally path connected).

This may be a useful preliminary for the work of introducing "injectively path connected" and the corresponding local property.