### PR TITLE
Long ray is countably compact

### DIFF
--- a/spaces/S000038/properties/P000019.md
+++ b/spaces/S000038/properties/P000019.md
@@ -7,7 +7,7 @@ refs:
   name: Counterexamples in Topology
 ---
 
-Every countable set $S\subseteq X$ is bounded in $X$,
+Every infinite countable set $S\subseteq X$ is bounded in $X$,
 and thus is contained in some interval $[p,q]$ with $p<q$ in $X$.
 Such an interval is homeomorphic to {S158}, which is {P19}.
 Therefore $S$ has an $\omega$-accumulation point in $[p,q]$ and also in $X$.


### PR DESCRIPTION
Fixing the proof of Long ray (S38) is countably compact (P19).

If $U_n$ is an unbounded open set (for example a little interval around each successor ordinal in $\omega_1$), it does not mean that it must contain a full unbounded interval.

But the proof in S&S is enough: every sequence has an accumulation point.