### PR TITLE
Line with two origins S83 is cozero complemented

### DIFF
--- a/spaces/S000083/properties/P000061.md
+++ b/spaces/S000083/properties/P000061.md
@@ -1,0 +1,16 @@
+---
+space: S000083
+property: P000061
+value: true
+refs:
+  - mathse: 5108293
+    name: Cozero complemented property for a space and its Tychonoff reflection
+---
+
+The {P6}-reflection of $X$ is {S25},
+with the reflection map $\varphi:X\to\mathbb R$ sending the two "origins" to $0$
+and every other element to itself.
+
+Since {S25|P61}
+and the reflection map $\varphi$ is open,
+the result follows from the Proposition in {{mathse:5108293}}.


### PR DESCRIPTION
S83 (line with two origins) is cozero complemented.

The proof follows from the proposition in https://math.stackexchange.com/questions/5108293/cozero-complemented-property-for-a-space-and-its-tychonoff-reflection, which should be reviewed at the same time.

More spaces can be handled in the same way, but I am just starting with this one as proof of concept.
