### PR TITLE
Add LC^0 to locally path connected

### DIFF
--- a/properties/P000042.md
+++ b/properties/P000042.md
@@ -1,6 +1,9 @@
 ---
 uid: P000042
 name: Locally path connected
+aliases:
+  - $LC^0$
+  - Locally $0$-connected
 refs:
   - zb: "1342.30054"
     name: The Mazurkiewicz distance and sets that are finitely connected at the boundary (Björn, Björn, Shanmugalingam)
@@ -8,6 +11,8 @@ refs:
     name: Locally connected space on Wikipedia
   - zb: "0386.54001"
     name: Counterexamples in Topology
+  - mathse: 3002235
+    name: Answer to "Definition of locally pathwise connected"
 ---
 
 The topology of $X$ has a base consisting of {P37} open sets.
@@ -22,10 +27,15 @@ that is, each $x$ has a neighborhood base consisting of open path connected sets
 * $X$ is *path connected im kleinen at $x$* for every $x\in X$;
 that is, each $x$ has a neighborhood base consisting of (not necessarily open) path connected sets.
 
+* ($LC^0$ = *locally $0$-connected*) For each $x\in X$, every neighborhood $U$ of $x$
+contains a neighborhood $V$ of $x$ such that every continuous $\phi:S^0\to V$
+is null-homotopic in $U$ (where $S^0=\{-1,1\}$ with the discrete topology).
+
 Note: In general, local path connectedness at a point $x$ is not equivalent to path connectedness im kleinen at $x$.
 But the corresponding global statements (where the condition holds at every point) are equivalent.
 
-For terminology and the equivalence between the conditions above, see section 2 of {{zb:1342.30054}} and {{wikipedia:Locally_connected_space}}, plus the references therein.
+For terminology and the equivalence between the conditions above, see section 2 of {{zb:1342.30054}} and {{wikipedia:Locally_connected_space}}, plus the references therein,
+and also {{mathse:3002235}}.
 
 Defined on page 30 of {{zb:0386.54001}}.
 


### PR DESCRIPTION
Add $LC^0$ characterization of locally path connected (P42).

This will be handy when we add $LC^1$ as one of the "locally simply connected" variants.