### PR TITLE
T472: avoid circular reasoning

### DIFF
--- a/properties/P000186.md
+++ b/properties/P000186.md
@@ -7,3 +7,9 @@ refs:
 ---
 
 Homeomorphic to a subspace of a space that is {P87} and {P187}.
+
+----
+#### Meta-properties
+
+- This property is hereditary.
+- This property is preserved by countable products.

--- a/theorems/T000472.md
+++ b/theorems/T000472.md
@@ -7,10 +7,11 @@ if:
 then:
   P000186: true 
 refs:
-  - wikipedia: Topological_group
-    name: Topological group on Wikipedia
-  - zb: "0684.54001"
-    name: General Topology (Engelking, 1989)
+  - zb: "1052.54001"
+    name: General Topology (Willard)
 ---
 
-A separable metrizable space embeds into {S30} (see theorem 4.2.10 in {{zb:0684.54001}}) which is a $W$-group since {S30|P87} and {S30|P187}.
+A separable metrizable space embeds into {S30}
+(see Theorem 23.1 in {{zb:1052.54001}}), which is a W-group as a countable product of $W$-groups
+since {S25|P87}
+and {S25|P187}.

--- a/theorems/T000472.md
+++ b/theorems/T000472.md
@@ -12,6 +12,7 @@ refs:
 ---
 
 A separable metrizable space embeds into {S30}
-(see Theorem 23.1 in {{zb:1052.54001}}), which is a W-group as a countable product of $W$-groups
-since {S25|P87}
-and {S25|P187}.
+(see Theorem 23.1 in {{zb:1052.54001}}), which is a W-group since
+(1) {S30|P87},
+(2) {S30|P28}
+and (3) {T473}.


### PR DESCRIPTION
Change T472 (separable + metrizable => embeds in a topological W-group) to avoid circular reasoning.
The previous justification from #1446 was using the linked https://topology.pi-base.org/spaces/S30/properties/P187, which was itself depending on T472.

Also changed the reference to Willard, as it had a more self-contained result.

@pzjp @Moniker1998 
