### PR TITLE
Radial is preserved under Kolmogorov quotient

### DIFF
--- a/properties/P000172.md
+++ b/properties/P000172.md
@@ -11,3 +11,8 @@ refs:
 A space such that for each $A\subseteq X$ and each $p\in \overline A$ there is a transfinite sequence $(x_\alpha)_{\alpha<\lambda}$ of points of $A$ converging to $p$.  (Here $\lambda$ is a limit ordinal and can always be taken to be a regular cardinal.)
 
 See the chapter "d-4 Pseudoradial spaces" in {{zb:1059.54001}}.
+
+----
+#### Meta-properties
+
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.

--- a/spaces/S000018/properties/P000172.md
+++ b/spaces/S000018/properties/P000172.md
@@ -1,0 +1,8 @@
+---
+space: S000018
+property: P000172
+value: true
+---
+
+The Kolmogorov quotient of $X$ is {S17}
+and {S17|P172}.


### PR DESCRIPTION
Both implications are pretty simple, you can easily prove this using that $q:X\to\text{Kol}(X)$ is a continuous, open, closed, surjection such that $q(x_\alpha)\to q(x) \iff x_\alpha\to x$ for any net $(x_\alpha)\subseteq X$ and $x\in X$.

As a corollary, S18 is radial