### PR TITLE
S6 Deleted integer topology, general revamp 

### DIFF
--- a/properties/P000043.md
+++ b/properties/P000043.md
@@ -16,3 +16,8 @@ Compare with {P42} and {P96}.
 
 Defined on page 30 of {{doi:10.1007/978-1-4612-6290-9}} with the name "locally arc connected".
 Here we reserve that name for the stronger property {P96}.
+
+----
+#### Meta-properties
+
+- This property is preserved by arbitrary disjoint unions.

--- a/properties/P000087.md
+++ b/properties/P000087.md
@@ -12,3 +12,8 @@ There exists a continuous group operation $(x,y)\mapsto x\cdot y$ on the space s
 the inverse operation $x\mapsto x^{-1}$ is also continuous.
 
 Contrary to Munkres or Willard, we do not assume any separation axiom like {P3}, {P2} or {P1}.
+
+----
+#### Meta-properties
+
+- This property is preserved by arbitrary products.

--- a/spaces/S000006/README.md
+++ b/spaces/S000006/README.md
@@ -3,15 +3,16 @@ uid: S000006
 name: Deleted integer topology on $\mathbb R\setminus\mathbb Z$
 counterexamples_id: 7
 refs:
-  - doi: 10.1007/978-1-4612-6290-9 
+  - zb: "0386.54001"
     name: Counterexamples in Topology
   - wikipedia: Partition_topology
     name: Partition topology on Wikipedia
 ---
+
 Let $X=\mathbb R\setminus\mathbb Z$, and
 take as a basis $\{(n,n+1)\mid n \in \mathbb{Z}\}$.
 
 Equivalently, the product of {S2} and {S194}.
 
 Defined as counterexample #7 ("Deleted Integer Topology")
-in {{doi:10.1007/978-1-4612-6290-9}}.
+in {{zb:0386.54001}}.

--- a/spaces/S000006/properties/P000021.md
+++ b/spaces/S000006/properties/P000021.md
@@ -2,11 +2,7 @@
 space: S000006
 property: P000021
 value: true
-refs:
-- doi: 10.1007/978-1-4612-6290-9
-  name: Counterexamples in Topology
 ---
 
-Every non-empty subset of $X$ has a limit point.
-
-See item #3 for space #7 in {{doi:10.1007/978-1-4612-6290-9}}.
+If $A\subseteq X$ is non-empty and $x\in (n, n+1)\cap A$, and if $y\in (n, n+1)\setminus \{x\}$, then $y\in A'$. 
+In particular, any infinite subset of $X$ has a limit point.

--- a/spaces/S000006/properties/P000043.md
+++ b/spaces/S000006/properties/P000043.md
@@ -4,4 +4,4 @@ property: P000043
 value: true
 ---
 
-The space is a coproduct of copies of {S194}, and {S194|P38}.
+The space is a disjoint union of copies of {S194}, and {S194|P38}.

--- a/spaces/S000006/properties/P000065.md
+++ b/spaces/S000006/properties/P000065.md
@@ -4,4 +4,4 @@ property: P000065
 value: true
 ---
 
-By construction.
+By definition.

--- a/spaces/S000006/properties/P000087.md
+++ b/spaces/S000006/properties/P000087.md
@@ -4,4 +4,6 @@ property: P000087
 value: true
 ---
 
-The space is the product of {S2} and {S194}, each of which admits a topological group structure. See {S2|P87} and {S194|P87}.
+$X$ is the product of two spaces which admits a topological group structure:
+{S2|P87}
+and {S194|P87}.

--- a/spaces/S000006/properties/P000087.md
+++ b/spaces/S000006/properties/P000087.md
@@ -2,9 +2,6 @@
 space: S000006
 property: P000087
 value: true
-refs:
-- doi: 10.1007/978-1-4612-6290-9
-  name: Counterexamples in Topology
 ---
 
 The space is the product of {S2} and {S194}, each of which admits a topological group structure. See {S2|P87} and {S194|P87}.

--- a/spaces/S000006/properties/P000185.md
+++ b/spaces/S000006/properties/P000185.md
@@ -2,11 +2,6 @@
 space: S000006
 property: P000185
 value: true
-refs:
-- doi: 10.1007/978-1-4612-6290-9
-  name: Counterexamples in Topology
 ---
 
 The basis $\{(n,n+1)\mid n \in \mathbb{Z}\}$ is a partition.
-
-See the entry for space #7 in {{doi:10.1007/978-1-4612-6290-9}}.


### PR DESCRIPTION
Changes:

- Added spaces in front (not sure if necessary but I did that)
- Changed doi link to zb link for Counterexamples
- Removed "asserted in Counterexamples" claims (we shouldn't add properties based on assertions)
- Updated arguments for properties
- Removed unnecessary refs to Counterexamples
- Added two meta-properties