### PR TITLE
S5 Odd-Even topology, general revamp

### DIFF
--- a/spaces/S000005/README.md
+++ b/spaces/S000005/README.md
@@ -3,12 +3,13 @@ uid: S000005
 name: Odd-Even Topology
 counterexamples_id: 6
 refs:
-  - doi: 10.1007/978-1-4612-6290-9 
+  - zb: "0386.54001"
     name: Counterexamples in Topology
   - wikipedia: Partition_topology
     name: Partition topology on Wikipedia
 ---
-Define a topology on $\mathbb{N}$ by taking as a basis all sets of the form $\{\{2k-1,2k\}\mid k \in \mathbb{N}\}$.
+
+Define a topology on $X = \mathbb{N}$ by taking as a basis all sets of the form $\{\{2k-1,2k\}\mid k \in \mathbb{N}\}$.
 
 Homeomorphic to the product of {S2} and {S4}.
 

--- a/spaces/S000005/README.md
+++ b/spaces/S000005/README.md
@@ -14,7 +14,7 @@ Define a topology on $X = \mathbb{N}$ by taking as a basis all sets of the form 
 Homeomorphic to the product of {S2} and {S4}.
 
 Defined as counterexample #6 ("Odd-Even Topology")
-in {{doi:10.1007/978-1-4612-6290-9}}.
+in {{zb:0386.54001}}.
 
 <!-- [[Proof of Topology]]
 Let $X=\{\{2k-1, 2k\} | k \in \mathbb{N}\}$. Also, let $\tau = \{$Collection of all subsets, $B$, of $X\}$. Finally, let $\mathcal{B} = \{$collection of all $B\}$ Now, for any $k \in \mathbb{N}$, $\{2k-1, 2k\} \in X$. Since $B \subseteq X$, we know that for any $\{2k-1, 2k\}$ chosen, it is in an arbitrary $B$, that it is in at least one $B$. Without loss of generality, let $\{2k-1, 2k\}$ be in $B_1$ and $B_2$. Let $B_1 \cap B_2 = \{2k-1, 2k\}$. Again, without the loss of generality, let there be a $B_3$ such that $\{2k-1, 2k\} \in B_3$. This means that $B_3 \subset B_1 \cap B_2$, which is vacuously true. -->

--- a/spaces/S000005/properties/P000021.md
+++ b/spaces/S000005/properties/P000021.md
@@ -2,11 +2,6 @@
 space: S000005
 property: P000021
 value: true
-refs:
-- doi: 10.1007/978-1-4612-6290-9
-  name: Counterexamples in Topology
 ---
 
-Every non-empty subset of $X$ has a limit point.
-
-See item #3 for space #6 in {{doi:10.1007/978-1-4612-6290-9}}.
+If $A\subseteq X$ is non-empty then $A'\neq\emptyset$, since if $2n\in A$ then $2n+1\in A'$ and if $2n+1\in A$ then $2n\in A'$. In particular, the same is true for every infinite subset.

--- a/spaces/S000005/properties/P000022.md
+++ b/spaces/S000005/properties/P000022.md
@@ -2,12 +2,6 @@
 space: S000005
 property: P000022
 value: false
-refs:
-- doi: 10.1007/978-1-4612-6290-9
-  name: Counterexamples in Topology
 ---
 
-The map $\{2k-1,2k\} \mapsto \{k\}$ is continuous and unbounded.
-
-Asserted in the General Reference Chart for space #6 in
-{{doi:10.1007/978-1-4612-6290-9}}.
+The map $f:X\to\mathbb{R}$ given by $f(n) = \lfloor n/2\rfloor$ is continuous and unbounded.

--- a/spaces/S000005/properties/P000087.md
+++ b/spaces/S000005/properties/P000087.md
@@ -4,4 +4,4 @@ property: P000087
 value: true
 ---
 
-The space can be viewed as the product of a countably infinite discrete space with an indiscrete space with two elements, each satisfying the property: {S2|P87}, and {S4|P87}.
+The space can be viewed as the product of {S2} and {S4}, each satisfying the property: {S2|P87}, and {S4|P87}.

--- a/spaces/S000005/properties/P000087.md
+++ b/spaces/S000005/properties/P000087.md
@@ -4,4 +4,4 @@ property: P000087
 value: true
 ---
 
-The space can be viewed as the product of {S2} and {S4}, each satisfying the property: {S2|P87}, and {S4|P87}.
+Since {S2|P87} and {S4|P87}.

--- a/spaces/S000005/properties/P000087.md
+++ b/spaces/S000005/properties/P000087.md
@@ -2,9 +2,6 @@
 space: S000005
 property: P000087
 value: true
-refs:
-- doi: 10.1007/978-1-4612-6290-9
-  name: Counterexamples in Topology
 ---
 
 The space can be viewed as the product of a countably infinite discrete space with an indiscrete space with two elements, each satisfying the property: {S2|P87}, and {S4|P87}.

--- a/spaces/S000005/properties/P000094.md
+++ b/spaces/S000005/properties/P000094.md
@@ -3,4 +3,5 @@ space: S000005
 property: P000094
 value: true
 ---
+
 By construction, as each set in the basis $\{\{2k-1,2k\}\mid k\in\mathbb N\}$ is finite.

--- a/spaces/S000005/properties/P000181.md
+++ b/spaces/S000005/properties/P000181.md
@@ -2,8 +2,6 @@
 space: S000005
 property: P000181
 value: true
-refs:
-- doi: 10.1007/978-1-4612-6290-9
-  name: Counterexamples in Topology
 ---
+
 By definition.


### PR DESCRIPTION
Changes:

- Added spaces in front (not sure if necessary but I did that)
- Changed doi link to zb link for Counterexamples
- Removed "asserted in Counterexamples" claims (we shouldn't add properties based on assertions)
- Updated arguments for properties
- Removed unnecessary refs to Counterexamples