### PR TITLE
W-space updates

### DIFF
--- a/properties/P000012.md
+++ b/properties/P000012.md
@@ -21,4 +21,5 @@ Equivalently, the topology is induced by a uniformity.  See Theorem 38.2 in {{zb
 ----
 #### Meta-properties
 
+- This property is hereditary.
 - $X$ is {P12} iff its Kolmogorov quotient $\text{Kol}(X)$ is {P6}.

--- a/properties/P000028.md
+++ b/properties/P000028.md
@@ -9,3 +9,10 @@ refs:
 A space with a countable local basis at every point.
 
 Defined on page 7 of {{doi:10.1007/978-1-4612-6290-9}}.
+
+----
+#### Meta-properties
+
+- This property is hereditary.
+- A space that is locally {P28} (every point has a neighborhood with the property)
+has the property.

--- a/properties/P000077.md
+++ b/properties/P000077.md
@@ -5,4 +5,12 @@ refs:
   - mr: 584666
     name: On function spaces of compact subspaces of Σ-products of the real line.
 ---
-Any compact subspace of a $\Sigma$-product of real lines.
+
+$X$ is homeomorphic to a compact subspace of a $\Sigma$-product of real lines.
+By homogeneity of the real line, one can assume the $\Sigma$-product is of the form
+
+$\quad Y=\{x=(x_\alpha)\in\mathbb R^\Gamma:\{\alpha:x_\alpha\ne 0\}\text{ is countable}\}$
+
+for some set $\Gamma$.
+The space $Y$ has the topology of pointwise convergence induced from
+the product topology of $\mathbb R^\Gamma$.

--- a/properties/P000187.md
+++ b/properties/P000187.md
@@ -2,20 +2,25 @@
 uid: P000187
 name: W-space
 refs:
-  - doi: 10.1016/0016-660X(76)90024-6
+  - zb: "0327.54019"
     name: Infinite games and generalizations of first-countable spaces (Gruenhage)
+  - zb: "1141.54020"
+    name: The story of a topological game (Gruenhage)
 ---
 
 P1 has a winning strategy at each point $x\in X$ 
-for the following game defined by Gruenhage in
-{{doi:10.1016/0016-660X(76)90024-6}}.
+for the following game defined by Gruenhage in {{zb:0327.54019}}.
 
 During each round $n<\omega$, P1 chooses some neighborhood $U_n$ of $x$,
-then P2 chooses some point $p_n\in U_n$. P1 wins provided the sequence
-$p_n$ converges to $x$; P2 wins otherwise.
+then P2 chooses some point $x_n\in U_n$. P1 wins provided the sequence
+of $x_n$ converges to $x$; P2 wins otherwise.
+
+See also section 2 of {{zb:1141.54020}}.
 
 ----
 #### Meta-properties
 
 - This property is hereditary.
-- A locally $W$-space (every point has a neighborhood that is a $W$-space) is a $W$-space.
+- This property is preserved by countable products (see Theorem 4.1 of {{zb:0327.54019}}).
+- This property is preserved by $\Sigma$-products (see Theorem 4.6 of {{zb:0327.54019}}).
+- A locally $W$-space (every point has a neighborhood with the property) is a $W$-space.

--- a/theorems/T000472.md
+++ b/theorems/T000472.md
@@ -9,4 +9,5 @@ refs:
     name: Topological group on Wikipedia
 ---
 
-Follows as $\mathbb R^n$ is {P87} and {P28} (and therefore {P187}).
+Follows as $\mathbb R^n$ is a topological group under addition
+and is {P28} (and therefore {P187}).

--- a/theorems/T000473.md
+++ b/theorems/T000473.md
@@ -9,6 +9,6 @@ refs:
     name: Infinite games and generalizations of first-countable spaces (Gruenhage)
 ---
 
-Follows from Theorem 3.2 on page 342 of {{doi:10.1016/0016-660X(76)90024-6}}.
+Follows from Theorem 3.2 of {{doi:10.1016/0016-660X(76)90024-6}}.
 Given a decreasing local base $\{B_n:n<\omega\}$ at a point $x$, the winning strategy
-at $x$ for the first player is to play $B_n$ during round $n$.
+at $x$ for Player 1 is to play $B_n$ during round $n$.

--- a/theorems/T000477.md
+++ b/theorems/T000477.md
@@ -6,4 +6,11 @@ then:
   P000186: true
 ---
 
-By definition as any $\Sigma$ product of reals {P87} and is {P187}.
+The $\Sigma$-product
+
+$\quad Y=\{x=(x_\alpha)\in\mathbb R^\Gamma:\{\alpha:x_\alpha\ne 0\}\text{ is countable}\}$
+
+for some set $\Gamma$ is a subgroup of the topological group $(\mathbb R^\Gamma,+)$
+with the product topology, and is {P187}
+since {S25|P187}
+and the {P187} property is preserved by $\Sigma$-products.

--- a/theorems/T000479.md
+++ b/theorems/T000479.md
@@ -1,9 +1,9 @@
 ---
 uid: T000479
 if:
-  P000186: true # embeds in topological W group
+  P000186: true
 then:
-  P000187: true # W space
+  P000187: true
 ---
 
-Follows as {P187} is hereditary.
+Follows as the {P187} property is hereditary.

--- a/theorems/T000580.md
+++ b/theorems/T000580.md
@@ -3,12 +3,16 @@ uid: T000580
 if:
   and:
   - P000187: true
-  - P000057: true
+  - P000093: true
 then:
   P000028: true
 refs:
-  - doi: 10.1016/0016-660X(76)90024-6
+  - zb: "0327.54019"
     name: Infinite games and generalizations of first-countable spaces (Gruenhage)
 ---
 
-Shown in Corollary 3.4 of {{doi:10.1016/0016-660X(76)90024-6}}.
+Suppose $X$ satisfies the hypotheses.
+Any point $x\in X$ has a countable neighborhood $V$,
+which is also {P187} by hereditariness.
+By Corollary 3.4 of {{zb:0327.54019}}, $V$ is {P28}.
+The result follows because being {P28} is a local property.


### PR DESCRIPTION
Updates related to the properties P187 (W-space) and P186 (embeds in a topological W-group).

Added meta-properties, clarifications of some definitions and theorems.
Generalized T580 from (W-space + countable => first countable) to (W-space + locally countable => first countable).
