### PR TITLE
Hereditarily Lindelof is preserved under Kolmogorov quotient

### DIFF
--- a/properties/P000131.md
+++ b/properties/P000131.md
@@ -15,3 +15,8 @@ A space for which every subspace is {P18}.  Equivalently, a space in which every
 The equivalence between the two is shown for example in {{mathse:494918}}.
 
 Defined in 16E of {{zb:1052.54001}}.
+
+----
+#### Meta-properties
+
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.

--- a/spaces/S000018/properties/P000131.md
+++ b/spaces/S000018/properties/P000131.md
@@ -1,0 +1,8 @@
+---
+space: S000018
+property: P000131
+value: true
+---
+
+The Kolmogorov quotient of $X$ is {S17}
+and {S17|P131}.


### PR DESCRIPTION
The proof here is only slightly more complicated.

If $A\subseteq X$ and $q:X\to \text{Kol}(X)$ is the Kolmogorov quotient, then the important observation is that $q\restriction_A:A\to q(A)$ is also a Kolmogorov quotient, as seen from $q(U\cap A) = q(U)\cap q(A)$ for open $U\subseteq X$.

As a corollary, S18 is hereditarily Lindelof