### PR TITLE
Warsaw circle is not homogeneous

### DIFF
--- a/spaces/S000205/properties/P000086.md
+++ b/spaces/S000205/properties/P000086.md
@@ -1,0 +1,8 @@
+---
+space: S000205
+property: P000086
+value: false
+---
+
+At any point not in $\{0\}\times[-1,1]$ the space is locally Euclidean, hence locally connected.
+But this does not hold at all points since {S205|P41}.


### PR DESCRIPTION
The Warsaw circle (S205) is not homogeneous (P86).
https://topology.pi-base.org/spaces/S000205/properties/P000086

Based on #1365.