### PR TITLE
Some updates on P76 (Proximal)

### DIFF
--- a/properties/P000076.md
+++ b/properties/P000076.md
@@ -26,3 +26,9 @@ or the intersection $\bigcap_{n<\omega}D_n[x_n]$ is empty.
 Note that while many authors require {P76} spaces to be {P3}
 (equivalently, {P1}),
 we do not require this separation axiom here.
+
+----
+#### Meta-properties
+
+- This property is hereditary with respect to closed sets (see Lemma 7 in {{doi:10.1016/j.topol.2014.06.014}}).
+- This property is preserved by $\Sigma$-products (see Theorem 8 in {{doi:10.1016/j.topol.2014.06.014}}).

--- a/spaces/S000041/properties/P000076.md
+++ b/spaces/S000041/properties/P000076.md
@@ -1,0 +1,8 @@
+---
+space: S000041
+property: P000076
+value: false
+---
+
+{S41} contains a closed subspace $\bigl( (0, 1] \times \{0\} \bigr) \cup \bigl( [0, 1) \times \{1\} \bigr)$, which is homeomorphic to {S93}.
+But {S93|P76}, so {S41} is not {P76}.

--- a/spaces/S000043/properties/P000076.md
+++ b/spaces/S000043/properties/P000076.md
@@ -4,7 +4,10 @@ property: P000076
 value: false
 refs:
 - doi: 10.1016/j.topol.2014.06.014
-  name: "An infinite game with topological consequences (Bell)"
+  name: An infinite game with topological consequences (Bell)
 ---
+
+The square of {S43} is {S76}, and {S76|P76}.
+So {S43} is not {P76}.
 
 See Example 3 of {{doi:10.1016/j.topol.2014.06.014}}.

--- a/spaces/S000063/properties/P000076.md
+++ b/spaces/S000063/properties/P000076.md
@@ -1,0 +1,8 @@
+---
+space: S000063
+property: P000076
+value: false
+---
+
+The product of {S63} and {S28} is {S77}, and {S77|P76}.
+But {S28|P76}, so {S63} is not {P76}.

--- a/theorems/T000177.md
+++ b/theorems/T000177.md
@@ -6,7 +6,7 @@ then:
   P000076: true
 refs:
 - doi: 10.1016/j.topol.2014.06.014
-  name: An infinite game with topological consequences
+  name: An infinite game with topological consequences (Bell)
 ---
 
 The entourage-picker in the proximal game may choose the metric entourage of radius $2^{-n}$ during round $n$ of the game.

--- a/theorems/T000475.md
+++ b/theorems/T000475.md
@@ -6,7 +6,7 @@ then:
   P000187: true
 refs:
   - doi: 10.1016/j.topol.2014.06.014
-    name: An infinite game with topological consequences (Jocelyn Bell)
+    name: An infinite game with topological consequences (Bell)
 ---
 
 Shown in Lemma 6 of {{doi:10.1016/j.topol.2014.06.014}}.

--- a/theorems/T000707.md
+++ b/theorems/T000707.md
@@ -1,0 +1,12 @@
+---
+uid: T000707
+if:
+  P000076: true
+then:
+  P000088: true
+refs:
+  - doi: 10.1016/j.topol.2014.06.014
+    name: An infinite game with topological consequences (Bell)
+---
+
+See Theorem 10 of {{doi:10.1016/j.topol.2014.06.014}}.

--- a/theorems/T000708.md
+++ b/theorems/T000708.md
@@ -1,0 +1,12 @@
+---
+uid: T000708
+if:
+  P000076: true
+then:
+  P000032: true
+refs:
+  - doi: 10.1016/j.topol.2014.06.014
+    name: An infinite game with topological consequences (Bell)
+---
+
+See Corollary 4 of {{doi:10.1016/j.topol.2014.06.014}}.


### PR DESCRIPTION
Add two theorems and meta-properties from [DOI 10.1016/j.topol.2014.06.014](https://doi.org/10.1016/j.topol.2014.06.014).

Deduce 12 more spaces (including Sorgenfrey, Michael line, Lexicographical unit square, etc.) that is not proximal.

*(This PR is mainly the negative results of Proximal, making it easier to review.)*