### PR TITLE
Locally orderable spaces are radial

### DIFF
--- a/properties/P000172.md
+++ b/properties/P000172.md
@@ -19,7 +19,6 @@ Compare with {P80}.
 
 - This property is hereditary.
 - $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
-- A space that is locally {P172} (every point has a neighborhood with the property)
-has the property.
+- If each point has a neighborhood with the property, $X$ also has the property.
 - This property is not preserved by products
 (Example: {S78|P172}).

--- a/theorems/T000839.md
+++ b/theorems/T000839.md
@@ -6,6 +6,5 @@ then:
   P000172: true
 ---
 
-This follows from the fact that {P172} is a "local" property,
-and {P133} spaces are {P172}
+Each point has a neighborhood that is {P133} and hence {P172}
 [(Explore)](https://topology.pi-base.org/spaces?q=LOTS%2B%7ERadial).


### PR DESCRIPTION
New theorem: Locally orderable => radial.

Plus some metaproperties for Radial.  I added "not preserved by products" because it was not initially obvious, and could be surprising to some.

This theorem allows to derive two more spaces are radial: S40 (altered long ray) and S196 (long circle),
and two more spaces are not locally orderable: S109 (Novak space) and S110 (strong ultrafilter topology).