### PR TITLE
T700: door + not anticompact => almost discrete

### DIFF
--- a/theorems/T000700.md
+++ b/theorems/T000700.md
@@ -1,0 +1,14 @@
+---
+uid: T000700
+if:
+  and:
+  - P000126: true
+  - P000136: false
+then:
+  P000203: true
+refs:
+  - mathse: 4995169
+    name: Does every door space with an infinite compact set have a single non-isolated point?
+---
+
+See {{mathse:4995169}}.


### PR DESCRIPTION
New T700: Door + not anticompact => almost discrete.

This allows to derive that 17 more spaces are not door, including S86 (everywhere doubled line):
https://topology.pi-base.org/spaces?q=%3Fdoor%2B%7Eanticompact%2B%7EAlmost+discrete

Note: this was one of the pending results in PR #821, where it was labeled T588.  There was some discussion about the best way to present a proof for this, as I did not fully understand what was proposed then.  The current version chooses to just refer to a complete answer in mathse.  If someone wants later to expand this, they could do it separately.
