### PR TITLE
Locally countable + $T_1$ implies $G_\delta$ points

### DIFF
--- a/theorems/T000790.md
+++ b/theorems/T000790.md
@@ -2,8 +2,8 @@
 uid: T000790
 if:
   and:
-  - P000002: true
   - P000093: true
+  - P000002: true
 then:
   P000191: true
 ---


### PR DESCRIPTION
We have a similar theorem which says:
Countable + $T_1$ then $G_\delta$ diagonal.

This isn't true for locally countable, Nyikos space #1451 is locally countable $T_2$ but doesn't have $G_\delta$ diagonal (otherwise it would be compact, and so regular). 