### PR TITLE
3 new theorems about G_delta diagonals

### DIFF
--- a/theorems/T000737.md
+++ b/theorems/T000737.md
@@ -1,0 +1,16 @@
+---
+uid: T000737
+if:
+  and:
+  - P000008: true
+  - P000087: true
+  - P000167: false
+
+then:
+  P000106: true
+refs:
+  - doi: 10.48550/arXiv.1209.0847
+    name: On Hereditarily Normal Topological Groups (Buzyakova)
+---
+
+See theorem 2.3 of {{doi:10.48550/arXiv.1209.0847}}.

--- a/theorems/T000738.md
+++ b/theorems/T000738.md
@@ -1,0 +1,15 @@
+---
+uid: T000738
+if:
+  and:
+  - P000019: true
+  - P000106: true
+
+then:
+  P000016: true
+refs:
+  - mathse: 3793006
+    name: $G_\delta$ diagonal of countably compact space implies compact
+---
+
+See {{mathse:3793006}}.

--- a/theorems/T000739.md
+++ b/theorems/T000739.md
@@ -1,0 +1,16 @@
+---
+uid: T000739
+if:
+  and:
+  - P000030: true
+  - P000003: true
+  - P000106: true
+
+then:
+  P000112: true
+refs:
+  - mr: 0188982
+    name: On stratifiable spaces (Borges)
+---
+
+See lemma 8.2 in {{mr:0188982}}.


### PR DESCRIPTION
Motivated by @StevenClontz question about hereditarily normal spaces, I've started browsing articles about them.

There I've encountered theorem of Buzyakova about hereditarily normal topological groups.

I've also saw a well-known theorem of Chaber there: a countably compact Hausdorff space with $G_\delta$ diagonal is metrizable.

I couldn't find the proof anywhere, but I found that countably compact Hausdorff space with $G_\delta$ diagonal is compact.

In my search I've noticed I can improve on theorem of Chaber by including it as two theorems instead: a paracompact Hausdorff space with $G_\delta$ diagonal is submetrizable. Note that "paracompact Hausdorff" cannot really be weakened, since paracompact space with $G_\delta$ diagonal is not necessarily submetrizable (cofinite topology on $\mathbb{N}$), and if we switch "paracompact Hausdorff" to "strongly collectionwise normal", which is the property used in the proof, then together with "has $G_\delta$ diagonal" this will be equivalent to paracompact Hausdorff anyway. So no improvement there.

Also I found @StevenClontz proof that compact spaces with $G_\delta$ diagonal are metrizable on his blog here https://clontz.org/blog/2014/02/09/compact-spaces-with-g-delta-diagonals-are-metrizable/ although it seems that the formatting does not display \overline correctly. 