### PR TITLE
Better names for Bing's and Michael's spaces

### DIFF
--- a/spaces/S000136/README.md
+++ b/spaces/S000136/README.md
@@ -1,17 +1,22 @@
 ---
 uid: S000136
-name: Bing's discrete extension space
+name: Bing's Example G
 aliases:
-  - Bing's Example G
+  - Bing's discrete extension space
 counterexamples_id: 142
 refs:
   - doi: 10.1007/978-1-4612-6290-9
     name: Counterexamples in Topology
   - doi: 10.4153/CJM-1951-022-3
-    name: Bing, R.H., Metrization of Topological Spaces
+    name: Metrization of topological spaces (R. H. Bing)
 ---
-Let $X = 2^{2^\mathbb{R}}$. For $r \in \mathbb{R}$, let $x_r: 2^\mathbb{R} \rightarrow 2$ by $x_r(\lambda) = 1 \iff r \in \lambda$. Let $M = \{x_r: r \in \mathbb{R}\}$. Bing's Discrete Extension Space is the set $X$ where points of $M$ have their usual product neighborhoods and points of $X \setminus M$ are isolated.
+
+Let $X = 2^{2^\mathbb{R}}$. For $r \in \mathbb{R}$, let $x_r: 2^\mathbb{R} \rightarrow 2$ by $x_r(\lambda) = 1 \iff r \in \lambda$. Let $M = \{x_r: r \in \mathbb{R}\}$.
+For the topology on $X$, points of $M$ have their usual neighborhoods from the product topology
+and points of $X\setminus M$ are isolated.
 
 Defined as counterexample #142 ("Bing's Discrete Extension Space")
 in {{doi:10.1007/978-1-4612-6290-9}}
 and Example G in {{doi:10.4153/CJM-1951-022-3}}.
+
+See also <https://dantopology.wordpress.com/2012/11/18/bings-example-g/>.

--- a/spaces/S000137/README.md
+++ b/spaces/S000137/README.md
@@ -1,15 +1,22 @@
 ---
 uid: S000137
-name: Michael's closed subspace
+name: Michael's subspace of Bing's Example G
+aliases:
+  - Michael's closed subspace
 counterexamples_id: 143
 refs:
 - doi: 10.1007/978-1-4612-6290-9
   name: Counterexamples in Topology
+- doi: 10.4153/CJM-1955-029-6
+  name: Point-finite and localy finite coverings (E. Michael)
 ---
-Michael's Closed Subspace is the subspace $Y = M \cup F$ of {S000136} $X$ where
-$F=\{x\in X\setminus M: x(\lambda)=1 \text{ for only finitely many }\lambda\in 2^{\Bbb{R}}\}$.
+
+This space is the subspace $Y = M \cup F$ of $X=$ {S000136} where
+$F=\{x\in X: x(\lambda)=1 \text{ for only finitely many }\lambda\in 2^{\Bbb{R}}\}$.
+The subspace $Y$ is closed in $X$.
 
 Defined as counterexample #143 ("Michael's Closed Subspace")
-in {{doi:10.1007/978-1-4612-6290-9}}.
+in {{doi:10.1007/978-1-4612-6290-9}};
+originally published by E. Michael as Example 2 in {{doi:10.4153/CJM-1955-029-6}}.
 
 See also <https://dantopology.wordpress.com/2012/12/02/a-subspace-of-bings-example-g/>.


### PR DESCRIPTION
Better names for S136 ("Bing's Example G" is the usual name here) and for S137 (the previous name was not clear out of context).

Plus minor tweaks, in particular following the pi-base guideline of not repeating the name of a space in the description if possible (@Moniker1998 FYI).
