### PR TITLE
Bing's example G does not have $G_\delta$ points and Michael's closed subspace is submetrizable

### DIFF
--- a/spaces/S000136/properties/P000191.md
+++ b/spaces/S000136/properties/P000191.md
@@ -1,0 +1,7 @@
+---
+space: S000136
+property: P000191
+value: false
+---
+
+Any $G_\delta$-set $A$ with $x_r\in A$ contains a set of the form $\{x\in X : x(\lambda) = x_r(\lambda), \lambda\in \Lambda\}$ where $\Lambda\subseteq 2^\mathbb{R}$ is countable. If $\lambda_0\in 2^{\mathbb{R}}\setminus \Lambda$ is arbitrary, let $x\in X$ be any point such that $x(\lambda) = x_r(\lambda)$ for all $\lambda\in \Lambda$ and $x(\lambda_0)\neq x_r(\lambda_0)$, then $x\in A\setminus \{x_r\}$. It follows $\{x_r\}$ is not a $G_\delta$-set for $r\in\mathbb{R}$.

--- a/spaces/S000136/properties/P000191.md
+++ b/spaces/S000136/properties/P000191.md
@@ -4,4 +4,4 @@ property: P000191
 value: false
 ---
 
-Any $G_\delta$-set $A$ with $x_r\in A$ contains a set of the form $\{x\in X : x(\lambda) = x_r(\lambda), \lambda\in \Lambda\}$ where $\Lambda\subseteq 2^\mathbb{R}$ is countable. If $\lambda_0\in 2^{\mathbb{R}}\setminus \Lambda$ is arbitrary, let $x\in X$ be any point such that $x(\lambda) = x_r(\lambda)$ for all $\lambda\in \Lambda$ and $x(\lambda_0)\neq x_r(\lambda_0)$, then $x\in A\setminus \{x_r\}$. It follows $\{x_r\}$ is not a $G_\delta$-set for $r\in\mathbb{R}$.
+Any $G_\delta$-set $A$ with $x_r\in A$ contains a set of the form $\{x\in X : x(\lambda) = x_r(\lambda)\text{ for all } \lambda\in \Lambda\}$ where $\Lambda\subseteq 2^\mathbb{R}$ is countable. If $\lambda_0\in 2^{\mathbb{R}}\setminus \Lambda$ is arbitrary, let $x\in X$ be any point such that $x(\lambda) = x_r(\lambda)$ for all $\lambda\in \Lambda$ and $x(\lambda_0)\neq x_r(\lambda_0)$, then $x\in A\setminus \{x_r\}$. It follows $\{x_r\}$ is not a $G_\delta$-set for $r\in\mathbb{R}$.

--- a/spaces/S000137/properties/P000112.md
+++ b/spaces/S000137/properties/P000112.md
@@ -1,0 +1,10 @@
+---
+space: S000137
+property: P000112
+value: true
+refs:
+- mo: 497834
+  name: Answer to "Is there a normal space with a $G_\delta$ diagonal which is not submetrizable?"
+---
+
+Shown in {{mo:497834}}.


### PR DESCRIPTION
I was trying to find a normal space with $G_\delta$-diagonal which would not be submetrizable. I didn't find such example, but at least I could show that Michael's closed subspace is submetrizable. 