### PR TITLE
Hereditarily connected => alpha_i

### DIFF
--- a/theorems/T000842.md
+++ b/theorems/T000842.md
@@ -1,0 +1,12 @@
+---
+uid: T000842
+if:
+  P000196: true
+then:
+  P000216: true
+refs:
+  - mathse: 5116649
+    name: Answer to "Do the Arkhangel'skii $\alpha_i$ properties hold for order topologies?"
+---
+
+See the remark to {{mathse:5116649}}.

--- a/theorems/T000842.md
+++ b/theorems/T000842.md
@@ -3,7 +3,7 @@ uid: T000842
 if:
   P000196: true
 then:
-  P000216: true
+  P000210: true
 refs:
   - mathse: 5116649
     name: Answer to "Do the Arkhangel'skii $\alpha_i$ properties hold for order topologies?"


### PR DESCRIPTION
You can use the same argument as for order topologies which we had earlier.
This doesnt actually give any new traits, but is not in the engnine, so why not..