### PR TITLE
restore pushes to R2

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -26,13 +26,13 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: us-east-2
 
-      # - name: Upload bundle to R2
-      #   run: |
-      #     aws s3api put-object --endpoint-url https://78c505984bbdc3e69206eecb9471c4de.r2.cloudflarestorage.com --bucket pi-base --key ${GITHUB_REF:-unknown}.json --body bundle.json
-      #   env:
-      #     AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-      #     AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-      #     AWS_DEFAULT_REGION: auto
+      - name: Upload bundle to R2
+        run: |
+          aws s3api put-object --endpoint-url https://78c505984bbdc3e69206eecb9471c4de.r2.cloudflarestorage.com --bucket pi-base --key ${GITHUB_REF:-unknown}.json --body bundle.json --checksum-algorithm CRC32
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
 
 #       - name: Notify Slack
 #         run: |


### PR DESCRIPTION
I'd like to start moving the storage backend over (in part b/c the egress costs from S3 are becoming non-trivial).

The actual error appears to stem from the [compatibility issue mentioned here](https://developers.cloudflare.com/r2/examples/aws/aws-cli/); adding an explicit `--checksum-algorithm` looks to resolve it.