### PR TITLE
Equivalence between Markov Menger and Markov k-Menger for anticompact spaces

### DIFF
--- a/theorems/T000726.md
+++ b/theorems/T000726.md
@@ -1,0 +1,11 @@
+---
+uid: T000726
+if:
+  and:
+  - P000136: true
+  - P000070: true
+then:
+  P000161: true
+---
+
+If compact and finite subsets coincide, then $\Omega_X = \mathcal{K}_X$ so that the games $\mathsf{G}_\text{fin}(\Omega_X, \Omega_X)$ and $\mathsf{G}_\text{fin}(\mathcal{K}_X, \mathcal{K}_X)$ are the same. Since {P70} is equivalent to Markov $\Omega$-Menger, it follows that $X$ is {P161}.

--- a/theorems/T000727.md
+++ b/theorems/T000727.md
@@ -1,11 +1,12 @@
 ---
 uid: T000727
 if:
-  and:
-  - P000136: true
-  - P000161: true
+  P000161: true
 then:
   P000070: true
+refs:
+  - doi: 10.4995/agt.2024.21437 
+    name: On traditional Menger and Rothberger variations (Caruvana, Clontz, Holshouser)
 ---
 
-If compact and finite subsets coincide, then $\Omega_X = \mathcal{K}_X$ so that the games $\mathsf{G}_\text{fin}(\Omega_X, \Omega_X)$ and $\mathsf{G}_\text{fin}(\mathcal{K}_X, \mathcal{K}_X)$ are the same. Since {P70} is equivalent to Markov $\Omega$-Menger, it follows that $X$ is {P70}.
+See figure 1 and and theorem 4.43 of {{doi:10.4995/agt.2024.21437}}.

--- a/theorems/T000727.md
+++ b/theorems/T000727.md
@@ -1,0 +1,11 @@
+---
+uid: T000727
+if:
+  and:
+  - P000136: true
+  - P000161: true
+then:
+  P000070: true
+---
+
+If compact and finite subsets coincide, then $\Omega_X = \mathcal{K}_X$ so that the games $\mathsf{G}_\text{fin}(\Omega_X, \Omega_X)$ and $\mathsf{G}_\text{fin}(\mathcal{K}_X, \mathcal{K}_X)$ are the same. Since {P70} is equivalent to Markov $\Omega$-Menger, it follows that $X$ is {P70}.


### PR DESCRIPTION
This will show that cocountable topology on $\mathbb{R}$ (S17) is Markov k-Menger.

Might be a good idea to clean up S17 after this is approved.

Note that I would add just one theorem instead of two, but I'm not sure there is any sleek way to do it on pi-base.