### PR TITLE
Revert "Well-based is hereditary, Modified Fort space on $\mathbb{R}$ is not well-based"

### DIFF
--- a/properties/P000174.md
+++ b/properties/P000174.md
@@ -29,4 +29,3 @@ See also {{mo:202280}} and {{mo:322162}}.
 #### Meta-properties
 
 - $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
-- This property is hereditary.

--- a/spaces/S000024/properties/P000174.md
+++ b/spaces/S000024/properties/P000174.md
@@ -1,7 +1,0 @@
----
-space: S000024
-property: P000174
-value: false
----
-
-It has {S154} as subspace and {S154|P174}.


### PR DESCRIPTION
Partially reverts pi-base/data#1329, S24|P174 is redundant by S24|187.

https://topology.pi-base.org/spaces/S000024/properties/P000174