### PR TITLE
alpha_i miscellaneous metaproperties

### DIFF
--- a/properties/P000210.md
+++ b/properties/P000210.md
@@ -12,6 +12,8 @@ refs:
     name: The frequency spectrum of a topological space and the classification of spaces (A. V. Arkhangel'skii)
   - mathse: 5122756
     name: Are the Arkhangel'skii $\alpha_i$ properties preserved by finite products?
+  - mathse: 5123855
+    name: Does the Arkhangel'skii $\alpha_1$ property hold for $X$ if it holds for its Kolmogorov quotient?
 ---
 
 For every $x\in X$ and every sequence of countably infinite sets $S_1,S_2,\dots\subseteq X$ with
@@ -37,6 +39,6 @@ are due to Arkhangel'skii ({{zb:0275.54004}}).
 #### Meta-properties
 
 - This property is hereditary.
-- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does (see {{mathse:5123855}}).
 - This property is preserved by finite products (see {{mathse:5122756}}).
 - This property is preserved by arbitrary disjoint unions.

--- a/properties/P000210.md
+++ b/properties/P000210.md
@@ -38,3 +38,4 @@ are due to Arkhangel'skii ({{zb:0275.54004}}).
 
 - This property is hereditary.
 - This property is preserved by finite products (see {{mathse:5122756}}).
+- This property is preserved by arbitrary disjoint unions.

--- a/properties/P000210.md
+++ b/properties/P000210.md
@@ -37,5 +37,6 @@ are due to Arkhangel'skii ({{zb:0275.54004}}).
 #### Meta-properties
 
 - This property is hereditary.
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is preserved by finite products (see {{mathse:5122756}}).
 - This property is preserved by arbitrary disjoint unions.

--- a/properties/P000210.md
+++ b/properties/P000210.md
@@ -10,6 +10,8 @@ refs:
     name: Subsets of ${}^\omega\omega$ and the Fréchet-Urysohn and $\alpha_i$-properties (P. Nyikos)
   - zb: "0275.54004"
     name: The frequency spectrum of a topological space and the classification of spaces (A. V. Arkhangel'skii)
+  - mathse: 5122756
+    name: Are the Arkhangel'skii $\alpha_i$ properties preserved by finite products?
 ---
 
 For every $x\in X$ and every sequence of countably infinite sets $S_1,S_2,\dots\subseteq X$ with
@@ -35,3 +37,4 @@ are due to Arkhangel'skii ({{zb:0275.54004}}).
 #### Meta-properties
 
 - This property is hereditary.
+- This property is preserved by finite products (see {{mathse:5122756}}).

--- a/properties/P000210.md
+++ b/properties/P000210.md
@@ -42,3 +42,4 @@ are due to Arkhangel'skii ({{zb:0275.54004}}).
 - $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does (see {{mathse:5123855}}).
 - This property is preserved by countable products (see {{mathse:5127008}}).
 - This property is preserved by arbitrary disjoint unions.
+- $X$ satisfies this property iff all its countable subspaces do.

--- a/properties/P000210.md
+++ b/properties/P000210.md
@@ -10,8 +10,8 @@ refs:
     name: Subsets of ${}^\omega\omega$ and the Fréchet-Urysohn and $\alpha_i$-properties (P. Nyikos)
   - zb: "0275.54004"
     name: The frequency spectrum of a topological space and the classification of spaces (A. V. Arkhangel'skii)
-  - mathse: 5122756
-    name: Are the Arkhangel'skii $\alpha_i$ properties preserved by finite products?
+  - mathse: 5127008
+    name: Answer to "Are the Arkhangel'skii $\alpha_i$ properties preserved by finite products?"
   - mathse: 5123855
     name: Does the Arkhangel'skii $\alpha_1$ property hold for $X$ if it holds for its Kolmogorov quotient?
 ---
@@ -40,5 +40,5 @@ are due to Arkhangel'skii ({{zb:0275.54004}}).
 
 - This property is hereditary.
 - $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does (see {{mathse:5123855}}).
-- This property is preserved by finite products (see {{mathse:5122756}}).
+- This property is preserved by countable products (see {{mathse:5127008}}).
 - This property is preserved by arbitrary disjoint unions.

--- a/properties/P000211.md
+++ b/properties/P000211.md
@@ -10,6 +10,8 @@ refs:
     name: Subsets of ${}^\omega\omega$ and the Fréchet-Urysohn and $\alpha_i$-properties (P. Nyikos)
   - mathse: 5122756
     name: Are the Arkhangel'skii $\alpha_i$ properties preserved by finite products?
+  - mathse: 5123855
+    name: Does the Arkhangel'skii $\alpha_1$ property hold for $X$ if it holds for its Kolmogorov quotient?
 ---
 
 For every $x\in X$ and every sequence of pairwise disjoint countably infinite sets
@@ -36,6 +38,6 @@ This property was introduced by Nyikos in {{zb:0774.54019}}.
 #### Meta-properties
 
 - This property is hereditary.
-- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does (see {{mathse:5123855}}).
 - This property is preserved by finite products (see {{mathse:5122756}}).
 - This property is preserved by arbitrary disjoint unions.

--- a/properties/P000211.md
+++ b/properties/P000211.md
@@ -36,5 +36,6 @@ This property was introduced by Nyikos in {{zb:0774.54019}}.
 #### Meta-properties
 
 - This property is hereditary.
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is preserved by finite products (see {{mathse:5122756}}).
 - This property is preserved by arbitrary disjoint unions.

--- a/properties/P000211.md
+++ b/properties/P000211.md
@@ -8,6 +8,8 @@ refs:
     name: Arhangel'skii sheaf amalgamations in topological groups (Tsaban & Zdomskyy)
   - zb: "0774.54019"
     name: Subsets of ${}^\omega\omega$ and the Fréchet-Urysohn and $\alpha_i$-properties (P. Nyikos)
+  - mathse: 5122756
+    name: Are the Arkhangel'skii $\alpha_i$ properties preserved by finite products?
 ---
 
 For every $x\in X$ and every sequence of pairwise disjoint countably infinite sets
@@ -34,3 +36,4 @@ This property was introduced by Nyikos in {{zb:0774.54019}}.
 #### Meta-properties
 
 - This property is hereditary.
+- This property is preserved by finite products (see {{mathse:5122756}}).

--- a/properties/P000211.md
+++ b/properties/P000211.md
@@ -37,3 +37,4 @@ This property was introduced by Nyikos in {{zb:0774.54019}}.
 
 - This property is hereditary.
 - This property is preserved by finite products (see {{mathse:5122756}}).
+- This property is preserved by arbitrary disjoint unions.

--- a/properties/P000211.md
+++ b/properties/P000211.md
@@ -41,3 +41,4 @@ This property was introduced by Nyikos in {{zb:0774.54019}}.
 - $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does (see {{mathse:5123855}}).
 - This property is preserved by countable products (see {{mathse:5127008}}).
 - This property is preserved by arbitrary disjoint unions.
+- $X$ satisfies this property iff all its countable subspaces do.

--- a/properties/P000211.md
+++ b/properties/P000211.md
@@ -8,8 +8,8 @@ refs:
     name: Arhangel'skii sheaf amalgamations in topological groups (Tsaban & Zdomskyy)
   - zb: "0774.54019"
     name: Subsets of ${}^\omega\omega$ and the Fréchet-Urysohn and $\alpha_i$-properties (P. Nyikos)
-  - mathse: 5122756
-    name: Are the Arkhangel'skii $\alpha_i$ properties preserved by finite products?
+  - mathse: 5127008
+    name: Answer to "Are the Arkhangel'skii $\alpha_i$ properties preserved by finite products?"
   - mathse: 5123855
     name: Does the Arkhangel'skii $\alpha_1$ property hold for $X$ if it holds for its Kolmogorov quotient?
 ---
@@ -39,5 +39,5 @@ This property was introduced by Nyikos in {{zb:0774.54019}}.
 
 - This property is hereditary.
 - $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does (see {{mathse:5123855}}).
-- This property is preserved by finite products (see {{mathse:5122756}}).
+- This property is preserved by countable products (see {{mathse:5127008}}).
 - This property is preserved by arbitrary disjoint unions.

--- a/properties/P000212.md
+++ b/properties/P000212.md
@@ -10,6 +10,8 @@ refs:
     name: Subsets of ${}^\omega\omega$ and the Fréchet-Urysohn and $\alpha_i$-properties (P. Nyikos)
   - zb: "0275.54004"
     name: The frequency spectrum of a topological space and the classification of spaces (A. V. Arkhangel'skii)
+  - mathse: 5122756
+    name: Are the Arkhangel'skii $\alpha_i$ properties preserved by finite products?
 ---
 
 For every $x\in X$ and every sequence of countably infinite sets $S_1,S_2,\dots\subseteq X$ with
@@ -34,3 +36,4 @@ are due to Arkhangel'skii ({{zb:0275.54004}}).
 #### Meta-properties
 
 - This property is hereditary.
+- This property is preserved by finite products (see {{mathse:5122756}}).

--- a/properties/P000212.md
+++ b/properties/P000212.md
@@ -36,5 +36,6 @@ are due to Arkhangel'skii ({{zb:0275.54004}}).
 #### Meta-properties
 
 - This property is hereditary.
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is preserved by finite products (see {{mathse:5122756}}).
 - This property is preserved by arbitrary disjoint unions.

--- a/properties/P000212.md
+++ b/properties/P000212.md
@@ -12,6 +12,8 @@ refs:
     name: The frequency spectrum of a topological space and the classification of spaces (A. V. Arkhangel'skii)
   - mathse: 5122756
     name: Are the Arkhangel'skii $\alpha_i$ properties preserved by finite products?
+  - mathse: 5123855
+    name: Does the Arkhangel'skii $\alpha_1$ property hold for $X$ if it holds for its Kolmogorov quotient?
 ---
 
 For every $x\in X$ and every sequence of countably infinite sets $S_1,S_2,\dots\subseteq X$ with
@@ -36,6 +38,6 @@ are due to Arkhangel'skii ({{zb:0275.54004}}).
 #### Meta-properties
 
 - This property is hereditary.
-- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does (see {{mathse:5123855}}).
 - This property is preserved by finite products (see {{mathse:5122756}}).
 - This property is preserved by arbitrary disjoint unions.

--- a/properties/P000212.md
+++ b/properties/P000212.md
@@ -37,3 +37,4 @@ are due to Arkhangel'skii ({{zb:0275.54004}}).
 
 - This property is hereditary.
 - This property is preserved by finite products (see {{mathse:5122756}}).
+- This property is preserved by arbitrary disjoint unions.

--- a/properties/P000212.md
+++ b/properties/P000212.md
@@ -41,3 +41,4 @@ are due to Arkhangel'skii ({{zb:0275.54004}}).
 - $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does (see {{mathse:5123855}}).
 - This property is preserved by countable products (see {{mathse:5127008}}).
 - This property is preserved by arbitrary disjoint unions.
+- $X$ satisfies this property iff all its countable subspaces do.

--- a/properties/P000212.md
+++ b/properties/P000212.md
@@ -10,8 +10,8 @@ refs:
     name: Subsets of ${}^\omega\omega$ and the Fréchet-Urysohn and $\alpha_i$-properties (P. Nyikos)
   - zb: "0275.54004"
     name: The frequency spectrum of a topological space and the classification of spaces (A. V. Arkhangel'skii)
-  - mathse: 5122756
-    name: Are the Arkhangel'skii $\alpha_i$ properties preserved by finite products?
+  - mathse: 5127008
+    name: Answer to "Are the Arkhangel'skii $\alpha_i$ properties preserved by finite products?"
   - mathse: 5123855
     name: Does the Arkhangel'skii $\alpha_1$ property hold for $X$ if it holds for its Kolmogorov quotient?
 ---
@@ -39,5 +39,5 @@ are due to Arkhangel'skii ({{zb:0275.54004}}).
 
 - This property is hereditary.
 - $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does (see {{mathse:5123855}}).
-- This property is preserved by finite products (see {{mathse:5122756}}).
+- This property is preserved by countable products (see {{mathse:5127008}}).
 - This property is preserved by arbitrary disjoint unions.

--- a/properties/P000213.md
+++ b/properties/P000213.md
@@ -10,6 +10,8 @@ refs:
     name: Subsets of ${}^\omega\omega$ and the Fréchet-Urysohn and $\alpha_i$-properties (P. Nyikos)
   - zb: "0275.54004"
     name: The frequency spectrum of a topological space and the classification of spaces (A. V. Arkhangel'skii)
+  - mathse: 5122756
+    name: Are the Arkhangel'skii $\alpha_i$ properties preserved by finite products?
 ---
 
 For every $x\in X$ and every sequence of countably infinite sets $S_1,S_2,\dots\subseteq X$ with
@@ -34,3 +36,4 @@ are due to Arkhangel'skii ({{zb:0275.54004}}).
 #### Meta-properties
 
 - This property is hereditary.
+- This property is preserved by finite products (see {{mathse:5122756}}).

--- a/properties/P000213.md
+++ b/properties/P000213.md
@@ -36,5 +36,6 @@ are due to Arkhangel'skii ({{zb:0275.54004}}).
 #### Meta-properties
 
 - This property is hereditary.
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is preserved by finite products (see {{mathse:5122756}}).
 - This property is preserved by arbitrary disjoint unions.

--- a/properties/P000213.md
+++ b/properties/P000213.md
@@ -12,6 +12,8 @@ refs:
     name: The frequency spectrum of a topological space and the classification of spaces (A. V. Arkhangel'skii)
   - mathse: 5122756
     name: Are the Arkhangel'skii $\alpha_i$ properties preserved by finite products?
+  - mathse: 5123855
+    name: Does the Arkhangel'skii $\alpha_1$ property hold for $X$ if it holds for its Kolmogorov quotient?
 ---
 
 For every $x\in X$ and every sequence of countably infinite sets $S_1,S_2,\dots\subseteq X$ with
@@ -36,6 +38,6 @@ are due to Arkhangel'skii ({{zb:0275.54004}}).
 #### Meta-properties
 
 - This property is hereditary.
-- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does (see {{mathse:5123855}}).
 - This property is preserved by finite products (see {{mathse:5122756}}).
 - This property is preserved by arbitrary disjoint unions.

--- a/properties/P000213.md
+++ b/properties/P000213.md
@@ -37,3 +37,4 @@ are due to Arkhangel'skii ({{zb:0275.54004}}).
 
 - This property is hereditary.
 - This property is preserved by finite products (see {{mathse:5122756}}).
+- This property is preserved by arbitrary disjoint unions.

--- a/properties/P000213.md
+++ b/properties/P000213.md
@@ -41,3 +41,4 @@ are due to Arkhangel'skii ({{zb:0275.54004}}).
 - $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does (see {{mathse:5123855}}).
 - This property is preserved by countable products (see {{mathse:5127008}}).
 - This property is preserved by arbitrary disjoint unions.
+- $X$ satisfies this property iff all its countable subspaces do.

--- a/properties/P000213.md
+++ b/properties/P000213.md
@@ -10,8 +10,8 @@ refs:
     name: Subsets of ${}^\omega\omega$ and the Fréchet-Urysohn and $\alpha_i$-properties (P. Nyikos)
   - zb: "0275.54004"
     name: The frequency spectrum of a topological space and the classification of spaces (A. V. Arkhangel'skii)
-  - mathse: 5122756
-    name: Are the Arkhangel'skii $\alpha_i$ properties preserved by finite products?
+  - mathse: 5127008
+    name: Answer to "Are the Arkhangel'skii $\alpha_i$ properties preserved by finite products?"
   - mathse: 5123855
     name: Does the Arkhangel'skii $\alpha_1$ property hold for $X$ if it holds for its Kolmogorov quotient?
 ---
@@ -39,5 +39,5 @@ are due to Arkhangel'skii ({{zb:0275.54004}}).
 
 - This property is hereditary.
 - $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does (see {{mathse:5123855}}).
-- This property is preserved by finite products (see {{mathse:5122756}}).
+- This property is preserved by countable products (see {{mathse:5127008}}).
 - This property is preserved by arbitrary disjoint unions.

--- a/properties/P000214.md
+++ b/properties/P000214.md
@@ -34,4 +34,5 @@ are due to Arkhangel'skii ({{zb:0275.54004}}).
 #### Meta-properties
 
 - This property is hereditary.
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is preserved by arbitrary disjoint unions.

--- a/properties/P000214.md
+++ b/properties/P000214.md
@@ -10,6 +10,8 @@ refs:
     name: Subsets of ${}^\omega\omega$ and the Fréchet-Urysohn and $\alpha_i$-properties (P. Nyikos)
   - zb: "0275.54004"
     name: The frequency spectrum of a topological space and the classification of spaces (A. V. Arkhangel'skii)
+  - mathse: 5122756
+    name: Are the Arkhangel'skii $\alpha_i$ properties preserved by finite products?
 ---
 
 For every $x\in X$ and every sequence of countably infinite sets $S_1,S_2,\dots\subseteq X$ with
@@ -34,3 +36,4 @@ are due to Arkhangel'skii ({{zb:0275.54004}}).
 #### Meta-properties
 
 - This property is hereditary.
+- This property is preserved by finite products (see {{mathse:5122756}}).

--- a/properties/P000214.md
+++ b/properties/P000214.md
@@ -10,8 +10,6 @@ refs:
     name: Subsets of ${}^\omega\omega$ and the Fréchet-Urysohn and $\alpha_i$-properties (P. Nyikos)
   - zb: "0275.54004"
     name: The frequency spectrum of a topological space and the classification of spaces (A. V. Arkhangel'skii)
-  - mathse: 5122756
-    name: Are the Arkhangel'skii $\alpha_i$ properties preserved by finite products?
 ---
 
 For every $x\in X$ and every sequence of countably infinite sets $S_1,S_2,\dots\subseteq X$ with
@@ -36,4 +34,3 @@ are due to Arkhangel'skii ({{zb:0275.54004}}).
 #### Meta-properties
 
 - This property is hereditary.
-- This property is preserved by finite products (see {{mathse:5122756}}).

--- a/properties/P000214.md
+++ b/properties/P000214.md
@@ -10,6 +10,8 @@ refs:
     name: Subsets of ${}^\omega\omega$ and the Fréchet-Urysohn and $\alpha_i$-properties (P. Nyikos)
   - zb: "0275.54004"
     name: The frequency spectrum of a topological space and the classification of spaces (A. V. Arkhangel'skii)
+  - mathse: 5123855
+    name: Does the Arkhangel'skii $\alpha_1$ property hold for $X$ if it holds for its Kolmogorov quotient?
 ---
 
 For every $x\in X$ and every sequence of countably infinite sets $S_1,S_2,\dots\subseteq X$ with
@@ -34,5 +36,5 @@ are due to Arkhangel'skii ({{zb:0275.54004}}).
 #### Meta-properties
 
 - This property is hereditary.
-- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does (see {{mathse:5123855}}).
 - This property is preserved by arbitrary disjoint unions.

--- a/properties/P000214.md
+++ b/properties/P000214.md
@@ -34,3 +34,4 @@ are due to Arkhangel'skii ({{zb:0275.54004}}).
 #### Meta-properties
 
 - This property is hereditary.
+- This property is preserved by arbitrary disjoint unions.

--- a/properties/P000214.md
+++ b/properties/P000214.md
@@ -38,3 +38,4 @@ are due to Arkhangel'skii ({{zb:0275.54004}}).
 - This property is hereditary.
 - $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does (see {{mathse:5123855}}).
 - This property is preserved by arbitrary disjoint unions.
+- $X$ satisfies this property iff all its countable subspaces do.

--- a/spaces/S000078/README.md
+++ b/spaces/S000078/README.md
@@ -9,7 +9,8 @@ refs:
     name: Tychonoff plank on Wikipedia
 ---
 
-The space $[0,\omega_1] \times [0,\omega]$ where each factor has the order topology.
+The space $[0,\omega_1] \times [0,\omega]$ where each factor has the order topology;
+that is, the product of {S36} and {S20}.
 
 Defined as counterexample #86 ("Tychonoff Plank")
 in {{zb:0386.54001}}.

--- a/spaces/S000078/properties/P000081.md
+++ b/spaces/S000078/properties/P000081.md
@@ -7,4 +7,5 @@ refs:
   name: Counterexamples in Topology
 ---
 
-{P81} is a hereditary property.  The space contains as a subspace a copy of {S36}, which is not {P81}.
+{S36} is homeomorphic to a subspace of $X$
+and {S36|P81}.

--- a/spaces/S000078/properties/P000210.md
+++ b/spaces/S000078/properties/P000210.md
@@ -1,0 +1,8 @@
+---
+space: S000078
+property: P000210
+value: true
+---
+
+{S36|P210} and {S20|P210},
+hence so is their product.

--- a/spaces/S000091/properties/P000210.md
+++ b/spaces/S000091/properties/P000210.md
@@ -1,0 +1,9 @@
+---
+space: S000091
+property: P000210
+value: true
+---
+
+{S154|P210} and
+{S20|P210},
+hence so is their product, which contains $X$ as a homeomorphic subspace.

--- a/spaces/S000181/properties/P000210.md
+++ b/spaces/S000181/properties/P000210.md
@@ -1,0 +1,8 @@
+---
+space: S000181
+property: P000210
+value: true
+---
+
+$X$ is a subspace of a countable product of {P210} spaces,
+since {S36|P210}.

--- a/spaces/S000191/properties/P000210.md
+++ b/spaces/S000191/properties/P000210.md
@@ -1,0 +1,8 @@
+---
+space: S000191
+property: P000210
+value: true
+---
+
+{S155|P210} and {S20|P210},
+hence so is their product.

--- a/spaces/S000218/properties/P000210.md
+++ b/spaces/S000218/properties/P000210.md
@@ -1,0 +1,8 @@
+---
+space: S000218
+property: P000210
+value: true
+---
+
+{S35|P210} and {S36|P210},
+hence so is their product.


### PR DESCRIPTION
The $\alpha_i$ properties for $i=1,1.5,2,3$ are preserved by countable products.

There is a paper by Nogura that proves it for $i=1,2,3$ for Hausdorff spaces.  I provided a proof in general in https://math.stackexchange.com/questions/5122756.  (Need to add the case $\alpha_{1.5}$ to that mathse post, will do it right now).

This allows to assert the $\alpha_1$ trait for six more spaces.

Plus various other metaproperties.
