### PR TITLE
Remove unnecessary mentions of General reference chart

### DIFF
--- a/spaces/S000013/properties/P000029.md
+++ b/spaces/S000013/properties/P000029.md
@@ -2,12 +2,6 @@
 space: S000013
 property: P000029
 value: false
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 If $p$ is the excluded point, $ \{ \{x\}\ |\ x \neq p\} $ is an uncountable, pairwise disjoint collection of open sets.
-
-Asserted in the General Reference Chart for space #15 in
-{{zb:0386.54001}}.

--- a/spaces/S000014/properties/P000029.md
+++ b/spaces/S000014/properties/P000029.md
@@ -8,6 +8,3 @@ refs:
 ---
 
 $\{ \{x\}\ |\ x \neq 0\}$ is an uncountable, pairwise disjoint collection of open sets.
-
-Asserted in the General Reference Chart for space #17 in
-{{zb:0386.54001}}.

--- a/spaces/S000014/properties/P000036.md
+++ b/spaces/S000014/properties/P000036.md
@@ -2,12 +2,6 @@
 space: S000014
 property: P000036
 value: false
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 $X = \{-1\} \cup (-1,1]$ is a separation of $X$.
-
-Asserted in the General Reference Chart for space #17 in
-{{zb:0386.54001}}.

--- a/spaces/S000014/properties/P000065.md
+++ b/spaces/S000014/properties/P000065.md
@@ -2,12 +2,6 @@
 space: S000014
 property: P000065
 value: true
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 $|X| = \mathfrak{c}$ by definition.
-
-Asserted in the General Reference Chart for space #17 in
-{{zb:0386.54001}}.

--- a/spaces/S000017/properties/P000044.md
+++ b/spaces/S000017/properties/P000044.md
@@ -2,12 +2,6 @@
 space: S000017
 property: P000044
 value: false
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 Write $X = A \cup B$ with $A$ and $B$ disjoint and $|X| = |A| = |B|$. Then $A$ and $B$ are homeomorphic to $X$ and thus connected.
-
-Asserted in the General Reference Chart for space #20 in
-{{zb:0386.54001}}.

--- a/spaces/S000018/properties/P000026.md
+++ b/spaces/S000018/properties/P000026.md
@@ -2,12 +2,6 @@
 space: S000018
 property: P000026
 value: false
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 For any $D = \{(x_n, a_n)\ |\ n \in \omega\} \subset X \times \{0,1\}$, $U = \{(y,z)\ |\ y \neq x_n \text{ for any } n\}$ is a basic open set disjoint from $D$ and so $D$ is not dense.
-
-Asserted in the General Reference Chart for space #21 in
-{{zb:0386.54001}}.

--- a/spaces/S000019/properties/P000056.md
+++ b/spaces/S000019/properties/P000056.md
@@ -2,12 +2,6 @@
 space: S000019
 property: P000056
 value: true
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 For any $n \in \omega$, let $I_n$ denote the interval $(n, n+2)$. $\overline {I_n} = [n, n+2]$ and $int (\overline{I_n}) = \emptyset$ since any open set in $X$ is unbounded. Clearly $X = \bigcup_{n \in \omega} I_n$, so $X$ is meager.
-
-Asserted in the General Reference Chart for space #22 in
-{{zb:0386.54001}}.

--- a/spaces/S000024/properties/P000029.md
+++ b/spaces/S000024/properties/P000029.md
@@ -2,12 +2,6 @@
 space: S000024
 property: P000029
 value: false
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 $\{\{y\}\ |\ y \in Y\}$ is an uncountable pairwise disjoint collection of open sets.
-
-Asserted in the General Reference Chart for space #27 in
-{{zb:0386.54001}}.

--- a/spaces/S000025/properties/P000022.md
+++ b/spaces/S000025/properties/P000022.md
@@ -2,12 +2,6 @@
 space: S000025
 property: P000022
 value: false
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 The identity map is an unbounded continuous function.
-
-Asserted in the General Reference Chart for space #28 in
-{{zb:0386.54001}}.

--- a/spaces/S000025/properties/P000053.md
+++ b/spaces/S000025/properties/P000053.md
@@ -2,12 +2,6 @@
 space: S000025
 property: P000053
 value: true
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 By definition.
-
-Asserted in the General Reference Chart for space #28 in
-{{zb:0386.54001}}.

--- a/spaces/S000026/properties/P000050.md
+++ b/spaces/S000026/properties/P000050.md
@@ -2,12 +2,6 @@
 space: S000026
 property: P000050
 value: true
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 For each $\sigma \in 2^{<\omega}$, let $[\sigma] = \{ x \in 2^\omega\ |\ x \text{ extends } \sigma \text{ as a sequence} \}$. Then $\{ [\sigma]\ |\ \sigma \in 2^{<\omega}\}$ is a clopen basis.
-
-Asserted in the General Reference Chart for space #29 in
-{{zb:0386.54001}}.

--- a/spaces/S000028/properties/P000022.md
+++ b/spaces/S000028/properties/P000022.md
@@ -2,12 +2,6 @@
 space: S000028
 property: P000022
 value: false
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 The inclusion map $\mathbb{R}\setminus\mathbb{Q} \hookrightarrow \mathbb{R}$ is unbounded.
-
-Asserted in the General Reference Chart for space #31 in
-{{zb:0386.54001}}.

--- a/spaces/S000028/properties/P000065.md
+++ b/spaces/S000028/properties/P000065.md
@@ -2,12 +2,6 @@
 space: S000028
 property: P000065
 value: true
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 $|\mathbb{R} \setminus \mathbb{Q}| = |\mathbb{R}| = \mathfrak{c}$
-
-Asserted in the General Reference Chart for space #31 in
-{{zb:0386.54001}}.

--- a/spaces/S000030/properties/P000042.md
+++ b/spaces/S000030/properties/P000042.md
@@ -2,12 +2,6 @@
 space: S000030
 property: P000042
 value: true
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 If $(a_i),(b_i) \in U \subset \mathbb{R}^\omega$ for a basic open set $U$ then $f: t \mapsto \big(a_i + t(b_i - a_i)\big)$ is a path in $U$ from $(a_i)$ to $(b_i)$.
-
-Asserted in the General Reference Chart for space #36 in
-{{zb:0386.54001}}.

--- a/spaces/S000033/properties/P000052.md
+++ b/spaces/S000033/properties/P000052.md
@@ -2,12 +2,6 @@
 space: S000033
 property: P000052
 value: false
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 The singleton $\{\omega\}$ is not open.
-
-Asserted in the General Reference Chart for space #40 in
-{{zb:0386.54001}}.

--- a/spaces/S000038/properties/P000065.md
+++ b/spaces/S000038/properties/P000065.md
@@ -2,12 +2,6 @@
 space: S000038
 property: P000065
 value: true
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 By construction (and since $|\omega_1| \leq \mathfrak{c}$), $|X| = \aleph_1\cdot \mathfrak{c} = \mathfrak{c}$.
-
-Asserted in the General Reference Chart for space #45 in
-{{zb:0386.54001}}.

--- a/spaces/S000040/properties/P000009.md
+++ b/spaces/S000040/properties/P000009.md
@@ -2,12 +2,6 @@
 space: S000040
 property: P000009
 value: true
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 Any totally-ordered set is clearly this, so we consider when $p$ is one of the points in question.  That is, let $q$ be a point on the long line and $p$ the special point added.  Let $r$ be the least ordinal greater than $q$.  Define the function $f:X\to [0,1]$ as follows for $t\le q$, define $f(q)=0$.  Now note that $[q, r]$ is homeomorphic with $[0,1]$, so for $q \le t \le r$, let $f(t)$ be such a homeomorphism with $f(q)=0$ and $f(r)=1$.  Then define $f(t)=1$ for $t > r$ or $t=p$.
-
-Asserted in the General Reference Chart for space #47 in
-{{zb:0386.54001}}.

--- a/spaces/S000040/properties/P000046.md
+++ b/spaces/S000040/properties/P000046.md
@@ -2,12 +2,6 @@
 space: S000040
 property: P000046
 value: false
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 Given any point $x$ in the long line, the interval from $x$ to the least ordinal greater than $x$ is homeomorphic to $[0,1]$, hence is path connected.
-
-Asserted in the General Reference Chart for space #47 in
-{{zb:0386.54001}}.

--- a/spaces/S000046/properties/P000056.md
+++ b/spaces/S000046/properties/P000056.md
@@ -2,15 +2,9 @@
 space: S000046
 property: P000056
 value: true
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 Each interval $U_n=(0,1/n)$ for $n\ge 2$ is open in $X$ and dense since $X$ is {P39}.
 So its complement $U_n^c=X\setminus (0,1/n)$ is nowhere dense.
 Since the intersection of the all $U_n$ is empty,
 $X$ is the countable union of the nowhere dense sets $U_n^c$.
-
-Asserted in the General Reference Chart for space #54 in
-{{zb:0386.54001}}.

--- a/spaces/S000046/properties/P000065.md
+++ b/spaces/S000046/properties/P000065.md
@@ -2,12 +2,6 @@
 space: S000046
 property: P000065
 value: true
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 Clearly $|X| = \mathfrak{c}$.
-
-Asserted in the General Reference Chart for space #54 in
-{{zb:0386.54001}}.

--- a/spaces/S000047/properties/P000021.md
+++ b/spaces/S000047/properties/P000021.md
@@ -2,12 +2,6 @@
 space: S000047
 property: P000021
 value: false
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 The subset $\{2n-1:n=1,2,\dots\}$ is infinite and without limit point, as it is closed and discrete.
-
-Asserted in the General Reference Chart for space #55 in
-{{zb:0386.54001}}.

--- a/spaces/S000047/properties/P000024.md
+++ b/spaces/S000047/properties/P000024.md
@@ -2,12 +2,6 @@
 space: S000047
 property: P000024
 value: true
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 For each point, the summand $\{2n-1,2n\}$ that it belongs to is a closed and compact neighborhood.
-
-Asserted in the General Reference Chart for space #55 in
-{{zb:0386.54001}}.

--- a/spaces/S000049/properties/P000039.md
+++ b/spaces/S000049/properties/P000039.md
@@ -2,14 +2,8 @@
 space: S000049
 property: P000039
 value: false
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 $\{ 2 \}$ and $\{ 3 \}$ are disjoint nonempty open subsets.
 
 In a bit more generality, if $n,m \in X$ are co-prime, then $U_n, U_m$ are disjoint nonempty open subsets.
-
-Asserted in the General Reference Chart for space #57 in
-{{zb:0386.54001}}.

--- a/spaces/S000054/properties/P000024.md
+++ b/spaces/S000054/properties/P000024.md
@@ -2,12 +2,6 @@
 space: S000054
 property: P000024
 value: true
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 For any $(a,b) \in X$, $(a-1,a+1) \times \{0,1\}$ is a neighborhood of $(a,b)$ with compact closure.
-
-Asserted in the General Reference Chart for space #62 in
-{{zb:0386.54001}}.

--- a/spaces/S000054/properties/P000027.md
+++ b/spaces/S000054/properties/P000027.md
@@ -2,12 +2,6 @@
 space: S000054
 property: P000027
 value: true
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 Let $\{U_n\}$ be a countable base for $\mathbb{R}$. Then $\{U_n \times \{0,1\}\}$ is a countable base for $X$.
-
-Asserted in the General Reference Chart for space #62 in
-{{zb:0386.54001}}.

--- a/spaces/S000060/properties/P000044.md
+++ b/spaces/S000060/properties/P000044.md
@@ -2,13 +2,7 @@
 space: S000060
 property: P000044
 value: false
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 The subspaces $(-\infty,0)$ and $(0,+\infty)$
 are disjoint, homeomorphic to $X$ and therefore {P36} since {S60|P36}.
-
-Asserted in the General Reference Chart for space #68 in
-{{zb:0386.54001}}.

--- a/spaces/S000064/properties/P000022.md
+++ b/spaces/S000064/properties/P000022.md
@@ -2,12 +2,6 @@
 space: S000064
 property: P000022
 value: false
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 The function $f : X \to \mathbb{R}$ defined by $f(x,y) = x$ can be shown to be continuous, and is unbounded.
-
-Asserted in the General Reference Chart for space #72 in
-{{zb:0386.54001}}.

--- a/spaces/S000070/properties/P000022.md
+++ b/spaces/S000070/properties/P000022.md
@@ -2,12 +2,6 @@
 space: S000070
 property: P000022
 value: false
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 For example, the function $f:X\to\mathbb R$ defined by $f(x,y)=y$ is continuous and unbounded.
-
-Asserted in the General Reference Chart for space #78 in
-{{zb:0386.54001}}.

--- a/spaces/S000073/properties/P000017.md
+++ b/spaces/S000073/properties/P000017.md
@@ -2,12 +2,6 @@
 space: S000073
 property: P000017
 value: true
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 The set $(0,1) \times (0,1)$ is $\sigma$-compact, because it has the Euclidean topology, and we can just write it as $\bigcup_n [\frac{1}{n}, 1-\frac{1}{n}]^2$. We then add the doubleton of the corner points.
-
-Asserted in the General Reference Chart for space #81 in
-{{zb:0386.54001}}.

--- a/spaces/S000073/properties/P000022.md
+++ b/spaces/S000073/properties/P000022.md
@@ -2,12 +2,6 @@
 space: S000073
 property: P000022
 value: false
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 The projection onto the $y$-coordinate (when imagined as a subset of the plane) is continuous and has $[0,1) \subset \mathbb{R}$ as its image. This is not pseudocompact (e.g. $f(x) = \frac{1}{1-x}$ is unbounded and continuous on it). And pseudocompactness is preserved by continuous images.
-
-Asserted in the General Reference Chart for space #81 in
-{{zb:0386.54001}}.

--- a/spaces/S000073/properties/P000056.md
+++ b/spaces/S000073/properties/P000056.md
@@ -2,12 +2,6 @@
 space: S000073
 property: P000056
 value: false
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 $(0,1) \times (0,1)$ is open, dense and Baire. So the whole space is Baire too, hence non-meager.
-
-Asserted in the General Reference Chart for space #81 in
-{{zb:0386.54001}}.

--- a/spaces/S000077/properties/P000006.md
+++ b/spaces/S000077/properties/P000006.md
@@ -2,12 +2,6 @@
 space: S000077
 property: P000006
 value: true
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 Follows as this space is the product of {P000006} spaces.
-
-Asserted in the General Reference Chart for space #85 in
-{{zb:0386.54001}}.

--- a/spaces/S000081/properties/P000006.md
+++ b/spaces/S000081/properties/P000006.md
@@ -2,12 +2,6 @@
 space: S000081
 property: P000006
 value: false
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 For all $\alpha , n$ there is no open neighborhood $V$ of $( \omega_1 , 0 )$ such that $\overline{V} \subseteq U(\alpha,n)$.
-
-Asserted in the General Reference Chart for space #88 in
-{{zb:0386.54001}}.

--- a/spaces/S000095/properties/P000003.md
+++ b/spaces/S000095/properties/P000003.md
@@ -2,9 +2,6 @@
 space: S000095
 property: P000003
 value: true
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 We will prove that the Concentric Circles Topology is $T_2$ by cases. There are four cases.
@@ -13,6 +10,3 @@ Case two a is on $C_1$ and b is the radial projection of a onto $C_2$. find any 
 Case three a is on $C_1$ and b is not the radial midpoint of a onto $C_2$. first we find the pre-image j of b in $C_1$ find the radial distance between a and j then multiply that by two and call that $\epsilon$ the take the epsilon neighborhood around j and the set containing b on $C_2$ these are two disjoint open sets containing a and b respectively.
 Case four both a and b are on $C_2$ this is trivial and just take the sets only conaining a and b respectively.
 Therefore the concentric circles Topology is $T_2$.
-
-Asserted in the General Reference Chart for space #97 in
-{{zb:0386.54001}}.

--- a/spaces/S000095/properties/P000036.md
+++ b/spaces/S000095/properties/P000036.md
@@ -2,12 +2,6 @@
 space: S000095
 property: P000036
 value: false
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 Since concentric circles are Hausdorff, singletons are closed. Any singleton in $C_2$ is also open. Therefore the space is disconnected.
-
-Asserted in the General Reference Chart for space #97 in
-{{zb:0386.54001}}.

--- a/spaces/S000101/properties/P000006.md
+++ b/spaces/S000101/properties/P000006.md
@@ -2,12 +2,6 @@
 space: S000101
 property: P000006
 value: true
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 Since $\omega$ is $T_{3\frac{1}{2}}$, so is its products.
-
-Asserted in the General Reference Chart for space #103
-in {{doi:10.1007\/978-1-4612-6290-9_6}}.

--- a/spaces/S000101/properties/P000023.md
+++ b/spaces/S000101/properties/P000023.md
@@ -2,13 +2,6 @@
 space: S000101
 property: P000023
 value: false
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 Let $x$ be any point and let $U$ be a neighborhood of $x$.  Let $V\subset U$ be a basic open set.  That is, $V$ is a product of subsets of $\mathbb{Z}^+$ which is all of $\mathbb{Z}^+$ in all but finitely many coordinates.  Let $\alpha$ be one of the coordinates where $V$ is all of $\mathbb{Z}^+$ in that coordinate.  Then define for each $n\in \mathbb{Z}^+$ $A_n$ to be the set of all $u\in U$ such that $u_\alpha=n$.  Then we see that the collection $\{A_n\}$ is a covering of $U$ which has no finite subcovering, hence $U$ is not compact.
-
-
-Asserted in the General Reference Chart for space #103
-in {{doi:10.1007\/978-1-4612-6290-9_6}}.

--- a/spaces/S000104/properties/P000041.md
+++ b/spaces/S000104/properties/P000041.md
@@ -2,14 +2,8 @@
 space: S000104
 property: P000041
 value: false
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 The point $\omega_0\times 0$ has no connected neighborhood.  Indeed, let $U$ be an open neighborhood of $\omega_0\times 0$.  Then $U$ contains a set of the form $(a,b)\times V$, with $a < \omega_0 < b$.  Let $A=([0,a+2)\times I^I)\cap U$ and $B=((a+1,\Omega)\times I^I)\cap U$.  Each is open since it is the intersection of two open sets.  They are clearly disjoint, and $U=A\cup B$, so they form a separation of $U$, hence $U$ is not connected.  
 
 It is noted that this works replacing $\omega_0$ with any limit ordinal and relies only on the fact that $[0,\Omega)$ is not locally connected.
-
-Asserted in the General Reference Chart for space #106 in
-{{zb:0386.54001}}.

--- a/spaces/S000104/properties/P000059.md
+++ b/spaces/S000104/properties/P000059.md
@@ -2,12 +2,6 @@
 space: S000104
 property: P000059
 value: true
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 $| [ 0, \Omega ) \times I^I | = | [0,\Omega ) | \cdot | I^I | = \aleph_1 \cdot |I|^{|I|} = \aleph_1 \cdot ( 2^{\aleph_0} )^{2^{\aleph_0}} = \aleph_1 \cdot 2^{\aleph_0 \cdot 2^{\aleph_0}} = \aleph_1 \cdot 2^{2^{\aleph_0}} = 2^{2^{\aleph_0}} = 2^\mathfrak{c}$.
-
-Asserted in the General Reference Chart for space #106 in
-{{zb:0386.54001}}.

--- a/spaces/S000105/properties/P000003.md
+++ b/spaces/S000105/properties/P000003.md
@@ -2,12 +2,6 @@
 space: S000105
 property: P000003
 value: true
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 Follows as {S105} is a subspace of {S103}, which is {P3}.
-
-Asserted in the General Reference Chart for space #107 in
-{{zb:0386.54001}}.

--- a/spaces/S000108/properties/P000020.md
+++ b/spaces/S000108/properties/P000020.md
@@ -2,12 +2,6 @@
 space: S000108
 property: P000020
 value: false
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 The sequence $x_n = n$ has no convergent subsequence.
-
-Asserted in the General Reference Chart for space #111 in
-{{zb:0386.54001}}.

--- a/spaces/S000110/properties/P000163.md
+++ b/spaces/S000110/properties/P000163.md
@@ -2,12 +2,6 @@
 space: S000110
 property: P000163
 value: false
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 {S110} is equinumerous with {S108}, which is of size $2^\mathfrak{c} > \mathfrak{c}$.
-
-Asserted in the General Reference Chart for space #113 in
-{{zb:0386.54001}}.

--- a/spaces/S000111/properties/P000022.md
+++ b/spaces/S000111/properties/P000022.md
@@ -2,12 +2,6 @@
 space: S000111
 property: P000022
 value: false
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 Since $F$ is a free ultrafilter, there is some infinite $A \in F$ with infinite complement in $\omega$. Let $f: X \rightarrow \mathbb{R}$ by $f(x)=0$ if $x \in A$ and $f(x)=x$ otherwise. Then $f$ is continuous and unbounded.
-
-Asserted in the General Reference Chart for space #114 in
-{{zb:0386.54001}}.

--- a/spaces/S000112/properties/P000022.md
+++ b/spaces/S000112/properties/P000022.md
@@ -2,12 +2,6 @@
 space: S000112
 property: P000022
 value: false
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 Let $\pi: \mathbb{R}^2 \rightarrow \mathbb{R}$ be projection onto the second coordinate. $\pi|_X$ is clearly continuous and unbounded.
-
-Asserted in the General Reference Chart for space #115 in
-{{zb:0386.54001}}.

--- a/spaces/S000112/properties/P000036.md
+++ b/spaces/S000112/properties/P000036.md
@@ -2,12 +2,6 @@
 space: S000112
 property: P000036
 value: false
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 The rectangle $R_1$ is clopen in $X$.
-
-Asserted in the General Reference Chart for space #115 in
-{{zb:0386.54001}}.

--- a/spaces/S000112/properties/P000046.md
+++ b/spaces/S000112/properties/P000046.md
@@ -2,12 +2,6 @@
 space: S000112
 property: P000046
 value: false
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 The subspace $L_1$ is {P37}.
-
-Asserted in the General Reference Chart for space #115 in
-{{zb:0386.54001}}.

--- a/spaces/S000117/properties/P000016.md
+++ b/spaces/S000117/properties/P000016.md
@@ -8,6 +8,3 @@ refs:
 ---
 
 $X$ is a closed and bounded subset of the plane.
-
-Asserted in the General Reference Chart for space #120 in
-{{zb:0386.54001}}.

--- a/spaces/S000122/properties/P000057.md
+++ b/spaces/S000122/properties/P000057.md
@@ -2,12 +2,6 @@
 space: S000122
 property: P000057
 value: true
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 By definition.
-
-Asserted in the General Reference Chart for space #125 in
-{{zb:0386.54001}}.

--- a/spaces/S000124/properties/P000057.md
+++ b/spaces/S000124/properties/P000057.md
@@ -2,12 +2,6 @@
 space: S000124
 property: P000057
 value: true
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 By definition.
-
-Asserted in the General Reference Chart for space #127 in
-{{zb:0386.54001}}.

--- a/spaces/S000126/properties/P000016.md
+++ b/spaces/S000126/properties/P000016.md
@@ -2,12 +2,6 @@
 space: S000126
 property: P000016
 value: false
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 $X$ is a subspace of $\mathbb{R}^2$ that is not closed in $\mathbb{R}^2$.
-
-Asserted in the General Reference Chart for space #129 in
-{{zb:0386.54001}}.

--- a/spaces/S000126/properties/P000065.md
+++ b/spaces/S000126/properties/P000065.md
@@ -2,12 +2,6 @@
 space: S000126
 property: P000065
 value: true
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 By construction.
-
-Asserted in the General Reference Chart for space #129 in
-{{zb:0386.54001}}.

--- a/spaces/S000127/properties/P000046.md
+++ b/spaces/S000127/properties/P000046.md
@@ -2,12 +2,6 @@
 space: S000127
 property: P000046
 value: true
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 Let $\alpha$ be a continuous function from $[0,1]$ to $X$. If $\alpha(0) \ne \alpha(1)$ then since $X$ is Hausdorff we may assume without loss of generality that $\alpha$ is injective. But then $\alpha([0,1]) = \alpha([0, 1/2]) \cup \alpha([1/2, 1])$, contradicting the fact that $X$ is hereditarily indecomposable. Thus $\alpha$ must be constant.
-
-Asserted in the General Reference Chart for space #130 in
-{{zb:0386.54001}}.

--- a/spaces/S000133/properties/P000029.md
+++ b/spaces/S000133/properties/P000029.md
@@ -2,12 +2,6 @@
 space: S000133
 property: P000029
 value: false
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 The set $\{\{x\}\mid x\ne p\}$ is an uncountable collection of disjoint open sets.
-
-Asserted in the General Reference Chart for space #139 in
-{{zb:0386.54001}}.

--- a/spaces/S000133/properties/P000055.md
+++ b/spaces/S000133/properties/P000055.md
@@ -2,9 +2,6 @@
 space: S000133
 property: P000055
 value: true
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 Note that the space is {P53} by
@@ -22,6 +19,3 @@ therefore we must conclude that
 $d(x_n,x_{n_I})\not=\|x_n\|+\|x_{n_I}\|$ and thus $x_{n}=x_{n_I}$.
 Hence $\langle x_n \rangle$ is constant for $n\ge N$ and therefore
 convergent.
-
-Asserted in the General Reference Chart for space #139 in
-{{zb:0386.54001}}.

--- a/spaces/S000133/properties/P000065.md
+++ b/spaces/S000133/properties/P000065.md
@@ -2,12 +2,6 @@
 space: S000133
 property: P000065
 value: true
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 By construction.
-
-Asserted in the General Reference Chart for space #139 in
-{{zb:0386.54001}}.

--- a/spaces/S000136/properties/P000059.md
+++ b/spaces/S000136/properties/P000059.md
@@ -2,12 +2,6 @@
 space: S000136
 property: P000059
 value: false
-refs:
-- zb: "0386.54001"
-  name: Counterexamples in Topology
 ---
 
 By definition, the space has cardinality $2^{2^\mathfrak{c}}$.
-
-Asserted in the General Reference Chart for space #142 in
-{{zb:0386.54001}}.


### PR DESCRIPTION
See also #1585.

As I mentioned there, we ought to get rid of the general reference chart as much as possible.

This PR removes (hopefully) all "Asserted in the General Reference Chart for space ..." (as well as the reference to the Counterexamples in Topology book) for all traits still mentioning it, despite having a valid proof already.
Except for this, I changed **nothing**. So while this might look like a lot, barely anything is happening.

Mentioning the General Reference chart there gives no new information and is at best confusing.

Sorting these out also helps detecting where we still need a valid proof and _only_ have "Asserted in the General Reference Chart for space ..." so far.

