### PR TITLE
WLC para-Lindelof regular spaces are strongly paracompact

### DIFF
--- a/properties/P000145.md
+++ b/properties/P000145.md
@@ -16,3 +16,4 @@ Defined on p. 326 of {{zb:0684.54001}} together with the condition that the spac
 #### Meta-properties
 
 - $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
+- This property is preserved by arbitrary disjoint unions.

--- a/theorems/T000812.md
+++ b/theorems/T000812.md
@@ -1,0 +1,16 @@
+---
+uid: T000812
+if:
+  and:
+  - P000023: true
+  - P000105: true
+  - P000011: true
+then:
+  P000145: true
+refs:
+  - mathse: 5028016
+    name: Answer to "Connected, locally compact, paracompact Hausdorff space is exhaustible by compacts"
+---
+
+From {{mathse:5028016}}, $X = \bigcup_{i\in I} X_i$ is a disjoint union of {P18} subspaces $X_i$. 
+By {T30}, each $X_i$ is {P145}, and so $X$ is {P145}.


### PR DESCRIPTION
Closes #1515 

WLC can be replaced by weakly locally Lindelof (which doesn't exist on pi-base)