### PR TITLE
countable pseudocharacter + pseudoradial implies sequential

### DIFF
--- a/spaces/S000140/properties/P000191.md
+++ b/spaces/S000140/properties/P000191.md
@@ -1,7 +1,0 @@
----
-space: S000140
-property: P000191
-value: false
----
-
-$\{\infty\}$ is a countable intersection of open sets if and only if $X \setminus \{\infty\} = \mathbb{R}$ is a countable union of closed sets. Let $C \subseteq \mathbb{R}$ be a closed set in $X$. As $X \setminus C$ is an open neighborhood of $\{\infty\}$ in $X$, $C$ is countable. As $\mathbb{R}$ is uncountable, it is not a countable union of closed sets.

--- a/theorems/T000725.md
+++ b/theorems/T000725.md
@@ -1,0 +1,11 @@
+---
+uid: T000725
+if:
+  and:
+  - P000173: true
+  - P000191: true
+then:
+  P000079: true
+---
+
+Let $A\subseteq X$ be sequentially closed. If $x_i\in A$ is a well-ordered net with uncountable cofinality such that $x_i\to x$, let $\{x\} = \bigcap_n U_n$ where $U_n$ are open. There exist $i_n$ such that $x_i\in U_n$ for $i\geq i_n$. Then $x_i = x$ for $i\geq \sup_n i_n$, so that $x\in A$. It follows that $A$ is radially closed, and so closed since $X$ is pseudoradial.


### PR DESCRIPTION
The proof technique is essentially the same as that of theorem 5.6 in https://people.math.sc.edu/nyikos/erdos.pdf

Came up with this while writing https://math.stackexchange.com/a/5059755/476484

It will automatically show that $\ell^2$ with weak topology is not pseudoradial, which is not known on pi-base