### PR TITLE
Change compact to $k_1$-space in T312

### DIFF
--- a/theorems/T000312.md
+++ b/theorems/T000312.md
@@ -2,7 +2,7 @@
 uid: T000312
 if:
   and:
-    - P000016: true
+    - P000140: true
     - P000100: true
 then:
   P000101: true
@@ -11,5 +11,6 @@ refs:
     name: '"All retracts are closed" and "all compacts are closed"'
 ---
 
-Asserted in {{mo:434451}}; let $R$ be a retract, then $R$ is the continuous image of
-the {P16} space, and thus is {P16}. By {P100} it is closed.
+If $A$ is a retract, $r:X\to A$ is a retraction and $K\subseteq X$ is compact, let $L = r^{-1}(K)\cap K$. 
+Since $X$ is {P100}, it follows that $L$ is compact. Then $r(L) = K\cap A$ so that $K\cap A$ is compact, and so closed in $K$.
+Because $X$ is {P140} it follows that $A$ is closed.


### PR DESCRIPTION
A small upgrade to the theorem of the form $P + KC \implies RC$ where $P=$ compact is replaced by $P = k_1$-space