### PR TITLE
Cocountable topology on the reals is not submetacompact

### DIFF
--- a/spaces/S000017/properties/P000194.md
+++ b/spaces/S000017/properties/P000194.md
@@ -1,0 +1,9 @@
+---
+space: S000017
+property: P000194
+value: false
+---
+
+Note that if $\mathcal{V} = \{V_j : j\in J\}$ is an open cover that refines $\mathcal{U}= \{U_i : i\in I\}$, then there is an open cover $\mathcal{W} = \{W_i : i\in I\}$ such that $W_i\subseteq U_i$ for all $i\in I$, and if $\mathcal{V}$ is point-finite at $x\in X$, then $\mathcal{W}$ is point-finite at $x\in X$. Indeed, there is $\pi:J\to I$ such that $V_j\subseteq U_{\pi(j)}$ for all $j\in J$, and it's enough to define $W_i = \bigcup_{j\in \pi^{-1}(i)} V_j$.
+
+Take $\mathcal{U} = \{\mathbb{R}\setminus\{n, n+1, ...\}:n\in\mathbb{N}\}$ and suppose that there are open covers $\mathcal{V}_n$ such that $\mathcal{V}_n$ refines $\mathcal{U}$ for each $n$, and for each $x\in \mathbb{R}$ there is $n$ such that $\mathcal{V}_n$ is point-finite at $x$. From the previous remark we can assume that $\mathcal{V}_n$ is countable for each $n$, and we can additionally assume that no $V\in\mathcal{V}_n$ is empty. Since $\mathcal{V}_n$ refines $\mathcal{U}$, it follows that $\mathcal{V}_n$ must be infinite. Since each $\mathcal{V}_n$ consists of cofinite sets, it follows that the intersection of al of them is a cofinite set, and so non-empty. Let $x$ be a member of the intersection. Then $x\in V$ for any $V\in\mathcal{V}_n$, and since $\mathcal{V}_n$ is infinite it follows that $\mathcal{V}_n$ is not point-finite at $x$. Contradiction.


### PR DESCRIPTION
Cocountable topology on $\mathbb{R}$ is not submetacompact