### PR TITLE
Strategically Rothberger is preserved under Kolmogorov quotient

### DIFF
--- a/properties/P000151.md
+++ b/properties/P000151.md
@@ -15,3 +15,8 @@ Strategically Rothberger: The second player has a winning strategy in the Rothbe
 Strategically $\Omega$-Rothberger: The second player has a winning strategy in the game $\mathsf{G}_1(\Omega_X,\Omega_X)$. See pages 2 and 3 of {{doi:10.1016/j.topol.2019.07.008}} for more details.
 
 Theorem 15 of {{doi:10.1016/j.topol.2019.07.008}} states the equivalence for {P6} spaces, but the equivalence is shown to not require any separations axioms at {{mathse:4738368}}.
+
+----
+#### Meta-properties
+
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.

--- a/spaces/S000018/properties/P000151.md
+++ b/spaces/S000018/properties/P000151.md
@@ -1,0 +1,8 @@
+---
+space: S000018
+property: P000151
+value: true
+---
+
+The Kolmogorov quotient of $X$ is {S17}
+and {S17|P151}.


### PR DESCRIPTION
The property Strategically Rothberger is a property of player 2 having winning strategy in a game $\mathcal{G}_1(\mathcal{O}_X, \mathcal{O}_X)$. Now the thing here is, that $\mathcal{O}_X$ are open covers of $X$, and the game only depends on the frame of open sets of a topological space. And for $X$ and its Kolmogorov quotient, those frames are isomorphic. 

Of course also the interesting conclusion here is that this game could be played on frames.

I've also added that S18 has this property since its Kolmogorov quotient is S17