### PR TITLE
Strengthen T534 to countably compact

### DIFF
--- a/theorems/T000534.md
+++ b/theorems/T000534.md
@@ -2,10 +2,17 @@
 uid: T000534
 if:
   and:
-  - P000016: true
+  - P000019: true
   - P000112: true
 then:
   P000053: true
 ---
 
-A compact space does not have a strictly coarser $T_2$ topology.
+Let $f \colon X \to Y$ be a continuous bijection from a {P19} space $X$ to a {P53} space $Y$.
+
+Let $A \subseteq X$ be closed.
+Since closed subspaces and continuous images of a {P19} space are {P19}, we know that $f(A)$ is {P19}.
+
+Since $Y$ is {P53}, it is {P103} [(Explore)](https://topology.pi-base.org/spaces?q=Metrizable+%2B+%7EStrongly+KC), and hence $f(A)$ is closed in $Y$.
+
+Therefore, $f$ is a closed map and we know that $f$ is a homeomorphism, which implies $X$ itself is {P53}.

--- a/theorems/T000534.md
+++ b/theorems/T000534.md
@@ -11,8 +11,7 @@ then:
 Let $f \colon X \to Y$ be a continuous bijection from a {P19} space $X$ to a {P53} space $Y$.
 
 Let $A \subseteq X$ be closed.
-Since closed subspaces and continuous images of a {P19} space are {P19}, we know that $f(A)$ is {P19}.
-
+Since closed subspaces and continuous images of a {P19} space are {P19}, $f(A)$ is {P19}.
 Since $Y$ is {P53}, it is {P103} [(Explore)](https://topology.pi-base.org/spaces?q=Metrizable+%2B+%7EStrongly+KC), and hence $f(A)$ is closed in $Y$.
 
-Therefore, $f$ is a closed map and we know that $f$ is a homeomorphism, which implies $X$ itself is {P53}.
+Therefore, $f$ is a closed map and $f$ is a homeomorphism, which implies $X$ itself is {P53}.


### PR DESCRIPTION
A little result resolves 6 unknown traits.

[π-Base, Search for `?Countably Compact + Submetrizable + ~Metrizable`](https://topology.pi-base.org/spaces?q=%3FCountably+Compact+%2B+Submetrizable+%2B+%7EMetrizable)
[π-Base, Search for `Countably Compact + ?Submetrizable + ~Metrizable`](https://topology.pi-base.org/spaces?q=Countably+Compact+%2B+%3FSubmetrizable+%2B+%7EMetrizable)