### PR TITLE
2-Markov Menger is preserved under Kolmogorov quotient

### DIFF
--- a/properties/P000072.md
+++ b/properties/P000072.md
@@ -6,3 +6,8 @@ refs:
     name: Applications of limited information strategies in Menger's game
 ---
 The second player has a $2$-Markov winning strategy in the Menger game (relying on only the round number and two most recent moves of the opponent).
+
+----
+#### Meta-properties
+
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.


### PR DESCRIPTION
https://dml.cz/bitstream/handle/10338.dmlcz/146790/CommentatMathUnivCarolRetro_58-2017-2_8.pdf
As @StevenClontz writes here, 2-Markov Menger is equivalent to the second player having 2-Markov strategy in the game $\mathcal{G}_\text{fin}(\mathcal{O}_X, \mathcal{O}_X)$, which depends only on the frame of open sets of $X$, which is isomorphic to frame of open sets of $\text{Kol}(X)$.

This PR doesn't serve a purpose right now, since it's unknown if S17 has 2-Markov Menger property
However it does imply that S17 and S18 having 2-Markov Menger property is equivalent, so this is a PR for the safekeeping purposes.
Note that I've asked if S17 has 2-Markov Menger property is independent of ZFC, which seems to be currently unknown. 