### PR TITLE
Strengthen T172 to Strongly Choquet

### DIFF
--- a/theorems/T000172.md
+++ b/theorems/T000172.md
@@ -1,15 +1,12 @@
 ---
 uid: T000172
 if:
-  P000122: true
+  and:
+  - P000122: true
+  - P000137: false
 then:
-  P000064: true
-refs:
-- wikipedia: Baire_space
-  name: Baire space on Wikipedia
-- mr: 431104
-  name: Baire spaces (Haworth & McCoy)
+  P000206: true
 ---
-Every point has a neighborhood $U$ homeomorphic to an open subset of $\mathbb R^n$.  That neighborhood $U$ is Baire as open in $\mathbb R^n$, which is Baire.  Since every point has a neighborhood that is a Baire space, $X$ is Baire.
 
-See {{wikipedia:Baire_space}} and Corollary 1.22 in {{mr:0431104}} (<https://eudml.org/doc/268479>).
+Player 2 can choose a neighborhood $V_0$ that is homeomorphic to $\mathbb R^n$.
+Then the game is played on $\mathbb R^n$ and Player 2 can win because $\mathbb R^n$ is {P206} [(Explore)](https://topology.pi-base.org/spaces?q=Completely+metrizable+%2B+%7EEmpty+%2B+%7EStrongly+Choquet).

--- a/theorems/T000172.md
+++ b/theorems/T000172.md
@@ -8,5 +8,5 @@ then:
   P000206: true
 ---
 
-Player 2 can choose a neighborhood $V_0$ that is homeomorphic to $\mathbb R^n$.
+Player 2 can choose a neighborhood $V_0$ that is homeomorphic to some $\mathbb R^n$.
 Then the game is played on $\mathbb R^n$ and Player 2 can win because $\mathbb R^n$ is {P206} [(Explore)](https://topology.pi-base.org/spaces?q=Completely+metrizable+%2B+%7EEmpty+%2B+%7EStrongly+Choquet).


### PR DESCRIPTION
Old T172: Locally Euclidean => Baire.
New T172: Locally Euclidean + not empty => strongly Choquet.

Allows to derive that 5 more spaces, including S83 (line with two origins), is strongly Choquet.