### PR TITLE
explain Alexandroff Square

### DIFF
--- a/spaces/S000099/README.md
+++ b/spaces/S000099/README.md
@@ -6,7 +6,7 @@ refs:
   - doi: 10.1007/978-1-4612-6290-9
     name: Counterexamples in Topology
 ---
-Let $X$ be the unit square $[0,1] \times [0,1] \subset \mathbb{R}^2$. For a point $(x,y)$ not on the diagonal (for $x \ne y$), basic open neighborhoods are given by the vertical segments $\{x\} \times (y - \varepsilon,y + \varepsilon)$ for $\varepsilon > 0$. For a point $(x,x)$ on the diagonal, basic open neighborhoods are given by open horizontal strips minus a finite number of vertical lines, i.e., sets of the form $S \times (x - \varepsilon,x + \varepsilon)$ for $\varepsilon > 0$ and $S$ cofinite subset of $[0,1]$ not containing $x$.
+Let $X$ be the unit square $[0,1] \times [0,1] \subset \mathbb{R}^2$. For a point $(x,y)$ not on the diagonal (for $x \ne y$), basic neighborhoods are given by the vertical segments $\{x\} \times (y - \varepsilon,y + \varepsilon)$ for $\varepsilon > 0$. For a point $(x,x)$ on the diagonal, basic open neighborhoods are given by open horizontal strips minus a finite number of vertical lines, i.e., sets of the form $S \times (x - \varepsilon,x + \varepsilon)$ for $\varepsilon > 0$ and $S$ cofinite subset of $[0,1]$ not containing $x$.
 
 Every vertical slice is homeomorphic to {S158}. Every horizontal slice is homeomorphic to {S154}, with the homeomorphism sending the point on the diagonal to $\infty$. The diagonal $\{(x,x) | x \in [0, 1]\}$ is homeomorphic to {S158}.
 


### PR DESCRIPTION
Explain the [Alexandroff square](https://topology.pi-base.org/spaces/S000099) better.

I was browsing [pi-base](https://topology.pi-base.org/) when I came across this space. Unfortunately I was not able to decipher the explanation given here. I had to get out the book Counterexamples in Topology and flip to the page containing the square, which had a picture that cleared things up.