### PR TITLE
Cofinite spaces

### DIFF
--- a/properties/P000222.md
+++ b/properties/P000222.md
@@ -1,0 +1,14 @@
+---
+uid: P000222
+name: Cofinite
+aliases:
+  - Minimal $T_1$
+---
+
+A space where $U\subseteq X$ is open iff $U = \emptyset$ or $X\setminus U$ is finite.
+
+Equivalently, 
+
+1. A {P2} space with no coarser {P2} topology,
+
+2. $A\subseteq X$ is closed iff $A = X$ or $A$ is finite.


### PR DESCRIPTION
One could ask why we are adding cofinite spaces but not, say, cocountable spaces.
My rationale is that cofinite spaces are precisely those spaces which have minimal $T_1$ topologies, so it's worth to add them.
Additionally this will allow me to introduce a theorem that says a subparacompact cofinite space is countable.