### PR TITLE
Proof of T73 (zero dim + T0 => totally separated)

### DIFF
--- a/theorems/T000073.md
+++ b/theorems/T000073.md
@@ -2,13 +2,19 @@
 uid: T000073
 if:
   and:
-  - P000001: true
   - P000050: true
+  - P000001: true
 then:
   P000048: true
 refs:
 - doi: 10.1007/978-1-4612-6290-9
   name: Counterexamples in Topology
 ---
+
+Given two distinct points $a,b\in X$, by {P1} there is an open set $U$
+containing one of the points and not the other, say $a\in U$ and $b\notin U$.
+By {P50} there is a clopen set $V$ with $a\in V\subseteq U$.
+Then $V$ is a clopen set containing $a$ and not $b$;
+and $X\setminus V$ is a clopen set containing $b$ and not $a$.
 
 Asserted in Figure 9 (page 32) of {{doi:10.1007/978-1-4612-6290-9}}.


### PR DESCRIPTION
T73 (zero dimensional + T0 => totally separated) did not have a proof.

It is straighforward to show, but I could not find a reference for it.  So adding one here.