### PR TITLE
Improved issue template for new theorem

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-theorem-suggestion.md
+++ b/.github/ISSUE_TEMPLATE/new-theorem-suggestion.md
@@ -12,18 +12,18 @@ labels:
 
 If a space is:
 
-- [P1](https://topology.pi-base.org/properties/P000001)
-- [P2](https://topology.pi-base.org/properties/P000002)
-- not [P3](https://topology.pi-base.org/properties/P000003)
+- **scattered** [P51](https://topology.pi-base.org/properties/P000051)
+- not **empty** [P137](https://topology.pi-base.org/properties/P000137)
 
-then it is [P4](https://topology.pi-base.org/properties/P000004).
+then it is **strongly Choquet** [P206](https://topology.pi-base.org/properties/P000206).
 
 ## Rationale
 
 This theorem would demonstrate that no spaces satisfy the following search:
 
-https://topology.pi-base.org/spaces?q=%24T_0%2B%24T_1%24%2B~%24T_2%24%2B~%24T_%7B2%20%5Cfrac%7B1%7D%7B2%7D%7D%24
+https://topology.pi-base.org/spaces?q=Scattered%2B%7EEmpty%2B%7EStrongly+Choquet
 
 ## Proof/References
 
-The result is trivial and essentially shown on page XYZ of Willard's topology, but was also discussed at [this Math.StackExchange post](https://math.stackexchange.com/questions/4778063).
+The result is essentially shown on page xxx of Willard's topology,
+but was also discussed at [this Math.StackExchange post](https://math.stackexchange.com/questions/4778063).


### PR DESCRIPTION
The current issue template for creating a new theorem currently suggests to only use property numbers P123 when stating the theorem.  This makes the result hard to understand without clicking to see what the properties are.  Example: #1032.

The change is to suggest adding the property names as well, as done in this example: #1189.

For illustration, other possible formats that use the property name: #1245  or #1179.  But the format in #1189 seems very clear to me.

@pzjp @StevenClontz FYI
