### PR TITLE
S212: Lexicographic Hilbert cube

### DIFF
--- a/spaces/S000032/README.md
+++ b/spaces/S000032/README.md
@@ -1,6 +1,6 @@
 ---
 uid: S000032
-name: Hilbert cube
+name: Hilbert cube $[0,1]^\omega$
 counterexamples_id: 38
 refs:
   - doi: 10.1007/978-1-4612-6290-9 

--- a/spaces/S000041/properties/P000061.md
+++ b/spaces/S000041/properties/P000061.md
@@ -2,9 +2,12 @@
 space: S000041
 property: P000061
 value: false
+refs:
+  - zb: "0684.54001"
+    name: General Topology (Engelking, 1989)
 ---
 
-The set $U = \bigl( \left[ 0, 1 \right] \cap \mathbb Q \bigr) \times (0, 1) \cup \bigl\{ \left< 0, 0 \right>, \left< 1, 1 \right> \bigr\}$ is an $F_\sigma$ open set in $X$, therefore a cozero set, since {S41|P13} (see Corollary 1.5.13 in {{zb:0684.54001}}).
+The set $U = \bigl( \left[ 0, 1 \right] \cap \mathbb Q \bigr) \times (0, 1)$ is an $F_\sigma$ open set in $X$, therefore a cozero set, since {S41|P13} (see Corollary 1.5.13 in {{zb:0684.54001}}).
 
 Suppose $V$ is a cozero set disjoint from $U$ such that $U \cup V$ is dense.
 Let $A := \operatorname{int}(X \setminus U) = \bigl( \left[ 0, 1 \right] \setminus \mathbb Q \bigr) \times (0, 1)$.

--- a/spaces/S000041/properties/P000076.md
+++ b/spaces/S000041/properties/P000076.md
@@ -4,5 +4,9 @@ property: P000076
 value: false
 ---
 
-{S41} contains a closed subspace $\bigl( (0, 1] \times \{0\} \bigr) \cup \bigl( [0, 1) \times \{1\} \bigr)$, which is homeomorphic to {S93}.
-But {S93|P76}, so {S41} is not {P76}.
+$X$ contains the closed subspace
+$\bigl( (0, 1] \times \{0\} \bigr) \cup \bigl( [0, 1) \times \{1\} \bigr)$,
+which is homeomorphic to {S93}.
+
+{S93|P76}, so neither is $X$
+since the {P76} property is hereditary with respect to closed sets.

--- a/spaces/S000212/README.md
+++ b/spaces/S000212/README.md
@@ -1,0 +1,9 @@
+---
+uid: S000212
+name: Lexicographic Hilbert cube $[0,1]^\omega$
+refs:
+  - mathse: 4453440
+    name: Answer to "Is there a nontrivial LOTS that is connected and totally path disconnected?"
+---
+
+The space $X=[0,1]^\omega$ ordered lexicographically and with the corresponding order topology.

--- a/spaces/S000212/properties/P000016.md
+++ b/spaces/S000212/properties/P000016.md
@@ -1,0 +1,14 @@
+---
+space: S000212
+property: P000016
+value: true
+refs:
+  - zb: "1052.54001"
+    name: General Topology (Willard)
+---
+
+The order on $X$ has a minimum element and a maximum element.
+And it is Dedekind-complete
+(since {S212|P36}).
+
+See Problem 17E in {{zb:1052.54001}}.

--- a/spaces/S000212/properties/P000028.md
+++ b/spaces/S000212/properties/P000028.md
@@ -1,0 +1,27 @@
+---
+space: S000212
+property: P000028
+value: true
+---
+
+Given a point $a=\left<a_0,a_1,\dots\right>\ne\min X$,
+one can find an increasing sequence of points $x^{(n)}\in X$ converging to $a$
+(i.e., cofinal in $(\leftarrow,a)$) as follows.
+
+If the values $a_0,a_1,\dots$ are non-zero infinitely many times,
+define
+$$x^{(n)}=\left<a_0,\dots,a_n,0,0,\dots\right>\in(\leftarrow,a).$$
+The sequence $(x^{(n)})_n$ is non-decreasing and by removing repeated entries
+one obtains an increasing subsequence converging to $a$.
+
+Otherwise, $a=\left<a_0,\dots,a_{m-1},a_m,0,0,\dots\right>$ with $a_m$ the last non-zero value.
+Take an increasing sequence $b_1<b_2<\dots$ in $[0,1]$ converging to $a_m$ and define
+$$x^{(n)}=\left<a_0,\dots,a_{m-1},b_n,0,0,\dots\right>\in(\leftarrow,a).$$
+The sequence $(x^{(n)})_n$ is increasing and converges to $a$.
+
+Similarly, given a point $a\ne\max X$,
+one can find an decreasing sequence of points $y^{(n)}\in X$ converging to $a$.
+
+So for $a\notin\{\min X,\max X\}$, the countably many intervals
+$(x^{(n)},y^{(n)})$ form a local base at $a$.  And for $a\in\{\min X,\max X\}$
+one can use the intervals $[a,y^{(n)})$ or $(x^{(n)},a]$.

--- a/spaces/S000212/properties/P000036.md
+++ b/spaces/S000212/properties/P000036.md
@@ -1,0 +1,10 @@
+---
+space: S000212
+property: P000036
+value: true
+refs:
+- mathse: 4453440
+  name: Answer to "Is there a nontrivial LOTS that is connected and totally path disconnected?"
+---
+
+See {{mathse:4453440}}.

--- a/spaces/S000212/properties/P000046.md
+++ b/spaces/S000212/properties/P000046.md
@@ -1,0 +1,10 @@
+---
+space: S000212
+property: P000046
+value: true
+refs:
+- mathse: 4453440
+  name: Answer to "Is there a nontrivial LOTS that is connected and totally path disconnected?"
+---
+
+See {{mathse:4453440}}.

--- a/spaces/S000212/properties/P000061.md
+++ b/spaces/S000212/properties/P000061.md
@@ -1,0 +1,30 @@
+---
+space: S000212
+property: P000061
+value: false
+refs:
+  - zb: "0684.54001"
+    name: General Topology (Engelking, 1989)
+---
+
+(similar to {S41|P61})
+
+Since {S212|P28},
+every open interval $(z,w)\subseteq X$ is an $F_\sigma$ set.
+For $a\in[0,1]$, let  $I_a$ denote the open interval
+from $\left<a,0,0,\dots\right>$ to $\left<a,1,1,\dots\right>$, which is therefore an $F_\sigma$ set.
+The set $U=\bigcup\{I_a:a\in[0,1]\cap\mathbb Q\}$ is an open $F_\sigma$ set,
+hence a cozero set since {S212|P13}
+(see Corollary 1.5.13 in {{zb:0684.54001}}).
+
+Suppose by contradiction $V$ is a cozero set disjoint from $U$ with $U\cup V$ dense in $X$.
+Necessarily, $V\cap I_a\ne\varnothing$ for $a\in[0,1]\setminus\mathbb Q$.
+And $V\cap\overline I_a=\varnothing$ for $a\in[0,1]\cap\mathbb Q$.
+So if $\pi:X\to[0,1]$ is the projection onto the $0$-th coordinate,
+$\pi(V)=[0,1]\setminus\mathbb Q$.
+Since every cozero set is an $F_\sigma$ set, $V=\bigcup_n F_n$ for some closed sets $F_n$,
+and $\pi(V)=\bigcup_n\pi(F_n)$.
+So there is at least one $F_n$ with $\pi(F_n)$ infinite; this $\pi(F_n)$ contains an accumulation point $r \in [0, 1]$.
+Then either $u=\left<r,0,0,\dots\right>\in F_n\subseteq V$ or $v=\left<r,1,1,\dots\right>\in F_n\subseteq V$.
+But any neighborhood of a point like $u$ or $v$ contains $I_a$ for some $a\in\mathbb Q$, so $V\cap U\ne\varnothing$.
+This contradiction shows that $X$ is not {P61}.

--- a/spaces/S000212/properties/P000076.md
+++ b/spaces/S000212/properties/P000076.md
@@ -1,0 +1,13 @@
+---
+space: S000212
+property: P000076
+value: false
+---
+
+$X$ contains the closed subspace
+$\bigl( (0, 1] \times \{0\}^\omega \bigr) \cup \bigl( [0, 1) \times \{1\}^\omega \bigr)$,
+which is homeomorphic to {S93}
+(by the map sending $\left<x_0,x_1,x_2,\dots\right>$ to $\left<x_0,x_1\right>$).
+
+{S93|P76}, so neither is $X$
+since the {P76} property is hereditary with respect to closed sets.

--- a/spaces/S000212/properties/P000133.md
+++ b/spaces/S000212/properties/P000133.md
@@ -1,0 +1,7 @@
+---
+space: S000212
+property: P000133
+value: true
+---
+
+By definition.


### PR DESCRIPTION
New S212: Lexicographic Hilbert cube.

As discussed in #642, this provides an example of connected LOTS that is totally path disconnected:
[π-Base, Search for `LOTS + Connected + Totally path disconnected + Has multiple points`](https://topology.pi-base.org/spaces?q=LOTS+%2B+Connected+%2B+Totally+path+disconnected+%2B+Has+multiple+points)

