### PR TITLE
T701: result about connected door spaces

### DIFF
--- a/theorems/T000701.md
+++ b/theorems/T000701.md
@@ -1,0 +1,23 @@
+---
+uid: T000701
+if:
+  and:
+  - P000126: true
+  - P000036: true
+  - P000203: false
+then:
+  P000039: true
+refs:
+- zb: "1400.39025"
+  name: Connected door spaces and topological solutions of equations (Wu, Wang, Zhang)
+---
+
+According to Theorem 1 in {{zb:1400.39025}}, there are three types of connected door spaces:
+- an *excluded point topology* (like {S12}),
+which is almost discrete;
+- a *particular point topology* (like {S8}),
+which is hyperconnected;
+- a *free ultrafilter topology* (like {S145}),
+which is hyperconnected.
+
+So, if a connected door space is not almost discrete, it must be hyperconnected.


### PR DESCRIPTION
New T701: Door + connected + not almost discrete => hyperconnected.

This allow to deduce that the Khalimski line (S51) is not door.

Note: this was one of the pending results in #821, where it was labeled T603.
