### PR TITLE
Dieudonné plank is not Sequentially Discrete

### DIFF
--- a/properties/P000136.md
+++ b/properties/P000136.md
@@ -15,4 +15,5 @@ Every compact subset of the space is finite.
 ----
 #### Meta-properties
 
+- This property is hereditary.
 - This property is preserved by finite products.

--- a/properties/P000167.md
+++ b/properties/P000167.md
@@ -13,3 +13,8 @@ Every convergent sequence in the space is eventually constant.
 Equivalently, every set is sequentially closed.  That is, the sequential coreflection of the space is discrete.
 
 See {{mo:451796}}.
+
+----
+#### Meta-properties
+
+- This property is hereditary.

--- a/spaces/S000191/README.md
+++ b/spaces/S000191/README.md
@@ -9,6 +9,8 @@ isolated and neighborhoods of $\omega_1$ cocountable,
 and $Z=[0,\omega]$ is given the topology with points of $[0,\omega)$
 isolated and neighborhoods of $\omega$ cofinite.
 
+Equivalently, the product of {S155} and {S20}.
+
 The space $X$ has the same underlying set as {S78}, but with a finer topology.
 
 Note that "Dieudonné plank" is also used to refer to {S87}.

--- a/spaces/S000191/properties/P000136.md
+++ b/spaces/S000191/properties/P000136.md
@@ -1,0 +1,7 @@
+---
+space: S000191
+property: P000136
+value: false
+---
+
+The set $\{0\} \times [0,\omega]$ is a compact infinite subset homeomorphic to {S20}.

--- a/spaces/S000191/properties/P000136.md
+++ b/spaces/S000191/properties/P000136.md
@@ -1,7 +1,0 @@
----
-space: S000191
-property: P000136
-value: false
----
-
-The set $\{0\} \times [0,\omega]$ is a compact infinite subset homeomorphic to {S20}.

--- a/spaces/S000191/properties/P000167.md
+++ b/spaces/S000191/properties/P000167.md
@@ -1,0 +1,7 @@
+---
+space: S000191
+property: P000167
+value: false
+---
+
+The sequence $(0, n)$ converges to $(0, \omega)$.


### PR DESCRIPTION
Adds the property that the [Dieudonné plank](https://topology.pi-base.org/spaces/S000191) is not [Sequentially Discrete](https://topology.pi-base.org/properties/P000167).

I was asking ChatGPT some topology questions and had to check on pi-base to make sure it wasn't lying to me (it was lying to me), and I discovered this missing property so I filled it in.