### PR TITLE
T748: First countable implies alpha_1

### DIFF
--- a/theorems/T000748.md
+++ b/theorems/T000748.md
@@ -1,0 +1,25 @@
+---
+uid: T000748
+if:
+  P000028: true
+then:
+  P000210: true
+refs:
+  - zb: "0774.54019"
+    name: Subsets of ${}^\omega\omega$ and the Fréchet-Urysohn and $\alpha_i$-properties (P. Nyikos)
+---
+
+Stated on p. 94 of {{zb:0774.54019}}.
+
+Let $x\in X$ and let $S_1, S_2, \dots\subseteq X$ be countably infinite sets, each converging to $x$.
+Since $X$ is {P28}, the point $x$ has a countable local base of neighborhoods
+$V_1\supseteq V_2\supseteq\dots$.
+As $S_n$ converges to $x$, the set $T_n=S_n\cap V_n$ is cofinite in $S_n$ and also converges to $x$.
+
+*Claim:* The set $S=\bigcup_{n=1}^\infty T_n$ is as required in the definition of {P210}:
+- (1) $S\cap S_n\supseteq T_n$ is cofinite in $S_n$ for each $n$.
+- (2) To show that $S$ converges to $x$, consider a basic neighborhood $V_m$ of $x$ for some fixed $m$.
+If $n\ge m$, we have $T_n\subseteq V_n\subseteq V_m$.
+And for the finitely many $n<m$, $V_m$ contains all but finitely many elements of $T_n$ since $T_n$ converges to $x$.
+Therefore, $V_m$ contains all but finitely many elements of $S$.
+This shows that $S$ converges to $x$.


### PR DESCRIPTION
New T748: First countable => $\alpha_1$.

This relates the $\alpha_i$ properties to some of the other properties, so the $\alpha_1$ properties stop being "unknown" for all spaces.

@NAndrews4122 @StevenClontz FYI