### PR TITLE
Fort space on R is Eberlein compact

### DIFF
--- a/spaces/S000154/properties/P000091.md
+++ b/spaces/S000154/properties/P000091.md
@@ -1,0 +1,11 @@
+---
+space: S000154
+property: P000091
+value: true
+refs:
+  - zb: "0232.46019"
+    name: Weakly compact sets - their topological properties and the Banach spaces they generate (J. Lindenstrauss)
+---
+
+It follows from Proposition 3.2 of {{zb:0232.46019}} that the one-point compactification of a locally compact metric spaces is {P91},
+and {S154} is the one-point compactification of {S3}, which is {P130} {P53}.

--- a/spaces/S000154/properties/P000091.md
+++ b/spaces/S000154/properties/P000091.md
@@ -5,7 +5,12 @@ value: true
 refs:
   - zb: "0232.46019"
     name: Weakly compact sets - their topological properties and the Banach spaces they generate (J. Lindenstrauss)
+  - mathse: 5071093
+    name: Is the one-point compactification of an uncountable discrete space Eberlein compact?
 ---
 
 It follows from Proposition 3.1 of {{zb:0232.46019}} that the one-point compactification of the disjoint union of {P91} spaces is {P91},
-and {S154} is the one-point compactification of {S3}, which is the disjoint union of {S162}.
+and {S154} is the one-point compactification of {S3},
+which is the disjoint union of copies of {S162}.
+
+See also {{mathse:5071093}}.

--- a/spaces/S000154/properties/P000091.md
+++ b/spaces/S000154/properties/P000091.md
@@ -7,5 +7,5 @@ refs:
     name: Weakly compact sets - their topological properties and the Banach spaces they generate (J. Lindenstrauss)
 ---
 
-It follows from Proposition 3.1 of {{zb:0232.46019}} that the one-point compactification of the disjoint union of Eberlein compact spaces is {P91},
+It follows from Proposition 3.1 of {{zb:0232.46019}} that the one-point compactification of the disjoint union of {P91} spaces is {P91},
 and {S154} is the one-point compactification of {S3}, which is the disjoint union of {S162}.

--- a/spaces/S000154/properties/P000091.md
+++ b/spaces/S000154/properties/P000091.md
@@ -7,5 +7,5 @@ refs:
     name: Weakly compact sets - their topological properties and the Banach spaces they generate (J. Lindenstrauss)
 ---
 
-It follows from Proposition 3.2 of {{zb:0232.46019}} that the one-point compactification of a locally compact metric spaces is {P91},
-and {S154} is the one-point compactification of {S3}, which is {P130} {P53}.
+It follows from Proposition 3.1 of {{zb:0232.46019}} that the one-point compactification of the disjoint union of Eberlein compact spaces is {P91},
+and {S154} is the one-point compactification of {S3}, which is the disjoint union of {S162}.


### PR DESCRIPTION
In addition, this make P16 (Compact), P50 (Zero dimensional) and P187 (W-space) redundant and I've not removed any of it.

It can be discussed whether to remove or keep.
