### PR TITLE
Mark some properties as hereditary

### DIFF
--- a/properties/P000003.md
+++ b/properties/P000003.md
@@ -16,4 +16,5 @@ Defined on page 11 of {{zb:0386.54001}}.
 ----
 #### Meta-properties
 
+- This property is hereditary.
 - The Kolmogorov quotient $\text{Kol}(X)$ is {P3} iff $X$ is {P134}.

--- a/properties/P000004.md
+++ b/properties/P000004.md
@@ -21,3 +21,8 @@ respectively, such that $cl(O_a)$ and $cl(O_b)$ are disjoint.
 Defined as "Urysohn" in 14F of {{zb:1052.54001}}.
 Defined as "completely Hausdorff" and $T_{2\frac{1}{2}}$ on page 13 of
 {{zb:0386.54001}}.
+
+----
+#### Meta-properties
+
+- This property is hereditary.

--- a/properties/P000009.md
+++ b/properties/P000009.md
@@ -18,3 +18,8 @@ Given any two distinct $a,b \in X$ there is a continuous function $f:X \rightarr
 
 Defined as "completely Hausdorff"/"functionally Hausdorff" in 14G of {{zb:1052.54001}}.
 Defined as "Urysohn" on page 16 of {{zb:0386.54001}}.
+
+----
+#### Meta-properties
+
+- This property is hereditary.

--- a/properties/P000011.md
+++ b/properties/P000011.md
@@ -19,4 +19,5 @@ See Definition 14.1 and Theorem 14.3 in {{zb:1052.54001}}.
 ----
 #### Meta-properties
 
+- This property is hereditary.
 - $X$ is {P11} iff its Kolmogorov quotient $\text{Kol}(X)$ is {P5}.

--- a/properties/P000014.md
+++ b/properties/P000014.md
@@ -18,3 +18,8 @@ Equivalently, any two *separated sets* (sets for which each misses the other's c
 can be placed into disjoint open sets.
 
 Defined on page 11 of {{zb:0386.54001}} (as $T_5$).
+
+----
+#### Meta-properties
+
+- This property is hereditary.

--- a/properties/P000027.md
+++ b/properties/P000027.md
@@ -9,3 +9,8 @@ refs:
 A space with a countable basis.
 
 Defined on page 7 of {{zb:0386.54001}}.
+
+----
+#### Meta-properties
+
+- This property is hereditary.

--- a/properties/P000048.md
+++ b/properties/P000048.md
@@ -16,3 +16,8 @@ $x\in A$ and $y\not\in A$.
 Defined on page 32 of {{zb:0386.54001}}.
 
 Some authors (for example {{zb:0684.54001}}) use "totally disconnected" to mean {P48} and "hereditarily disconnected" to mean {P47}.
+
+----
+#### Meta-properties
+
+- This property is hereditary.


### PR DESCRIPTION
This PR adds the "hereditary" property to all spaces up to 50 which are in fact hereditary.

All the ones not marked here (up to 50) ought to be in fact now hereditary. In preparation for an eventual proper implementation, this might be useful to know.

I prepared this PR (to make the entries) with Claude code, but figured out which properties are hereditary completely myself (with spreadsheet).