### PR TITLE
Splitting the arc connected properties

### DIFF
--- a/properties/P000037.md
+++ b/properties/P000037.md
@@ -6,8 +6,9 @@ refs:
     name: Counterexamples in Topology
 ---
 
-Given any two $x,y \in X$ there is a path $f$ with $f(0)=x$ and $f(1)=y$.
-
-A path in a space $X$ is a continuous map $f:[0,1] \rightarrow X$.
+Given any two points $x,y\in X$, there is a *path* in $X$ from $x$ to $y$;
+that is, a continuous map $f:[0,1]\to X$ with $f(0)=x$ and $f(1)=y$.
 
 Defined on page 29 of {{doi:10.1007/978-1-4612-6290-9}}.
+
+Compare with {P38} and {P95}.

--- a/properties/P000038.md
+++ b/properties/P000038.md
@@ -1,13 +1,27 @@
 ---
 uid: P000038
-name: Arc connected
+name: Injectively path connected
+aliases:
+  - Arc connected
 refs:
   - doi: 10.1007/978-1-4612-6290-9
     name: Counterexamples in Topology
 ---
 
-Given any two distinct $x,y \in X$ there is an arc $f$ with $f(0)=x$ and $f(1)=y$.
+Given any two distinct points $x,y\in X$, there is an *injective path* in $X$ from $x$ to $y$;
+that is, an injective continuous map $f:[0,1]\to X$ with $f(0)=x$ and $f(1)=y$.
 
-An arc in a space $X$ is an injective continuous map $f:[0,1] \rightarrow X$.
+Compare with {P37}, which does not require the path to be injective,
+and {P95}, which requires the path to be a homeomorphism onto its image.
 
-Defined on page 29 of {{doi:10.1007/978-1-4612-6290-9}}.
+Defined on page 29 of {{doi:10.1007/978-1-4612-6290-9}} with the name "arc connected".
+Here we reserve that name for the stronger property {P95},
+which is the more common usage in the literature.
+
+----
+##### WARNING:
+
+The properties {P38} and {P95}
+are currently being worked on.
+Some spaces may have inaccurate or incorrect traits for these properties.
+This is only temporary and will be corrected soon.

--- a/properties/P000042.md
+++ b/properties/P000042.md
@@ -28,3 +28,5 @@ But the corresponding global statements (where the condition holds at every poin
 For terminology and the equivalence between the conditions above, see section 2 of {{zb:1342.30054}} and {{wikipedia:Locally_connected_space}}, plus the references therein.
 
 Defined on page 30 of {{doi:10.1007/978-1-4612-6290-9}}.
+
+Compare with {P43} and {P96}.

--- a/properties/P000043.md
+++ b/properties/P000043.md
@@ -1,11 +1,26 @@
 ---
 uid: P000043
-name: Locally arc connected
+name: Locally injectively path connected
+aliases:
+  - Locally arc connected
 refs:
   - doi: 10.1007/978-1-4612-6290-9
     name: Counterexamples in Topology
 ---
 
-A space with a basis consisting of (open) {P38} sets.  Equivalently, every point has a local base of {P38} open neighborhoods.
+The topology of $X$ has a base consisting of {P38} open sets.
 
-Defined on page 30 of {{doi:10.1007/978-1-4612-6290-9}}.
+Equivalently, every point has a local base of {P38} open neighborhoods.
+
+Compare with {P42} and {P96}.
+
+Defined on page 30 of {{doi:10.1007/978-1-4612-6290-9}} with the name "locally arc connected".
+Here we reserve that name for the stronger property {P96}.
+
+----
+##### WARNING:
+
+The properties {P43} and {P96}
+are currently being worked on.
+Some spaces may have inaccurate or incorrect traits for these properties.
+This is only temporary and will be corrected soon.

--- a/properties/P000095.md
+++ b/properties/P000095.md
@@ -1,0 +1,28 @@
+---
+uid: P000095
+name: Arc connected
+refs:
+  - zb: "1052.54001"
+    name: General Topology (Willard)
+  - doi: 10.1007/978-1-4612-6290-9
+    name: Counterexamples in Topology
+---
+
+Given any two distinct points $x,y\in X$, there is an *arc* in $X$ from $x$ to $y$;
+that is, a homeomorphic embedding $f:[0,1]\to X$ with $f(0)=x$ and $f(1)=y$.
+
+See Definition 27.1 in {{zb:1052.54001}}, which uses the usual definition of "arc" from the literature.
+
+Compare with {P37} and {P38}.
+
+Note: Page 29 of {{doi:10.1007/978-1-4612-6290-9}} 
+uses the terms "arc" for an injective path
+and "arc connected" for the weaker property {P38}.
+
+----
+##### WARNING:
+
+The properties {P38} and {P95}
+are currently being worked on.
+Some spaces may have inaccurate or incorrect traits for these properties.
+This is only temporary and will be corrected soon.

--- a/properties/P000096.md
+++ b/properties/P000096.md
@@ -1,0 +1,24 @@
+---
+uid: P000096
+name: Locally arc connected
+refs:
+  - doi: 10.1007/978-1-4612-6290-9
+    name: Counterexamples in Topology
+---
+
+The topology of $X$ has a base consisting of {P95} open sets.
+
+Equivalently, every point has a local base of {P95} open neighborhoods.
+
+Compare with {P42} and {P43}.
+
+Note: Page 30 of {{doi:10.1007/978-1-4612-6290-9}} 
+uses the term "locally arc connected" for the weaker property {P43}.
+
+----
+##### WARNING:
+
+The properties {P43} and {P96}
+are currently being worked on.
+Some spaces may have inaccurate or incorrect traits for these properties.
+This is only temporary and will be corrected soon.

--- a/theorems/T000039.md
+++ b/theorems/T000039.md
@@ -4,9 +4,6 @@ if:
   P000038: true
 then:
   P000037: true
-refs:
-- doi: 10.1007/978-1-4612-6290-9
-  name: Counterexamples in Topology
 ---
 
-Asserted on page 29 of {{doi:10.1007/978-1-4612-6290-9}}.
+Evident from the definitions.

--- a/theorems/T000075.md
+++ b/theorems/T000075.md
@@ -6,10 +6,7 @@ if:
   - P000125: true
 then:
   P000058: false
-refs:
-- doi: 10.1007/978-1-4612-6290-9
-  name: Counterexamples in Topology
 ---
 
-If $f:[0,1] \rightarrow X$ is injective, then $|X| \geq |[0,1]| = \mathfrak{c}$.
-See page 29 of {{doi:10.1007/978-1-4612-6290-9}}.
+There is an injective path $f:[0,1]\to X$ joining two distinct points.
+Then $|X| \geq |[0,1]| = \mathfrak{c}$.

--- a/theorems/T000082.md
+++ b/theorems/T000082.md
@@ -3,9 +3,11 @@ uid: T000082
 if:
   P000122: true
 then:
-  P000043: true
+  P000096: true
 refs:
 - zb: "0951.54001"
   name: Topology (Munkres)
 ---
-Every point $x\in X$ has an open neighborhood homeomorphic to an open subset of $\mathbb R^n$.  Further restricting to an open ball around $x$ gives a neighborhood open in $X$ and {P38}.
+
+Every point $x\in X$ has an open neighborhood homeomorphic to an open subset of $\mathbb R^n$.
+Further restricting to an open ball around $x$ gives a neighborhood open in $X$ and {P95}.

--- a/theorems/T000083.md
+++ b/theorems/T000083.md
@@ -6,12 +6,8 @@ if:
   - P000052: false
 then:
   P000058: false
-refs:
-- doi: 10.1007/978-1-4612-6290-9
-  name: Counterexamples in Topology
 ---
 
-By non-discreteness choose a non-isolated point of \(X\).
-It has an arc connected neighborhood with at least two distinct points,
-so by {T75} this neighborhood is uncountable.
-See pages 29-30 of {{doi:10.1007/978-1-4612-6290-9}}.
+By non-discreteness choose a non-isolated point of $X$.
+It has a {P38} neighborhood with at least two distinct points,
+so by {T75} this neighborhood has cardinality at least $\mathfrak c$.

--- a/theorems/T000094.md
+++ b/theorems/T000094.md
@@ -8,4 +8,6 @@ then:
   P000044: false
 ---
 
-There is an arc $f:[0,1]\to X$ joining two distinct points of $X$.  Then, $f([0,1/3])$ and $f([2/3,1])$ are  disjoint connected sets, each of size at least $2$.  Thus $X$ is not {P44}.
+There is an injective path $f:[0,1]\to X$ joining two distinct points.
+Then, $f([0,1/3])$ and $f([2/3,1])$ are disjoint connected sets, each of size at least $2$.
+Thus $X$ is not {P44}.

--- a/theorems/T000095.md
+++ b/theorems/T000095.md
@@ -11,6 +11,6 @@ refs:
   name: General Topology (Willard)
 ---
 
-If $X$ is locally path connected, then since the union of two paths is again a path, path components are both open and closed.
+If $X$ is locally path connected, then since the concatenation of two paths is again a path, path components are both open and closed.
 
-Proven as 27.5 of {{zb:1052.54001}}.
+See Theorem 27.5 of {{zb:1052.54001}}.

--- a/theorems/T000240.md
+++ b/theorems/T000240.md
@@ -2,13 +2,19 @@
 uid: T000240
 if:
   and:
-  - P000003: true
   - P000037: true
+  - P000003: true
 then:
-  P000038: true
+  P000095: true
 refs:
+- mathse: 4247643
+  name: Answer to "Does path-connected imply simple path-connected?"
 - zb: "1052.54001"
   name: General Topology (Willard)
 ---
 
-This is Corollary 31.6 in {{zb:1052.54001}}.
+See Jeremy Brazas's
+[expository note](https://www.wcupa.edu/sciences-mathematics/mathematics/jBrazas/documents/Constructing_arcs_from_paths_9-9-21.pdf)
+referenced from {{mathse:4247643}}.
+
+See also Corollary 31.6 in {{zb:1052.54001}}.

--- a/theorems/T000526.md
+++ b/theorems/T000526.md
@@ -2,10 +2,12 @@
 uid: T000526
 if:
   and:
-  - P000003: true
   - P000042: true
+  - P000084: true
 then:
-  P000043: true
+  P000096: true
 ---
 
-Evident from {T240}, which shows that the {P37} base elements for the topology are {P38}.
+An arbitrary neighborhood $V$ of a point $x$ contains a {P3} neighborhood $W$ of $x$ by {P84}.
+By {P42}, $W$ contains a {P37} open neighborhood $U$ of $x$.
+And $U\subseteq V$ is {P95} since {T240}.

--- a/theorems/T000702.md
+++ b/theorems/T000702.md
@@ -10,7 +10,6 @@ then:
 
 Suppose $X$ is {P43} and not {P52}.
 There is at least one point with an {P38} neighborhood $V$ that is not a singleton.
-Two distinct point in $V$ are joined by an arc, that is, by an injective path $f:[0,1]\to X$.
-Then the images of disjoint intervals in $[0,1]$ are disjoint connected sets in $X$,
-each with at least two points,
-which is one of the characterizations to show that a space is not {P44}.
+Two distinct point in $V$ are joined by an injective path $f:[0,1]\to X$.
+Then, $f([0,1/3])$ and $f([2/3,1])$ are disjoint connected sets, each of size at least $2$.
+Thus $X$ is not {P44}.

--- a/theorems/T000703.md
+++ b/theorems/T000703.md
@@ -1,9 +1,9 @@
 ---
-uid: T000063
+uid: T000703
 if:
-  P000043: true
+  P000095: true
 then:
-  P000042: true
+  P000038: true
 ---
 
 Evident from the definitions.

--- a/theorems/T000704.md
+++ b/theorems/T000704.md
@@ -1,9 +1,9 @@
 ---
-uid: T000063
+uid: T000704
 if:
-  P000043: true
+  P000096: true
 then:
-  P000042: true
+  P000043: true
 ---
 
 Evident from the definitions.

--- a/theorems/T000705.md
+++ b/theorems/T000705.md
@@ -1,0 +1,13 @@
+---
+uid: T000705
+if:
+  P000095: true
+then:
+  P000002: true
+---
+
+Given distinct points $a,b\in X$, there is an arc $f:[0,1]\to X$ joining $a$ to $b$.
+The image $A=f([0,1])$ is homeomorphic to $[0,1]$.
+So $a$ has an open neighborhood $V$ in $A$ not containing $b$.
+Since $V=A\cap U$ for some open set $U$ in $X$,
+$a$ has $U$ as neighborhood in $X$ not containing $b$.

--- a/theorems/T000706.md
+++ b/theorems/T000706.md
@@ -1,0 +1,15 @@
+---
+uid: T000706
+if:
+  P000096: true
+then:
+  P000002: true
+refs:
+  - mathse: 3142995
+    name: Answer to "Locally Euclidean space implies T1 space"
+---
+
+Each point $x\in X$ has an open neighborhood $U$ that is {P95}.
+By {T705}, $U$ is $T_1$.
+Therefore $X$ is "locally {P2}", and hence {P2}
+(see {{mathse:3142995}}).


### PR DESCRIPTION
Reorganization of the properties related to arc connectedness, as discussed in #1246.
This is phase 1 from https://github.com/pi-base/data/issues/1246#issuecomment-2669583179.

New properties:
- P38: Injectively path connected (renamed from "arc connected")
- P95: Arc connected
- P43: Locally injectively path connected (renamed from "locally arc connected")
- P96: Locally arc connected

Plus tweaking all the related theorems, together with a few additional simple ones.

Phase 2 (the traits for spaces) will follow after this is approved.

@StevenClontz fyi