### PR TITLE
Updates for alpha_i properties

### DIFF
--- a/properties/P000210.md
+++ b/properties/P000210.md
@@ -1,20 +1,30 @@
 ---
 uid: P000210
 name: $\alpha_1$
+aliases:
+- $\alpha_1$-space
 refs:
   - zb: "0774.54019"
     name: Subsets of ${}^\omega\omega$ and the Fréchet-Urysohn and $\alpha_i$-properties. (Nyikos, P.)
   - zb: "0275.54004"
     name: The frequency spectrum of a topological space and the classification of spaces (Arkhangel’skii, A. V.)
+  - zb: "1348.54033"
+    name: Arhangel'skii sheaf amalgamations in topological groups (Tsaban & Zdomskyy)
 ---
 
-$X$ is an $\alpha_1$ space if for all $x \in X$ 
-and for all countable collections of sequences 
-$\gamma$ converging to $x$ there exists a sequence 
-$B$ converging to $x$ such that $A\setminus B$ is 
-finite for all $A \in \gamma$.  
+For every point $x \in X$ and every countable collection $\gamma$
+of (injective) sequences converging to $x$ there exists an (injective) sequence 
+$B$ converging to $x$ such that $A\setminus B$ is finite for each $A \in \gamma$.
+(One can always assume $B\subseteq\bigcup\gamma$.)
 
-The $\alpha_i$ properties for $i = 1, 2, 3, 4$ 
-are due to Arkhangel’skii ({{zb:0275.54004}}), 
-however the definition stated here is as presented 
-by Nyikos in {{zb:0774.54019}}. 
+PENDING ISSUE: equivalence with disjointness condition?
+
+Note: In the context of the definitions above, by "sequence" one has to understand an injective sequence,
+and we identify it with its range, which is a countably infinite set $A$.
+If one bijective enumeration of $A$ converges to $x$, all bijective enumerations of $A$ converge to $x$.
+Convergence thus becomes a property of countably infinite sets,
+with $A$ converging to $x$ if every neighborhood of $x$ contains all but finitely many points of $A$.
+
+The $\alpha_i$ properties for $i = 1, 2, 3, 4$ (sometimes called "sheaf amalgamation properties")
+are due to Arkhangel'skii ({{zb:0275.54004}}).
+The definition stated here is as presented by Nyikos in {{zb:0774.54019}}.

--- a/properties/P000210.md
+++ b/properties/P000210.md
@@ -5,9 +5,9 @@ aliases:
 - $\alpha_1$-space
 refs:
   - zb: "0774.54019"
-    name: Subsets of ${}^\omega\omega$ and the Fréchet-Urysohn and $\alpha_i$-properties. (Nyikos, P.)
+    name: Subsets of ${}^\omega\omega$ and the Fréchet-Urysohn and $\alpha_i$-properties (P. Nyikos)
   - zb: "0275.54004"
-    name: The frequency spectrum of a topological space and the classification of spaces (Arkhangel’skii, A. V.)
+    name: The frequency spectrum of a topological space and the classification of spaces (A. V. Arkhangel'skii)
   - zb: "1348.54033"
     name: Arhangel'skii sheaf amalgamations in topological groups (Tsaban & Zdomskyy)
 ---
@@ -17,7 +17,7 @@ of (injective) sequences converging to $x$ there exists an (injective) sequence
 $B$ converging to $x$ such that $A\setminus B$ is finite for each $A \in \gamma$.
 (One can always assume $B\subseteq\bigcup\gamma$.)
 
-PENDING ISSUE: equivalence with disjointness condition?
+Equivalently, the same condition holds with the additional requirement that the sequences in $\gamma$ are pairwise disjoint. (The equivalence is shown after Definition 1.1 in {{zb:1348.54033}}.)
 
 Note: In the context of the definitions above, by "sequence" one has to understand an injective sequence,
 and we identify it with its range, which is a countably infinite set $A$.

--- a/properties/P000211.md
+++ b/properties/P000211.md
@@ -1,21 +1,30 @@
 ---
 uid: P000211
 name: $\alpha_2$
+aliases:
+- $\alpha_2$-space
 refs:
   - zb: "0774.54019"
     name: Subsets of ${}^\omega\omega$ and the Fréchet-Urysohn and $\alpha_i$-properties. (Nyikos, P.)
   - zb: "0275.54004"
-    name: The frequency spectrum of a topological space and the classification of spaces (Arkhangel’skii, A. V.)
+    name: The frequency spectrum of a topological space and the classification of spaces (Arkhangel'skii, A. V.)
+  - zb: "1348.54033"
+    name: Arhangel'skii sheaf amalgamations in topological groups (Tsaban & Zdomskyy)
 ---
 
-$X$ is an $\alpha_2$ space if for all $x \in X$ 
-and for all countable collections of sequences 
-$\gamma$ converging to $x$ there exists a sequence 
-$B$ converging to $x$ such that $A\cap B$ is infinite 
-for all $A \in \gamma$, or equivalently, if $A\cap B$ 
-is non-empty for all $A \in \gamma$.  
+For every point $x \in X$ and every countable collection $\gamma$
+of (injective) sequences converging to $x$ there exists an (injective) sequence 
+$B$ converging to $x$ such that $A\cap B$ is infinite for each $A \in \gamma$.
+(One can always assume $B\subseteq\bigcup\gamma$.)
 
-The $\alpha_i$ properties for $i = 1, 2, 3, 4$ 
-are due to Arkhangel’skii ({{zb:0275.54004}}), 
-however the definition stated here is as presented 
-by Nyikos in {{zb:0774.54019}}. 
+Equivalently, the same condition holds with the additional requirement that the sequences in $\gamma$ are pairwise disjoint. (The equivalence follows from Lemma 1.2 in {{0774.54019}}.)
+
+Note: In the context of the definitions above, by "sequence" one has to understand an injective sequence,
+and we identify it with its range, which is a countably infinite set $A$.
+If one bijective enumeration of $A$ converges to $x$, all bijective enumerations of $A$ converge to $x$.
+Convergence thus becomes a property of countably infinite sets,
+with $A$ converging to $x$ if every neighborhood of $x$ contains all but finitely many points of $A$.
+
+The $\alpha_i$ properties for $i = 1, 2, 3, 4$ (sometimes called "sheaf amalgamation properties")
+are due to Arkhangel'skii ({{zb:0275.54004}}).
+The definition stated here is as presented by Nyikos in {{zb:0774.54019}}.

--- a/properties/P000212.md
+++ b/properties/P000212.md
@@ -1,23 +1,23 @@
 ---
 uid: P000212
-name: $\alpha_3$
+name: $\alpha_2$
 aliases:
-- $\alpha_3$-space
+- $\alpha_2$-space
 refs:
   - zb: "0774.54019"
-    name: Subsets of ${}^\omega\omega$ and the Fréchet-Urysohn and $\alpha_i$-properties. (Nyikos, P.)
+    name: Subsets of ${}^\omega\omega$ and the Fréchet-Urysohn and $\alpha_i$-properties (P. Nyikos)
   - zb: "0275.54004"
-    name: The frequency spectrum of a topological space and the classification of spaces (Arkhangel'skii, A. V.)
+    name: The frequency spectrum of a topological space and the classification of spaces (A. V. Arkhangel'skii)
   - zb: "1348.54033"
     name: Arhangel'skii sheaf amalgamations in topological groups (Tsaban & Zdomskyy)
 ---
 
 For every point $x \in X$ and every countable collection $\gamma$
 of (injective) sequences converging to $x$ there exists an (injective) sequence 
-$B$ converging to $x$ such that $A\cap B$ is infinite for infinitely many $A\in\gamma$.
+$B$ converging to $x$ such that $A\cap B$ is infinite for each $A \in \gamma$.
 (One can always assume $B\subseteq\bigcup\gamma$.)
 
-Equivalently, the same condition holds with the additional requirement that the sequences in $\gamma$ are pairwise disjoint. (The equivalence follows from Lemma 1.2 in {{0774.54019}}.)
+Equivalently, the same condition holds with the additional requirement that the sequences in $\gamma$ are pairwise disjoint. (The equivalence follows from Lemma 1.2 in {{zb:0774.54019}}.)
 
 Note: In the context of the definitions above, by "sequence" one has to understand an injective sequence,
 and we identify it with its range, which is a countably infinite set $A$.

--- a/properties/P000212.md
+++ b/properties/P000212.md
@@ -1,20 +1,30 @@
 ---
 uid: P000212
 name: $\alpha_3$
+aliases:
+- $\alpha_3$-space
 refs:
   - zb: "0774.54019"
     name: Subsets of ${}^\omega\omega$ and the Fréchet-Urysohn and $\alpha_i$-properties. (Nyikos, P.)
   - zb: "0275.54004"
-    name: The frequency spectrum of a topological space and the classification of spaces (Arkhangel’skii, A. V.)
+    name: The frequency spectrum of a topological space and the classification of spaces (Arkhangel'skii, A. V.)
+  - zb: "1348.54033"
+    name: Arhangel'skii sheaf amalgamations in topological groups (Tsaban & Zdomskyy)
 ---
 
-$X$ is an $\alpha_3$ space if for all $x \in X$ 
-and for all countable collections of sequences 
-$\gamma$ converging to $x$ there exists a sequence 
-$B$ converging to $x$ such that $A\cap B$ is 
-infinite for infinitely many $A \in \gamma$.  
+For every point $x \in X$ and every countable collection $\gamma$
+of (injective) sequences converging to $x$ there exists an (injective) sequence 
+$B$ converging to $x$ such that $A\cap B$ is infinite for infinitely many $A\in\gamma$.
+(One can always assume $B\subseteq\bigcup\gamma$.)
 
-The $\alpha_i$ properties for $i = 1, 2, 3, 4$ 
-are due to Arkhangel’skii ({{zb:0275.54004}}), 
-however the definition stated here is as presented 
-by Nyikos in {{zb:0774.54019}}.  
+Equivalently, the same condition holds with the additional requirement that the sequences in $\gamma$ are pairwise disjoint. (The equivalence follows from Lemma 1.2 in {{0774.54019}}.)
+
+Note: In the context of the definitions above, by "sequence" one has to understand an injective sequence,
+and we identify it with its range, which is a countably infinite set $A$.
+If one bijective enumeration of $A$ converges to $x$, all bijective enumerations of $A$ converge to $x$.
+Convergence thus becomes a property of countably infinite sets,
+with $A$ converging to $x$ if every neighborhood of $x$ contains all but finitely many points of $A$.
+
+The $\alpha_i$ properties for $i = 1, 2, 3, 4$ (sometimes called "sheaf amalgamation properties")
+are due to Arkhangel'skii ({{zb:0275.54004}}).
+The definition stated here is as presented by Nyikos in {{zb:0774.54019}}.

--- a/properties/P000213.md
+++ b/properties/P000213.md
@@ -1,20 +1,30 @@
 ---
 uid: P000213
 name: $\alpha_4$
+aliases:
+- $\alpha_4$-space
 refs:
   - zb: "0774.54019"
     name: Subsets of ${}^\omega\omega$ and the Fréchet-Urysohn and $\alpha_i$-properties. (Nyikos, P.)
   - zb: "0275.54004"
     name: The frequency spectrum of a topological space and the classification of spaces (Arkhangel’skii, A. V.)
+  - zb: "1348.54033"
+    name: Arhangel'skii sheaf amalgamations in topological groups (Tsaban & Zdomskyy)
 ---
 
-$X$ is an $\alpha_4$ space if for all $x \in X$ 
-and for all countable collections of sequences 
-$\gamma$ converging to $x$ there exists a sequence 
-$B$ converging to $x$ such that $A\cap B$ is nonempty 
-for infinitely many $A \in \gamma$.  
+For every point $x \in X$ and every countable collection $\gamma$
+of (injective) sequences converging to $x$ there exists an (injective) sequence 
+$B$ converging to $x$ such that $A\cap B$ is nonempty for infinitely many $A\in\gamma$.
+(One can always assume $B\subseteq\bigcup\gamma$.)
 
-The $\alpha_i$ properties for $i = 1, 2, 3, 4$ 
-are due to Arkhangel’skii ({{zb:0275.54004}}), 
-however the definition stated here is as presented 
-by Nyikos in {{zb:0774.54019}}. 
+Equivalently, the same condition holds with the additional requirement that the sequences in $\gamma$ are pairwise disjoint. (The equivalence follows from Lemma 1.2 in {{0774.54019}}.)
+
+Note: In the context of the definitions above, by "sequence" one has to understand an injective sequence,
+and we identify it with its range, which is a countably infinite set $A$.
+If one bijective enumeration of $A$ converges to $x$, all bijective enumerations of $A$ converge to $x$.
+Convergence thus becomes a property of countably infinite sets,
+with $A$ converging to $x$ if every neighborhood of $x$ contains all but finitely many points of $A$.
+
+The $\alpha_i$ properties for $i = 1, 2, 3, 4$ (sometimes called "sheaf amalgamation properties")
+are due to Arkhangel'skii ({{zb:0275.54004}}).
+The definition stated here is as presented by Nyikos in {{zb:0774.54019}}.

--- a/properties/P000213.md
+++ b/properties/P000213.md
@@ -1,23 +1,23 @@
 ---
 uid: P000213
-name: $\alpha_4$
+name: $\alpha_3$
 aliases:
-- $\alpha_4$-space
+- $\alpha_3$-space
 refs:
   - zb: "0774.54019"
-    name: Subsets of ${}^\omega\omega$ and the Fréchet-Urysohn and $\alpha_i$-properties. (Nyikos, P.)
+    name: Subsets of ${}^\omega\omega$ and the Fréchet-Urysohn and $\alpha_i$-properties (P. Nyikos)
   - zb: "0275.54004"
-    name: The frequency spectrum of a topological space and the classification of spaces (Arkhangel’skii, A. V.)
+    name: The frequency spectrum of a topological space and the classification of spaces (A. V. Arkhangel'skii)
   - zb: "1348.54033"
     name: Arhangel'skii sheaf amalgamations in topological groups (Tsaban & Zdomskyy)
 ---
 
 For every point $x \in X$ and every countable collection $\gamma$
 of (injective) sequences converging to $x$ there exists an (injective) sequence 
-$B$ converging to $x$ such that $A\cap B$ is nonempty for infinitely many $A\in\gamma$.
+$B$ converging to $x$ such that $A\cap B$ is infinite for infinitely many $A\in\gamma$.
 (One can always assume $B\subseteq\bigcup\gamma$.)
 
-Equivalently, the same condition holds with the additional requirement that the sequences in $\gamma$ are pairwise disjoint. (The equivalence follows from Lemma 1.2 in {{0774.54019}}.)
+Equivalently, the same condition holds with the additional requirement that the sequences in $\gamma$ are pairwise disjoint. (The equivalence follows from Lemma 1.2 in {{zb:0774.54019}}.)
 
 Note: In the context of the definitions above, by "sequence" one has to understand an injective sequence,
 and we identify it with its range, which is a countably infinite set $A$.

--- a/properties/P000214.md
+++ b/properties/P000214.md
@@ -1,23 +1,23 @@
 ---
-uid: P000211
-name: $\alpha_{1.5}$
+uid: P000214
+name: $\alpha_4$
 aliases:
-- $\alpha_{1.5}$-space
+- $\alpha_4$-space
 refs:
   - zb: "0774.54019"
     name: Subsets of ${}^\omega\omega$ and the Fréchet-Urysohn and $\alpha_i$-properties (P. Nyikos)
+  - zb: "0275.54004"
+    name: The frequency spectrum of a topological space and the classification of spaces (A. V. Arkhangel'skii)
   - zb: "1348.54033"
     name: Arhangel'skii sheaf amalgamations in topological groups (Tsaban & Zdomskyy)
 ---
 
 For every point $x \in X$ and every countable collection $\gamma$
-of pairwise disjoint (injective) sequences converging to $x$ there exists an (injective) sequence
-$B$ converging to $x$ such that $A\setminus B$ is finite for infinitely many $A\in\gamma$.
+of (injective) sequences converging to $x$ there exists an (injective) sequence 
+$B$ converging to $x$ such that $A\cap B$ is nonempty for infinitely many $A\in\gamma$.
 (One can always assume $B\subseteq\bigcup\gamma$.)
 
-The requirement that the sequences be disjoint is important here.
-Without it, one gets a property equivalent to {P210},
-as explained in the discussion after Definition 1.1 of {{zb:1348.54033}}.
+Equivalently, the same condition holds with the additional requirement that the sequences in $\gamma$ are pairwise disjoint. (The equivalence follows from Lemma 1.2 in {{zb:0774.54019}}.)
 
 Note: In the context of the definitions above, by "sequence" one has to understand an injective sequence,
 and we identify it with its range, which is a countably infinite set $A$.
@@ -25,4 +25,6 @@ If one bijective enumeration of $A$ converges to $x$, all bijective enumerations
 Convergence thus becomes a property of countably infinite sets,
 with $A$ converging to $x$ if every neighborhood of $x$ contains all but finitely many points of $A$.
 
-This property was introduced by Nyikos in {{zb:0774.54019}}.
+The $\alpha_i$ properties for $i = 1, 2, 3, 4$ (sometimes called "sheaf amalgamation properties")
+are due to Arkhangel'skii ({{zb:0275.54004}}).
+The definition stated here is as presented by Nyikos in {{zb:0774.54019}}.

--- a/theorems/T000733.md
+++ b/theorems/T000733.md
@@ -1,0 +1,12 @@
+---
+uid: T000733
+if:
+  P000210: true
+then:
+  P000211: true
+refs:
+  - zb: "1348.54033"
+    name: Arhangel'skii sheaf amalgamations in topological groups (Tsaban & Zdomskyy)
+---
+
+Follows directly from the definitions.

--- a/theorems/T000734.md
+++ b/theorems/T000734.md
@@ -1,0 +1,12 @@
+---
+uid: T000734
+if:
+  P000211: true
+then:
+  P000212: true
+refs:
+  - zb: "1348.54033"
+    name: Arhangel'skii sheaf amalgamations in topological groups (Tsaban & Zdomskyy)
+---
+
+Follows directly from the definitions.

--- a/theorems/T000735.md
+++ b/theorems/T000735.md
@@ -1,0 +1,12 @@
+---
+uid: T000735
+if:
+  P000212: true
+then:
+  P000213: true
+refs:
+  - zb: "1348.54033"
+    name: Arhangel'skii sheaf amalgamations in topological groups (Tsaban & Zdomskyy)
+---
+
+Follows directly from the definitions.

--- a/theorems/T000736.md
+++ b/theorems/T000736.md
@@ -1,12 +1,12 @@
 ---
-uid: T000734
+uid: T000736
 if:
-  P000211: true
+  P000213: true
 then:
-  P000212: true
+  P000214: true
 refs:
   - zb: "1348.54033"
     name: Arhangel'skii sheaf amalgamations in topological groups (Tsaban & Zdomskyy)
 ---
 
-See the second paragraph after Definition 1.1 in {{zb:1348.54033}}.
+Follows directly from the definitions.


### PR DESCRIPTION
This is a continuation of #1366.

Updates for the $\alpha_i$ properties.  Also added the obvious chain of implications from $\alpha_1$ to $\alpha_4$.

@NAndrews4122 @StevenClontz Hope you can take a look and review this.

(@NAndrews4122 This is available on the branch `alphai-tweak` in the official repository.  So the easiest way to review this is to look at the result directly from that branch: from the pi-base web page, click on the Advanced tab, enter the new branch name and refresh.  Let us know if you have a problem with the refreshing.)

Listing a few issues separately below.