### PR TITLE
Weak topology on $\ell^2$ is not monotonically normal

### DIFF
--- a/spaces/S000021/properties/P000053.md
+++ b/spaces/S000021/properties/P000053.md
@@ -1,9 +1,0 @@
----
-space: S000021
-property: P000053
-value: false
-refs:
-- doi: 10.1016/B978-0-12-622760-4.X5000-6
-  name: Handbook of Analysis and Its Foundations
----
-See Corollary 28.18 (c) of {{doi:10.1016/B978-0-12-622760-4.X5000-6}}.

--- a/spaces/S000021/properties/P000109.md
+++ b/spaces/S000021/properties/P000109.md
@@ -1,0 +1,12 @@
+---
+space: S000021
+property: P000109
+value: false
+refs:
+- doi: 10.1016/S0166-8641(97)00113-2
+  name: Nonstratifiability of topological vector spaces
+- doi: 10.1016/B978-0-12-622760-4.X5000-6
+  name: Handbook of Analysis and Its Foundations
+---
+
+In Theorem 6a of {{doi:10.1016/S0166-8641(97)00113-2}} it's shown that a topological vector space with its weak topology is metrizable iff monotonically normal. But $X$ is not metrizable as seen in Corollary 28.18 (c) of {{doi:10.1016/B978-0-12-622760-4.X5000-6}}, and so cannot be monotonically normal.


### PR DESCRIPTION
Turns out that for weak topology on a TVS, stratifiability, metrizability and monotone normality are all equivalent.

I don't see a way to adapt it as any type of theorem, but it resolves this issue at least.

I've deleted the non-metrizability and merged the contents of that file with this one for monotone normality to avoid referencing to it if it'll be deleted in the cleanup.

This PR is also the last one from the series of PR's I've done for this space (for the currently tracked traits), and after the PR's are pushed, we can do a cleanup.

