### PR TITLE
Stop using Cloudflare R2 uploads

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -26,13 +26,13 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: us-east-2
 
-      - name: Upload bundle to R2
-        run: |
-          aws s3api put-object --endpoint-url https://78c505984bbdc3e69206eecb9471c4de.r2.cloudflarestorage.com --bucket pi-base --key ${GITHUB_REF:-unknown}.json --body bundle.json
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: auto
+      # - name: Upload bundle to R2
+      #   run: |
+      #     aws s3api put-object --endpoint-url https://78c505984bbdc3e69206eecb9471c4de.r2.cloudflarestorage.com --bucket pi-base --key ${GITHUB_REF:-unknown}.json --body bundle.json
+      #   env:
+      #     AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      #     AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      #     AWS_DEFAULT_REGION: auto
 
 #       - name: Notify Slack
 #         run: |

--- a/foo
+++ b/foo
@@ -1,0 +1,1 @@
+add words

--- a/foo
+++ b/foo
@@ -1,1 +1,0 @@
-add words


### PR DESCRIPTION
Cloudflare R2 uploads stopped working recently, but we do not seem to be using them in production for anything, so removing that unnecessary (broken) step for now.  ATTN @jamesdabbs @prabau 