### PR TITLE
T_4 submetacompact space smaller than first measurable cardinal is realcompact

### DIFF
--- a/theorems/T000382.md
+++ b/theorems/T000382.md
@@ -9,9 +9,11 @@ then:
   P000162: true
 refs:
   - doi: 10.1090/S0002-9939-1973-0322812-9  
-    name: Certain Subsets of Products of θ-refinable Spaces are Realcompact
+    name: Certain Subsets of Products of θ-refinable Spaces are Realcompact (P. Zenor)
   - doi: 10.1007/978-1-4615-7819-2
     name: Rings of Continuous Functions (Gillman & Jerison)
 ---
 
-By theorem in the article {{doi:10.1090/S0002-9939-1973-0322812-9}}, if $X$ is $T_4$, embeds as a closed subspace of product of $\theta$-refinable spaces, and every closed discrete subspace of $X$ is realcompact (equivalently, of cardinality smaller than the first measurable cardinal, see {{doi:10.1007/978-1-4615-7819-2}} theorem 12.2), then $X$ is realcompact. If $X$ is already $\theta$-refinable, then it's itself a product of $\theta$-refinable spaces in which it embeds as a closed subspace.
+By the main theorem of the article {{doi:10.1090/S0002-9939-1973-0322812-9}},
+if $X$ is {P7}, embeds as a closed subspace of product of {P194} spaces (e.g. it is itself {P194}),
+and every closed discrete subspace of $X$ is {P164} (e.g. it is itself {P164}), then $X$ is {P162}.

--- a/theorems/T000382.md
+++ b/theorems/T000382.md
@@ -3,13 +3,15 @@ uid: T000382
 if:
   and:
     - P000007: true
-    - P000031: true
+    - P000194: true
     - P000164: true
 then:
   P000162: true
 refs:
-- doi: 10.4153/CJM-1972-081-9
-  name: Certain Subsets of Products of Metacompact Spaces and Subparacompact Spaces are Realcompact
+  - doi: 10.1090/S0002-9939-1973-0322812-9  
+    name: Certain Subsets of Products of θ-refinable Spaces are Realcompact
+  - doi: 10.1007/978-1-4615-7819-2
+    name: Rings of Continuous Functions (Gillman & Jerison)
 ---
 
-See {{doi:10.4153/CJM-1972-081-9}} corollary 2.
+By theorem in the article {{doi:10.1090/S0002-9939-1973-0322812-9}}, if $X$ is $T_4$, embeds as a closed subspace of product of $\theta$-refinable spaces, and every closed discrete subspace of $X$ is realcompact (equivalently, of cardinality smaller than the first measurable cardinal, see {{doi:10.1007/978-1-4615-7819-2}} theorem 12.2), then $X$ is realcompact. If $X$ is already $\theta$-refinable, then it's itself a product of $\theta$-refinable spaces in which it embeds as a closed subspace.


### PR DESCRIPTION
This improves the previous theorem.

The better theorem was there all along, by the same author, but it seems we overlooked it somehow (or perhaps submetacompact wasn't there at the time yet)