### PR TITLE
Fortissimo space of size $\aleph_1$ is 2-Markov Menger

### DIFF
--- a/spaces/S000155/properties/P000072.md
+++ b/spaces/S000155/properties/P000072.md
@@ -1,0 +1,10 @@
+---
+space: S000155
+property: P000072
+value: true
+refs:
+  - doi: 10.14712/1213-7243.2015.201
+    name: Applications of limited information strategies in Menger's game
+---
+
+In definition 3.7 of {{doi:10.14712/1213-7243.2015.201}} a set-theoretic statement $\mathcal{A}(\kappa)$  is introduced, and in theorem 3.8 it's shown that $\mathcal{A}(\omega_1)$ holds. In theorem 5.6 it's shown that $\mathcal{A}(\kappa)$ implies that $L(\kappa)$ is robustly Menger, where $L(\kappa)$ is the one-point Lindelofication of discrete space of size $\kappa$. In this case $L(\omega_1)$ is {S155}. From theorem 5.5 it follows that robustly Menger implies 2-Markov Menger, so {S155|P72}.


### PR DESCRIPTION
This is essentially "nothing new", it was already known from paper of @StevenClontz , I assume it wasn't added since Fortissimo space of size $\aleph_1$ was created at a later date

(I suspect the same statement for fortissimo of size $\aleph_2, \mathfrak{c}$ is independent of ZFC; also for cocountable topology on $\mathbb{R}$)