### PR TITLE
Well-based is preserved under Kolmogorov

### DIFF
--- a/properties/P000174.md
+++ b/properties/P000174.md
@@ -24,3 +24,8 @@ One says that $X$ is *well-based at the point $x$* if the conditions above hold 
 So $X$ is well-based if it is well-based at every point.
 
 See also {{mo:202280}} and {{mo:322162}}.
+
+----
+#### Meta-properties
+
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.


### PR DESCRIPTION
This meta-property is quite obvious.

I didn't add anything else in this PR, its purpose is mostly to conclude that S18 being well-based is equivalent to CH, just like it is the case for S17.