### PR TITLE
"Completing" cofinite topology on R (S16)

### DIFF
--- a/spaces/S000016/properties/P000210.md
+++ b/spaces/S000016/properties/P000210.md
@@ -4,4 +4,4 @@ property: P000210
 value: true
 ---
 
-As $X$ has cofinite topology, for every open $U \subseteq X$ and every subset $A \subseteq X$, $A \setminus U$ is finite. Therefore every countably set converges to every point in $X$, meaning we can simply take $S := \bigcup_{n \in \mathbb{N}} S_n$.
+As $X$ has cofinite topology, for any open $U \subseteq X$ and subset $A \subseteq X$, $A \setminus U$ is finite. Hence, any countably set converges to every point in $X$, meaning we can simply take $S := \bigcup_{n \in \mathbb{N}} S_n$.


### PR DESCRIPTION
S16 (quite trivially) has the $\alpha_1$ (P210) property. This completes S16 (modulo CH, as usual).

In theory this could be expanded to a theorem : Has cofinite a topology (P222) -> $\alpha_1$ (P210)
but no other space would gain the trait for it, so I dont think it is really necessary.