### PR TITLE
Improved space names

### DIFF
--- a/spaces/S000006/README.md
+++ b/spaces/S000006/README.md
@@ -1,6 +1,6 @@
 ---
 uid: S000006
-name: Deleted integer topology
+name: Deleted integer topology on $\mathbb R\setminus\mathbb Z$
 counterexamples_id: 7
 refs:
   - doi: 10.1007/978-1-4612-6290-9 

--- a/spaces/S000009/README.md
+++ b/spaces/S000009/README.md
@@ -1,6 +1,6 @@
 ---
 uid: S000009
-name: Particular point topology on the real numbers
+name: Particular point topology on $\mathbb R$
 aliases:
   - Included point topology on $\mathbb R$
   - Uncountable Particular Point Topology

--- a/spaces/S000013/README.md
+++ b/spaces/S000013/README.md
@@ -1,6 +1,6 @@
 ---
 uid: S000013
-name: Excluded point topology on the real numbers
+name: Excluded point topology on $\mathbb R$
 aliases:
   - Uncountable excluded point topology
 counterexamples_id: 15
@@ -12,7 +12,7 @@ refs:
 ---
 
 Let $X=\mathbb R$ be the set of real numbers.  A set is open in this
-topology if it excludes a particular point $0$ or is the whole space.
+topology if it excludes a particular point $p=0$ or is the whole space.
 
 Defined as counterexample #15 ("Uncountable Excluded Point Topology")
 in {{doi:10.1007/978-1-4612-6290-9}}.

--- a/spaces/S000017/README.md
+++ b/spaces/S000017/README.md
@@ -3,7 +3,7 @@ uid: S000017
 name: Cocountable topology on $\mathbb R$
 aliases:
   - Cocountable topology on the real numbers
-  - Countable complement space
+  - Countable complement topology
 counterexamples_id: 20
 refs:
   - doi: 10.1007/978-1-4612-6290-9 
@@ -15,8 +15,3 @@ Let $X=\mathbb R$ be the set of real numbers.  Define the topology on $X$ by let
 
 Defined as counterexample #20 ("Countable Complement Topology")
 in {{doi:10.1007/978-1-4612-6290-9}}.
-
-<!-- [[Proof of Topology]]
-Let $\tau = \{$Any countable set$\}$. And let $X$ be an uncountable space.
-Frist we know that $X^c = \emptyset$, which is countable. Also $\emptyset ^c = X$, which is explicitly allowed, showing that both $X$ and $\emptyset$ are in $\tau$.
-Now let $\{ U_i | i \in \textbf{I}\}$ be a sub collection of $X$. (Show $\bigcup\limits_{i \in \textbf{I}} U_i \in X$) We know ($\bigcup\limits_{i \in \textbf{I}} U_i \in X$)$^c$ is countable. So ($\bigcup\limits_{i \in \textbf{I}} U_i$)$^c$ $=\bigcap\limits_{i \in \textbf{I}} U_i ^c$, by the DeMorgan's Law. We know that $\bigcap\limits_{i \in \textbf{I}} U_i ^c$ $\subseteq U_j^c$ for any $j \in \textbf{I}$, which is countable. Now let $\mathcal{A} = \{U_i | i \in [n]\}$ be a sub collection of open sets in $X$. Let $\bigcap\limits_{i=1}^n U_i$, where $U_i \in \mathcal{A}$. We know that ($\bigcap\limits_{i=1}^n U_i$)$^c$$=\bigcup\limits_{i=1}^n U_i^c$ by DeMorgan's Law. Since a countable union of countable sets is countable, it is countable. -->

--- a/spaces/S000022/README.md
+++ b/spaces/S000022/README.md
@@ -1,8 +1,7 @@
 ---
 uid: S000022
-name: Fortissimo space on the real numbers
+name: Fortissimo space on $\mathbb R$
 aliases:
-  - Fortissimo space
   - One-point Lindelöfication of uncountable discrete space
 counterexamples_id: 25
 refs:

--- a/spaces/S000024/README.md
+++ b/spaces/S000024/README.md
@@ -1,9 +1,6 @@
 ---
 uid: S000024
-name: Modified Fort Space on the Real Numbers
-aliases:
-  - Uncountable Modified Fort Space
-  - Modified Fort Space
+name: Modified Fort space on $\mathbb R$
 counterexamples_id: 27
 refs:
   - doi: 10.1007/978-1-4612-6290-9 
@@ -11,7 +8,7 @@ refs:
   - wikipedia: Fort_space
     name: Fort space
 ---
-Let \(X=\mathbb{R}\cup\{\infty_1,\infty_2\}\).
+Let $X=\mathbb{R}\cup\{\infty_1,\infty_2\}$.
 Every point of $\mathbb R$ is isolated and the open neighborhoods of each point $\infty_i$ are the cofinite subsets of $X$ containing the point.
 
 Defined as counterexample #27 ("Modified Fort Space")

--- a/spaces/S000025/README.md
+++ b/spaces/S000025/README.md
@@ -1,10 +1,9 @@
 ---
 uid: S000025
-name: Euclidean Real Numbers
+name: Euclidean real numbers $\mathbb R$
 aliases:
-  - Real Line
-  - Euclidean Topology
-  - Euclidean Space
+  - Real line
+  - Euclidean topology
 counterexamples_id: 28
 refs:
 - doi: 10.1007/978-1-4612-6290-9 

--- a/spaces/S000026/README.md
+++ b/spaces/S000026/README.md
@@ -1,6 +1,6 @@
 ---
 uid: S000026
-name: Cantor space
+name: Cantor space $2^\omega$
 aliases:
 - Cantor set
 counterexamples_id: 29

--- a/spaces/S000027/README.md
+++ b/spaces/S000027/README.md
@@ -1,8 +1,7 @@
 ---
 uid: S000027
-name: Rational numbers
+name: Rational numbers $\mathbb Q$
 aliases:
-  - $\mathbb Q$
   - Furstenberg topology
   - Evenly spaced integer topology
   - The $p$-adic topology on $\mathbb{Z}$
@@ -25,7 +24,7 @@ in {{doi:10.1007/978-1-4612-6290-9}}.
 ----
 A purely topological characterization of the space $\mathbb Q$, due to Sierpinski, is given by the following equivalent theorems:
 - Every countably infinite, {P53} space without isolated point is homeomorphic to $\mathbb Q$.
-- Every countably infinite, {P5} {P28} space without isolated point is homeomorphic to $\mathbb Q$.
+- Every countably infinite, {P5}, {P28} space without isolated point is homeomorphic to $\mathbb Q$.
 
 For a proof, see [Countable metric spaces without isolated points (A. Dasgupta)](http://at.yorku.ca/p/a/c/a/25.pdf) or {{doi:10.48550/arXiv.1210.1008}}.
 And for the equivalence between the two theorems, the second one easily follows from the first; and the reverse direction follows from {T212} together with Urysohn's metrization theorem.

--- a/spaces/S000028/README.md
+++ b/spaces/S000028/README.md
@@ -1,12 +1,9 @@
 ---
 uid: S000028
-name: Irrational numbers
+name: Irrational numbers $\mathbb R\setminus\mathbb Q$
 aliases:
-  - Irrationals
-  - Z^Z
-  - Omega to the omega power
-  - Baire space
-  - Baire product
+  - Baire space $\omega^\omega$
+  - $\mathbb Z^{\mathbb Z}$
   - Countable power of a countable discrete space
 counterexamples_id: 31
 refs:
@@ -16,26 +13,16 @@ refs:
   name: Irrational number on Wikipedia
 - wikipedia: Baire_space_(set_theory)
   name: Baire space (set theory) on Wikipedia
+- mathse: 352547
+  name: Baire space homeomorphic to irrationals
 ---
+
 Let $X$ be the complement of the rational numbers in $\mathbb{R}$ with the subspace topology.
 
-This space is homeomorphic to the Baire space \(\omega^\omega\) with the
-product topology.
+This space is homeomorphic to the *Baire space* $\omega^\omega$ with the
+product topology.  See for example {{mathse:352547}}.
 
 Defined as counterexample #31 ("The Irrational Numbers")
 in {{doi:10.1007/978-1-4612-6290-9}}.
-Also defined as counterexample #102 ("\(\mathbb{Z}^{\mathbb{Z}}\)")
+Also defined as counterexample #102 ("$\mathbb Z^{\mathbb Z}$")
 in {{doi:10.1007/978-1-4612-6290-9}}.
-
-<!-- [[Proof of Topology]]
-In order to confirm the topology on the irrational numbers we simply must verify it is a subspace.  Let $\mathbb{I}$ be the set of irrational numbers.  Let $\tau$ denote the topology on $\mathbb{R}$.  
-Observe both $\emptyset$ and $\mathbb{I}$ belong to $\tau_\mathbb{I}$ since
-$$\emptyset = \mathbb{I} \cap \emptyset$$  $$\mathbb{I} = \mathbb{I} \cap \mathbb{R},$$
-noting that both $\emptyset$ and $\mathbb{I}$ belong to $\tau$.
-
-Taking the arbitrary union of any elements of $\tau_\mathbb{I}$ we note
-$$ \bigcup_{i \in I} (\mathbb{I} \cap U_i) = \mathbb{I} \cap \bigcup_{i \in I} U_i $$
-which is in $\tau_\mathbb{I}$ since $\bigcup_{i \in I} U_i \in \tau$.   
-Taking the intersection of finitely-many elements of $\tau_\mathbb{I}$, we note
-$$ \bigcap_{i = 1}^n (\mathbb{I} \cap U_i) = \mathbb{I} \cap \bigcap_{i = 1}^n U_i $$
-which is in $\tau_\mathbb{I}$ since $\bigcap_{i=1}^n U_i \in \tau$. -->

--- a/spaces/S000102/README.md
+++ b/spaces/S000102/README.md
@@ -1,8 +1,7 @@
 ---
 uid: S000102
-name: Baire metric on a countable product of reals
+name: Baire metric on $\mathbb R^\omega$
 aliases:
-  - Baire product metric
   - Countable product of continuum-sized discrete spaces
 counterexamples_id: 104
 refs:

--- a/spaces/S000169/README.md
+++ b/spaces/S000169/README.md
@@ -1,17 +1,17 @@
 ---
 uid: S000169
-name: Sphere
+name: Sphere $S^2$
 aliases:
-- $S^2$
 - Two-dimensional sphere
 refs:
   - wikipedia: Sphere
     name: Sphere on Wikipedia
 ---
 
-The subspace $\{x \in \mathbb{R}^3: \|x\| = 1\}$ of the Euclidean space $\mathbb{R}^3$, consisting of points with distance 1 from the origin.
+The subspace $\{x \in \mathbb{R}^3: \|x\| = 1\}$ of the Euclidean space $\mathbb{R}^3$
+consisting of points with distance 1 from the origin.
 
 This space is homeomorphic to:
-- The one-point compactification of {S176}
+- The one-point compactification of {S176},
 - The suspension of {S170}, i.e., the quotient of $S^1 \times [0,1]$ where $S^1 \times \{0\}$ is identified to a
-single point and $S^1 \times \{1\}$ is identified to a single point
+single point and $S^1 \times \{1\}$ is identified to a single point.

--- a/spaces/S000170/README.md
+++ b/spaces/S000170/README.md
@@ -1,12 +1,16 @@
 ---
 uid: S000170
-name: Circle
+name: Circle $S^1$
 aliases:
-- $S^1$
 - One-dimensional sphere
 refs:
   - wikipedia: Circle
     name: Circle on Wikipedia
 ---
 
-The quotient of an interval identifying its endpoints.
+The subspace $\{x \in \mathbb{R}^2: \|x\| = 1\}$ of
+{S176} consisting of points with distance $1$ from the origin.
+
+This space is homeomorphic to:
+- The one-point compactification of {S25},
+- The quotient of the interval $[0,1]$ identifying its endpoints.


### PR DESCRIPTION
Improved names and streamlined aliases for some spaces, as discussed in latest zoom meeting.

My guiding principle when removing some aliases was that, due to fuzzy matching, the space would still be accessible by starting to type the previous alias.