### PR TITLE
Rothberger is hereditarily with respect to closed subspaces

### DIFF
--- a/properties/P000068.md
+++ b/properties/P000068.md
@@ -14,3 +14,7 @@ A space that satisfies the selection principle
 also an open cover.
 
 See section 6 of {{doi:10.1016/0166-8641(95)00067-4}}.
+
+#### Meta-properties
+
+- This property is hereditary under closed subspaces.

--- a/spaces/S000021/properties/P000068.md
+++ b/spaces/S000021/properties/P000068.md
@@ -1,0 +1,7 @@
+---
+space: S000021
+property: P000068
+value: false
+---
+
+{S21} has {S25} as a closed subspace, and {S25|P68}.


### PR DESCRIPTION
Proof:

Let $\mathcal{U}_n$ be a sequence of open covers of closed $Y\subseteq X$ by open subsets of $X$. Then $\mathcal{U}_n\cup \\{X\setminus Y\\}$ is an open cover of $X$. Since $X$ is Rothberger there exist some $V_n\in \mathcal{U}_n\cup \\{X\setminus Y\\}$ such that $V_n$ cover $X$. Define $U_n = V_n$ if $V_n\in\mathcal{U}_n$ and $U_n\in\mathcal{U}_n$ arbitrary otherwise. Then $U_n\in \mathcal{U}_n$ for all $n$, and $Y\subseteq \bigcup_n U_n$. $\square$

As a corollary, weak topology on $\ell^2$ is not Rothberger