### PR TITLE
Shorter names for spaces related to rationals

### DIFF
--- a/spaces/S000029/README.md
+++ b/spaces/S000029/README.md
@@ -1,6 +1,8 @@
 ---
 uid: S000029
-name: One Point Compactification of the Rationals
+name: One-point compactification of $\mathbb Q$
+aliases:
+  - One point compactification of the rationals
 counterexamples_id: 35
 refs:
   - doi: 10.1007/978-1-4612-6290-9 
@@ -9,7 +11,7 @@ refs:
     name: Alexandroff extension on Wikipedia
 ---
 
-The space $X = \mathbb{Q} \cup \{\infty\}$ is the Alexandroff one point compactification of {S27}.
+The space $X = \mathbb{Q} \cup \{\infty\}$ is the Alexandroff one-point compactification of {S27}.
 The open sets in $X$ are the open subsets of $\mathbb Q$ together with the sets $X\setminus C$ with $C$ compact in $\mathbb Q$.
 
 Defined as counterexample #35 ("One Point Compactification of the Rationals")

--- a/spaces/S000031/README.md
+++ b/spaces/S000031/README.md
@@ -1,6 +1,8 @@
 ---
 uid: S000031
-name: Square of One Point Compactification of the Rationals
+name: Square of one-point compactification of $\mathbb Q$
+aliases:
+  - Square of one-point compactification of the rationals
 refs:
 - mathse: 632320
   name: Weak Hausdorff space not KC

--- a/spaces/S000050/README.md
+++ b/spaces/S000050/README.md
@@ -1,10 +1,13 @@
 ---
 uid: S000050
-name: Rationals extended by a focal point
+name: $\mathbb Q$ extended by a focal point
 aliases:
+  - Rationals extended by a focal point
   - Non-Hausdorff cone over the rationals
   - Open extension of the rationals
 ---
 
-Let $X = \mathbb{Q} \cup \{\infty\}$, where $\mathbb{Q}$ has the usual topology on {S27} and is an open subset
-of $X$, and where the only neighborhood of $\infty$ is $X$. See {P202}.
+Let $X = \mathbb{Q} \cup \{\infty\}$, where $\mathbb{Q}$ has the usual topology
+of {S27} and is open in $X$,
+and the only neighborhood of $\infty$ is $X$.
+See {P202}.


### PR DESCRIPTION
Changing to shorter primary names for three spaces involving $\mathbb Q$.

Also added hyphen in "one-point compactification", as it is more common.