### PR TITLE
$T_1$ $G_\delta$-space with countable extent has countable spread

### DIFF
--- a/theorems/T000792.md
+++ b/theorems/T000792.md
@@ -1,0 +1,13 @@
+---
+uid: T000792
+if:
+  and:
+  - P000002: true
+  - P000132: true
+  - P000198: true
+then:
+  P000197: true
+---
+
+Assume $X$ is not {P197} and take discrete uncountable set $D\subseteq X$. For each $d\in D$ take open $U_d$ such that $U_d\cap D = \{d\}$. 
+There exist closed sets $F_n\subseteq X$ such that $\bigcup_n F_n = \bigcup_{d\in D} U_d$. Since $D$ is uncountable, there exists $n$ such that $F_n\cap D$ is uncountable. Since $F_n\cap D$ is uncountable and discrete, there exists a limit point $x\in (F_n\cap D)' \subseteq F_n\subseteq \bigcup_{d\in D} U_d$, and so there exists $d\in D$ such that $x\in U_d$. But $U_d$ intersects only finitely many elements of $F_n\cap D$, which is impossible for a limit point in {P2} space.

--- a/theorems/T000792.md
+++ b/theorems/T000792.md
@@ -2,12 +2,14 @@
 uid: T000792
 if:
   and:
+  - P000198: true
   - P000002: true
   - P000132: true
-  - P000198: true
 then:
   P000197: true
 ---
 
-Assume $X$ is not {P197} and take discrete uncountable set $D\subseteq X$. For each $d\in D$ take open $U_d$ such that $U_d\cap D = \{d\}$. 
-There exist closed sets $F_n\subseteq X$ such that $\bigcup_n F_n = \bigcup_{d\in D} U_d$. Since $D$ is uncountable, there exists $n$ such that $F_n\cap D$ is uncountable. Since $F_n\cap D$ is uncountable and discrete, there exists a limit point $x\in (F_n\cap D)' \subseteq F_n\subseteq \bigcup_{d\in D} U_d$, and so there exists $d\in D$ such that $x\in U_d$. But $U_d$ intersects only finitely many elements of $F_n\cap D$, which is impossible for a limit point in {P2} space.
+Assume $X$ is not {P197} and take a discrete uncountable set $D\subseteq X$.
+For each $d\in D$ take an open set $U_d$ such that $U_d\cap D = \{d\}$. 
+There exist closed sets $F_n\subseteq X$ such that $\bigcup_n F_n = \bigcup_{d\in D} U_d$. Since $D$ is uncountable, there exists $n$ such that $F_n\cap D$ is uncountable. Since $F_n\cap D$ is uncountable and discrete, there exists a limit point $x\in (F_n\cap D)' \subseteq F_n\subseteq \bigcup_{d\in D} U_d$, and so there exists $d\in D$ such that $x\in U_d$.
+But $U_d$ intersects $F_n\cap D$ in only finitely many elements, which is impossible for a limit point in a {P2} space.


### PR DESCRIPTION
A $T_0$ $G_\delta$-space is $T_1$ so we cannot generalize it.

And we cannot drop $T_0$ assumption since product of uncountable discrete space and two-point indiscrete space is $G_\delta$-space, has countable extent (as the only closed discrete subspace is the empty set), but not countable spread. 

I also note this generalizes to inequality $s(X)\leq e(X)\cdot \Psi(X)$ for $T_1$ spaces (where I should also note that the cardinal function $\Psi$ is defined for $R_0$ spaces, and again theorem is not true more generally for non- $T_0$ spaces). This inequality is known in Handbook of set-theoretic topology, but somewhat hidden there.