### PR TITLE
Changed description of Rudin's nonmetrizable manifold

### DIFF
--- a/spaces/S000197/README.md
+++ b/spaces/S000197/README.md
@@ -1,10 +1,9 @@
 ---
 uid: S000197
-name: Mary Ellen Rudin's nonmetrizable manifold
+name: Van Douwen line
 refs:
 - doi: 10.1016/0166-8641(90)90099-N
   name: Two nonmetrizable manifolds (Mary Ellen Rudin)
 ---
 
-The example constructed in section 1 of {{doi:10.1016/0166-8641(90)90099-N}} that
-is {P7}, {P26}, {P123}, but not {P53}.
+The example constructed in section 1 of {{doi:10.1016/0166-8641(90)90099-N}}.

--- a/spaces/S000197/README.md
+++ b/spaces/S000197/README.md
@@ -6,5 +6,5 @@ refs:
   name: Two nonmetrizable manifolds (M. E. Rudin)
 ---
 
-The space is based on Van Douwen line construction. It's locally $2$-Euclidean.
-It has been constructed in section 1 of {{doi:10.1016/0166-8641(90)90099-N}}. 
+This space is constructed in section 1 of {{doi:10.1016/0166-8641(90)90099-N}}. 
+It is based on a Van Douwen line construction. It is {P123} of dimension $2$.

--- a/spaces/S000197/README.md
+++ b/spaces/S000197/README.md
@@ -1,11 +1,10 @@
 ---
 uid: S000197
-name: Van Douwen line
+name: Rudin's nonmetrizable manifold
 refs:
 - doi: 10.1016/0166-8641(90)90099-N
-  name: Two nonmetrizable manifolds (Mary Ellen Rudin)
+  name: Two nonmetrizable manifolds (M. E. Rudin)
 ---
 
-The Van Douwen line is a space based on the construction of the Kunen line. It is locally $2$-Euclidean.
-
-Van douwen line has been constructed in section 1 of {{doi:10.1016/0166-8641(90)90099-N}}. 
+The space is based on Van Douwen line construction. It's locally $2$-Euclidean.
+It has been constructed in section 1 of {{doi:10.1016/0166-8641(90)90099-N}}. 

--- a/spaces/S000197/README.md
+++ b/spaces/S000197/README.md
@@ -6,4 +6,6 @@ refs:
   name: Two nonmetrizable manifolds (Mary Ellen Rudin)
 ---
 
-The example constructed in section 1 of {{doi:10.1016/0166-8641(90)90099-N}}.
+The Van Douwen line is a space based on the construction of the Kunen line. It is locally $2$-Euclidean.
+
+Van douwen line has been constructed in section 1 of {{doi:10.1016/0166-8641(90)90099-N}}. 


### PR DESCRIPTION
I think the name change is fair since Rudin in the article calls it "Van Douwen line" since it's a construction similar to that of "Kunen line" which was suggested by Van Douwen. Not sure if "v" should be capitalized or not here, I assume it does.

It's a bit awkward to have a different name if the author calls it that. 