### PR TITLE
Slightly strengthen T685: Non-trivial closed manifolds are not contractible

### DIFF
--- a/theorems/T000685.md
+++ b/theorems/T000685.md
@@ -22,6 +22,6 @@ a closed $n$-manifold as a space which is {P123}, {P3}, and {P16}.
 Hence $M$ is a closed $n$-manifold in this sense. It follows from the remark after Theorem 3.26 in the same section that $H_n(M; \mathbb Z_2) = \mathbb Z_2$; 
 
 But since $M$ is {P199}, we have $H_n(M; \mathbb Z_2) = 0$ for all $n \geq 1$.
-This forces $n = 0$ and therefore $M$ is {S162}.
+This forces $n = 0$. Therefore $M$ is {S162}.
 
 See also {{mathse:418509}}.


### PR DESCRIPTION
This is a free improvement since the text of Hatcher's Section 3.3 defines an n-manifold without requiring second countable.

Edit: Actually I realized this improvement is trivial (or perhaps stylistic) because compact + locally Euclidean already implies second countable. It's more faithful to the text of our reference, but I think I'll just close this.

[π-Base, Search for `compact + Locally Euclidean + ~sec`](https://topology.pi-base.org/spaces?q=compact+%2B+Locally+Euclidean+%2B+%7Esec)