### PR TITLE
Pseudocompact preserved in coarser topology

### DIFF
--- a/properties/P000022.md
+++ b/properties/P000022.md
@@ -2,10 +2,15 @@
 uid: P000022
 name: Pseudocompact
 refs:
-  - doi: 10.1007/978-1-4612-6290-9
+  - zb: "0386.54001"
     name: Counterexamples in Topology
 ---
 
-Every continuous function from the space to {S25} is bounded.
+Every continuous function from $X$ to {S25} is bounded.
 
-Defined on page 20 of {{doi:10.1007/978-1-4612-6290-9}}.
+Defined on page 20 of {{zb:0386.54001}}.
+
+----
+#### Meta-properties
+
+- This property is preserved in any coarser topology.


### PR DESCRIPTION
Meta-property for P22 (pseudocompact): preserved in any coarser topology.
(easy to check)

See https://github.com/pi-base/data/pull/1410#issuecomment-3218397530.