### PR TITLE
Anticompact is closed under finite products

### DIFF
--- a/properties/P000136.md
+++ b/properties/P000136.md
@@ -11,3 +11,8 @@ refs:
 ---
 
 Every compact subset of the space is finite.
+
+----
+#### Meta-properties
+
+- This property is preserved by finite products.

--- a/spaces/S000018/properties/P000136.md
+++ b/spaces/S000018/properties/P000136.md
@@ -1,0 +1,7 @@
+---
+space: S000018
+property: P000136
+value: true
+---
+
+{S18} is a product of {S17} and {S4} and both {S17|P136} and {S4|P136} so that their product is also {P136}

--- a/spaces/S000018/properties/P000136.md
+++ b/spaces/S000018/properties/P000136.md
@@ -4,4 +4,4 @@ property: P000136
 value: true
 ---
 
-{S18} is a product of {S17} and {S4} and both {S17|P136} and {S4|P136} so that their product is also {P136}
+$X$ is a product of two {P136} spaces, as {S17|P136} and {S4|P136}.


### PR DESCRIPTION
I haven't seen standard phrasing used for this meta-property, so I've used what I saw in another file.

As a corollary, S18 is anticompact.

Curiously, anticompact is not closed under Kolmogorov quotient, as infinite indiscrete space shows, so this time I couldn't have said that this space is anticompact because the same is true for its Kolmogorov quotient.