### PR TITLE
Completing ray topologies on rational interval

### DIFF
--- a/spaces/S000150/properties/P000089.md
+++ b/spaces/S000150/properties/P000089.md
@@ -11,6 +11,5 @@ is a continuous self-map of $X$.
 Consider the map $f(x):=\frac{x+1}{x+2}$.
 As a function on $\mathbb R$ it admits two irrational fixed points only.
 Restricted to $X$ it is an increasing bijection onto 
-$[\frac{1}{2},\frac{2}{3}]\cap \mathbb Q$
-(with inverse $f^{-1}(y)=\frac{1-2y}{y-1}$),
-therfore it is a continous self-map of $X$ with no fixed point.
+$[\frac{1}{2},\frac{2}{3}]\cap \mathbb Q$,
+therefore it is a continuous self-map of $X$ with no fixed point.

--- a/spaces/S000150/properties/P000089.md
+++ b/spaces/S000150/properties/P000089.md
@@ -1,0 +1,23 @@
+---
+space: S000150
+property: P000089
+value: false
+---
+
+Observe that any increasing bijection
+$X\to [a,b]\cap\mathbb Q$, where $0\leq a<b\leq 1$,
+is a continuous self-map of $X$.
+
+Fix $\theta \in (0,1)\setminus \mathbb Q$ and two monotone sequences of irrational numbers
+$1>a_0>\ldots>a_k>a_{k+1}> \theta$
+and $0<b_0<\ldots <b_k<b_{k+1}<\theta$
+such that $a_k\to \theta$ and $b_k\to \theta$.
+Pick also $\tilde a \in (a_1,a_0)\cap\mathbb Q$
+and $\tilde b\in (b_0,b_1)\cap\mathbb Q$.
+
+We construct an increasing bijection $f:X\to [\tilde b,\tilde a]\cap\mathbb Q$ by chooseing arbitrary bijections between the rational intervals
+$[0,b_0)\to[\tilde b, b_1)$, $(a_0,1]\to(a_1,\tilde a]$ and $(b_k,b_{k+1})\to(b_{k+1},b_{k+2})$,
+$(a_{k+2},a_{k+1})\to(a_{k+1},a_k)$ for $k\geq 0$.
+It is evident that union of those bijections
+has no fixed point. 
+

--- a/spaces/S000150/properties/P000089.md
+++ b/spaces/S000150/properties/P000089.md
@@ -8,19 +8,9 @@ Observe that any increasing bijection
 $X\to [a,b]\cap\mathbb Q$, where $0\leq a<b\leq 1$,
 is a continuous self-map of $X$.
 
-
-Fix $\theta \in (0,1)\setminus \mathbb Q$ and two sequences of irrational numbers $(a_k)$ and $(b_k)$
-such that $1>a_k>a_{k+1}> \theta > b_{k+1}>b_k >0$
-and $a_k\to \theta$, $b_k\to \theta$.
-E.g. $\theta=1/\sqrt{2}$ and $a_k=\theta+\frac{1}{k+4}$, $b_k=\theta-\frac{1}{k+2}$.
-Pick also $\tilde a \in (a_1,a_0)\cap\mathbb Q$
-and $\tilde b\in (b_0,b_1)\cap\mathbb Q$.
-
-From now on, to simplify the notation,
-every interval is assumed to consist exclusively of rational numbers.
-
-We construct an increasing bijection $f:X\to [\tilde b,\tilde a]$
-by choosing arbitrary order isomorphism between the rational intervals:
-$[0,b_0)\to[\tilde b, b_1)$, $(a_0,1]\to(a_1,\tilde a]$,
-$(b_k,b_{k+1})\to(b_{k+1},b_{k+2})$, and $(a_{k+2},a_{k+1})\to(a_{k+1},a_k)$ for all $k\geq 0$.
-Function $f$ being union of those increasing bijections has no fixed point. 
+Consider the map $f(x):=\frac{x+1}{x+2}$.
+As a function on $\mathbb R$ it admits two irrational fixed points only.
+Restricted to $X$ it is an increasing bijection onto 
+$[\frac{1}{2},\frac{2}{3}]\cap \mathbb Q$
+(with inverse $f^{-1}(y)=\frac{1-2y}{y-1}$),
+therfore it is a continous self-map of $X$ with no fixed point.

--- a/spaces/S000150/properties/P000089.md
+++ b/spaces/S000150/properties/P000089.md
@@ -9,10 +9,10 @@ $X\to [a,b]\cap\mathbb Q$, where $0\leq a<b\leq 1$,
 is a continuous self-map of $X$.
 
 
-Fix $\theta \in (0,1)\setminus \mathbb Q$ and two monotone sequences of irrational numbers
-$1>a_0>\ldots>a_k>a_{k+1}> \theta$
-and $0<b_0<\ldots <b_k<b_{k+1}<\theta$
-such that $a_k\to \theta$ and $b_k\to \theta$.
+Fix $\theta \in (0,1)\setminus \mathbb Q$ and two sequences of irrational numbers $(a_k)$ and $(b_k)$
+such that $1>a_k>a_{k+1}> \theta > b_{k+1}>b_k >0$
+and $a_k\to \theta$, $b_k\to \theta$.
+E.g. $\theta=1/\sqrt{2}$ and $a_k=\theta+\frac{1}{k+4}$, $b_k=\theta-\frac{1}{k+2}$.
 Pick also $\tilde a \in (a_1,a_0)\cap\mathbb Q$
 and $\tilde b\in (b_0,b_1)\cap\mathbb Q$.
 
@@ -23,5 +23,4 @@ We construct an increasing bijection $f:X\to [\tilde b,\tilde a]$
 by choosing arbitrary order isomorphism between the rational intervals:
 $[0,b_0)\to[\tilde b, b_1)$, $(a_0,1]\to(a_1,\tilde a]$,
 $(b_k,b_{k+1})\to(b_{k+1},b_{k+2})$, and $(a_{k+2},a_{k+1})\to(a_{k+1},a_k)$ for all $k\geq 0$.
-Function $f$ being union of those increasing bijections
-has no fixed point. 
+Function $f$ being union of those increasing bijections has no fixed point. 

--- a/spaces/S000150/properties/P000089.md
+++ b/spaces/S000150/properties/P000089.md
@@ -8,6 +8,7 @@ Observe that any increasing bijection
 $X\to [a,b]\cap\mathbb Q$, where $0\leq a<b\leq 1$,
 is a continuous self-map of $X$.
 
+
 Fix $\theta \in (0,1)\setminus \mathbb Q$ and two monotone sequences of irrational numbers
 $1>a_0>\ldots>a_k>a_{k+1}> \theta$
 and $0<b_0<\ldots <b_k<b_{k+1}<\theta$
@@ -15,9 +16,12 @@ such that $a_k\to \theta$ and $b_k\to \theta$.
 Pick also $\tilde a \in (a_1,a_0)\cap\mathbb Q$
 and $\tilde b\in (b_0,b_1)\cap\mathbb Q$.
 
-We construct an increasing bijection $f:X\to [\tilde b,\tilde a]\cap\mathbb Q$ by chooseing arbitrary bijections between the rational intervals
-$[0,b_0)\to[\tilde b, b_1)$, $(a_0,1]\to(a_1,\tilde a]$ and $(b_k,b_{k+1})\to(b_{k+1},b_{k+2})$,
-$(a_{k+2},a_{k+1})\to(a_{k+1},a_k)$ for $k\geq 0$.
-It is evident that union of those bijections
-has no fixed point. 
+From now on, to simplify the notation,
+every interval is assumed to consist exclusively of rational numbers.
 
+We construct an increasing bijection $f:X\to [\tilde b,\tilde a]$
+by choosing arbitrary order isomorphism between the rational intervals:
+$[0,b_0)\to[\tilde b, b_1)$, $(a_0,1]\to(a_1,\tilde a]$,
+$(b_k,b_{k+1})\to(b_{k+1},b_{k+2})$, and $(a_{k+2},a_{k+1})\to(a_{k+1},a_k)$ for all $k\geq 0$.
+Function $f$ being union of those increasing bijections
+has no fixed point. 

--- a/spaces/S000150/properties/P000208.md
+++ b/spaces/S000150/properties/P000208.md
@@ -1,7 +1,0 @@
----
-space: S000150
-property: P000208
-value: false
----
-
-$\left[ \frac 1n, \to \right)$ is a strictly increasing sequence of open sets.

--- a/spaces/S000151/properties/P000089.md
+++ b/spaces/S000151/properties/P000089.md
@@ -4,5 +4,5 @@ property: P000089
 value: false
 ---
 
-See the proof that {S150|P89}.
+Same proof as {S150|P89}.
 

--- a/spaces/S000151/properties/P000089.md
+++ b/spaces/S000151/properties/P000089.md
@@ -1,0 +1,8 @@
+---
+space: S000151
+property: P000089
+value: false
+---
+
+See the proof that {S150|P89}.
+

--- a/spaces/S000151/properties/P000138.md
+++ b/spaces/S000151/properties/P000138.md
@@ -2,12 +2,21 @@
 space: S000151
 property: P000138
 value: false
+refs:
+ - doi:10.1007/978-93-80250-91-5_9
+   name: Rational Numbers (in "Notes on Infinite Permutation Groups")
 ---
 
 For every irrational $\theta\in[0,1]$ there exists
 a contiunuous self-map of $X$ such that its set
 of fixed points is exactly $[0,\theta)\cap\mathbb Q$.
 
-The construction of a map $(\theta,1]\cap X \to (\theta,1]\cap X$ with no fixed point is analogous as in the proof that
-{S150|P89}
-(use only the sequence $b_k$).
+To construct such a map for given
+$\theta\in[0,1]\setminus\mathbb Q$, consider the sequence
+$a_n:=\theta+\frac{1-\theta}{n+1}$
+and fix $b\in(a_2,a_1)\cap\mathbb Q$.
+Then pick increasing bijections between rational intervals (c.f. Cantor's isomorphism theorem, 9.3 in {{doi:10.1007/978-93-80250-91-5_9}})
+$(a_{n+1},a_n)\to(a_{n+2},a_{n+1})$ for $n\geq 1$ and $(a_1,1]\to(a_2,b]$.
+Together with the identity on $[0,\theta)\cap X$ we obtain an increasing bijection
+onto interval $[0,b]\cap\mathbb Q$.
+It is therefore a continuous self-map of $X$.

--- a/spaces/S000151/properties/P000138.md
+++ b/spaces/S000151/properties/P000138.md
@@ -1,0 +1,13 @@
+---
+space: S000151
+property: P000138
+value: false
+---
+
+For every irrational $\theta\in[0,1]$ there exists
+a contiunuous self-map of $X$ such that its set
+of fixed points is exactly $[0,\theta)\cap\mathbb Q$.
+
+The construction of a map $(\theta,1]\cap X \to (\theta,1]\cap X$ with no fixed point is analogous as in the proof that
+{S150|P89}
+(use only the sequence $b_k$).

--- a/spaces/S000151/properties/P000138.md
+++ b/spaces/S000151/properties/P000138.md
@@ -5,7 +5,7 @@ value: false
 ---
 
 Fix $\theta\in[0,1]\setminus\mathbb Q$.
-Define a map on $X$ by the forumla:
+Define a map on $X$ by the formula:
 $f_\theta(x)=\begin{cases}\frac{x}{2}&\text{for }x<\theta,\\
 \frac{x+1}{2}&\text{for }x>\theta,\end{cases}\ x\in X$.
 

--- a/spaces/S000151/properties/P000138.md
+++ b/spaces/S000151/properties/P000138.md
@@ -2,21 +2,17 @@
 space: S000151
 property: P000138
 value: false
-refs:
-  - doi: 10.1007/978-93-80250-91-5_9
-    name: Rational Numbers (in "Notes on Infinite Permutation Groups")
 ---
 
-For every irrational $\theta\in[0,1]$ there exists
-a contiunuous self-map of $X$ such that its set
-of fixed points is exactly $[0,\theta)\cap\mathbb Q$.
+Fix $\theta\in[0,1]\setminus\mathbb Q$.
+Define a map on $X$ by the forumla:
+$f_\theta(x)=\begin{cases}\frac{x}{2}&\text{for }x<\theta,\\
+\frac{x+1}{2}&\text{for }x>\theta,\end{cases}\ x\in X$.
 
-To construct such a map for given
-$\theta\in[0,1]\setminus\mathbb Q$, consider the sequence
-$a_n:=\theta+\frac{1-\theta}{n+1}$
-and fix $b\in(a_2,a_1)\cap\mathbb Q$.
-Then pick increasing bijections between rational intervals (c.f. Cantor's isomorphism theorem, 9.3 in {{doi:10.1007/978-93-80250-91-5_9}})
-$(a_{n+1},a_n)\to(a_{n+2},a_{n+1})$ for $n\geq 1$ and $(a_1,1]\to(a_2,b]$.
-Together with the identity on $[0,\theta)\cap X$ we obtain an increasing bijection
-onto interval $[0,b]\cap\mathbb Q$.
-It is therefore a continuous self-map of $X$.
+The set $X\setminus f_\theta(X)=(\frac{\theta}2,\frac{\theta+1}2)\cap\mathbb Q$ is different for each irrational $\theta$.
+
+Continuity of $f_\theta$ can be verified on the canonical basis for the topology on $X$.
+The map is strictly increasing and
+$f_\theta^{-1}((x,\rightarrow))=(f_\theta^{-1}(x),\rightarrow)$ for every $x\in f_\theta(X)$.
+For $x\in X\setminus f_\theta(X)$ the set
+$f_\theta^{-1}((x,\rightarrow))=(\theta,\rightarrow)$ is open as well.

--- a/spaces/S000151/properties/P000138.md
+++ b/spaces/S000151/properties/P000138.md
@@ -3,8 +3,8 @@ space: S000151
 property: P000138
 value: false
 refs:
- - doi:10.1007/978-93-80250-91-5_9
-   name: Rational Numbers (in "Notes on Infinite Permutation Groups")
+  - doi: 10.1007/978-93-80250-91-5_9
+    name: Rational Numbers (in "Notes on Infinite Permutation Groups")
 ---
 
 For every irrational $\theta\in[0,1]$ there exists

--- a/spaces/S000151/properties/P000208.md
+++ b/spaces/S000151/properties/P000208.md
@@ -1,7 +1,0 @@
----
-space: S000151
-property: P000208
-value: false
----
-
-$\left( \frac 1n, \to \right)$ is a strictly increasing sequence of open sets.


### PR DESCRIPTION
Missing traits for spaces [S150](https://topology.pi-base.org/spaces/S150) and [S151](https://topology.pi-base.org/spaces/S151).
Adding no [fixed point property](https://topology.pi-base.org/properties/P00089) (for both) and un[countable cont. maps](https://topology.pi-base.org/properties/P000138) for S151.