### PR TITLE
S216 One point compactification of Q is not hereditarily paracompact

### DIFF
--- a/spaces/S000029/properties/P000216.md
+++ b/spaces/S000029/properties/P000216.md
@@ -1,0 +1,10 @@
+---
+space: S000029
+property: P000216
+value: false
+refs:
+- mathse: 5070817
+  name: Does the one-point compactification of $\mathbb{Q}$ have the fixed point property?
+---
+
+Any neighbourhood of $\infty$ is dense (see lemma 2 in {mathse:5070817}), and so given open $U\subseteq X$ with $\infty\in U$ and an open cover $\mathcal{U}$ of $U$ which is locally finite at $\infty$, the cover $\mathcal{U}$ must be finite. It follows that if $U$ is paracompact, then it is compact. Then since $X$ is {P100} space, $U$ must be closed, and since it is a neighbourhood of $\infty$ and so dense in $X$, we must have $U = X$. And so if $K\subseteq \mathbb{Q}$ is any non-empty compact set then $X\setminus K$ is not {P30}.


### PR DESCRIPTION
This argument shows an open subset $U\subseteq X$ is paracompact iff $U\subseteq \mathbb{Q}$.