### PR TITLE
Meta-properties for sigma-connected

### DIFF
--- a/properties/P000189.md
+++ b/properties/P000189.md
@@ -4,12 +4,20 @@ name: $\sigma$-connected
 refs:
   - doi: 10.1201/9781315274089
     name: Continuum Theory (Nadler)
+  - mathse: 4975867
+    name: Answer to "$\sigma$-connected spaces and path-connected property"
 ---
 
 The space cannot be partitioned into more than one and at most countably infinitely many nonempty closed sets.
 
-Equivalently, $X$ is connected and cannot be written as a countably infinite union of pairwise disjoint nonempty closed sets.
+Equivalently, $X$ is {P36} and cannot be written as a countably infinite union of pairwise disjoint nonempty closed sets.
 
 Equivalently, every continuous map from $X$ to {S15} is constant. (This is easy to check using the fact that the codomain is countable and $T_1$, and each of its proper closed subsets is a finite union of singletons.)
 
 Defined in Chapter 5, Section 4, Definition 5.15 of {{doi:10.1201/9781315274089}}.
+
+----
+#### Meta-properties
+
+- If a dense subspace of $X$ satisfies this property, so does $X$ (see Fact 3 in {{mathse:4975867}}).
+- The continuous image of a {P189} space is {P189} (see Fact 2 in {{mathse:4975867}}).


### PR DESCRIPTION
Some meta-properties for P189 (sigma-connected), as suggested in https://github.com/pi-base/data/pull/1241#issuecomment-2660634897, so we can use it for #1241.  See also #1242.

I did not add the property about union with nonempty intersection, as it seemed somehow too specialized for listing in the Meta-properties section for now.

I phrased the other two meta-properties in terms of the whole space.  One could also have written something in terms of subsets of a space, something like:
- the closure of a sigma-connected set is sigma-connected.
- the continuous image of a sigma-connected set is sigma-connected.

Maybe that would be better?  Not sure.  It's equivalent anyway by considering subspaces.

@yhx-12243 @pzjp Comments?  One of you can review.