### PR TITLE
Basically disconnected and Tychonoff implies sequentially discrete

### DIFF
--- a/theorems/T000787.md
+++ b/theorems/T000787.md
@@ -1,0 +1,14 @@
+---
+uid: T000787
+if:
+  and:
+  - P000085: true
+  - P000006: true
+then:
+  P000167: true
+refs:
+  - mathse: 4751804
+    name: Answer to "What separation is required to ensure extremally disconnected spaces are sequentially discrete?"
+---
+
+Since $X$ is {P6}, in the proof of {{mathse:4751804}} we can take $U_n$ to be cozero sets. Then $U = \bigcup_n U_{2n}$ and $V = \bigcup_n U_{2n+1}$ are open disjoint cozero sets with $x\in \overline{U}\cap \overline{V}$, which contradicts that $X$ is basically disconnected.


### PR DESCRIPTION
This is a slight modification of theorem 10 which says that extremally disconnected locally Hausdorff space is sequentially discrete.
Note that we can't really change Tychonoff to "locally X" because the "locally" would have to be cozero type of locally for this subspace to still be basically disconnected, which is why that part doesn't generalize.

In particular this theorem implies https://github.com/pi-base/data/pull/1423 is not basically disconnected