### PR TITLE
Cleanup for arc properties

### DIFF
--- a/properties/P000038.md
+++ b/properties/P000038.md
@@ -17,11 +17,3 @@ and {P95}, which requires the path to be a homeomorphism onto its image.
 Defined on page 29 of {{doi:10.1007/978-1-4612-6290-9}} with the name "arc connected".
 Here we reserve that name for the stronger property {P95},
 which is the more common usage in the literature.
-
-----
-##### WARNING:
-
-The properties {P38} and {P95}
-are currently being worked on.
-Some spaces may have inaccurate or incorrect traits for these properties.
-This is only temporary and will be corrected soon.

--- a/properties/P000043.md
+++ b/properties/P000043.md
@@ -16,11 +16,3 @@ Compare with {P42} and {P96}.
 
 Defined on page 30 of {{doi:10.1007/978-1-4612-6290-9}} with the name "locally arc connected".
 Here we reserve that name for the stronger property {P96}.
-
-----
-##### WARNING:
-
-The properties {P43} and {P96}
-are currently being worked on.
-Some spaces may have inaccurate or incorrect traits for these properties.
-This is only temporary and will be corrected soon.

--- a/properties/P000095.md
+++ b/properties/P000095.md
@@ -18,11 +18,3 @@ Compare with {P37} and {P38}.
 Note: Page 29 of {{doi:10.1007/978-1-4612-6290-9}} 
 uses the terms "arc" for an injective path
 and "arc connected" for the weaker property {P38}.
-
-----
-##### WARNING:
-
-The properties {P38} and {P95}
-are currently being worked on.
-Some spaces may have inaccurate or incorrect traits for these properties.
-This is only temporary and will be corrected soon.

--- a/properties/P000096.md
+++ b/properties/P000096.md
@@ -14,11 +14,3 @@ Compare with {P42} and {P43}.
 
 Note: Page 30 of {{doi:10.1007/978-1-4612-6290-9}} 
 uses the term "locally arc connected" for the weaker property {P43}.
-
-----
-##### WARNING:
-
-The properties {P43} and {P96}
-are currently being worked on.
-Some spaces may have inaccurate or incorrect traits for these properties.
-This is only temporary and will be corrected soon.

--- a/theorems/T000075.md
+++ b/theorems/T000075.md
@@ -9,4 +9,4 @@ then:
 ---
 
 There is an injective path $f:[0,1]\to X$ joining two distinct points.
-Then $|X| \geq |[0,1]| = \mathfrak{c}$.
+Therefore $|X| \geq |[0,1]| = \mathfrak{c}$.

--- a/theorems/T000082.md
+++ b/theorems/T000082.md
@@ -4,10 +4,8 @@ if:
   P000122: true
 then:
   P000096: true
-refs:
-- zb: "0951.54001"
-  name: Topology (Munkres)
 ---
 
-Every point $x\in X$ has an open neighborhood homeomorphic to an open subset of $\mathbb R^n$.
-Further restricting to an open ball around $x$ gives a neighborhood open in $X$ and {P95}.
+Every point $x\in X$ has an open neighborhood $U$ homeomorphic to some $\mathbb R^n$.
+The open balls centered at $x$ within $U$
+form a local base of neighborhoods open in $X$ and {P95}.


### PR DESCRIPTION
Cleanup for the arc properties after #1249.

Also fix the proof for T82 (locally Euclidean => locally arc connected), which was previously incomplete.
