### PR TITLE
Rename UID of S1103

### DIFF
--- a/spaces/S000222/README.md
+++ b/spaces/S000222/README.md
@@ -1,5 +1,5 @@
 ---
-uid: S001103
+uid: S000222
 name: Product topology on $\omega^{2^\mathfrak{c}}$
 aliases:
   - Uncountable product of $\mathbb Z^+$

--- a/spaces/S000222/properties/P000013.md
+++ b/spaces/S000222/properties/P000013.md
@@ -1,5 +1,5 @@
 ---
-space: S001103
+space: S000222
 property: P000013
 value: false
 refs:

--- a/spaces/S000222/properties/P000029.md
+++ b/spaces/S000222/properties/P000029.md
@@ -1,5 +1,5 @@
 ---
-space: S001103
+space: S000222
 property: P000029
 value: true
 refs:

--- a/spaces/S000222/properties/P000050.md
+++ b/spaces/S000222/properties/P000050.md
@@ -1,5 +1,5 @@
 ---
-space: S001103
+space: S000222
 property: P000050
 value: true
 ---

--- a/spaces/S000222/properties/P000059.md
+++ b/spaces/S000222/properties/P000059.md
@@ -1,5 +1,5 @@
 ---
-space: S001103
+space: S000222
 property: P000059
 value: false
 ---

--- a/spaces/S000222/properties/P000081.md
+++ b/spaces/S000222/properties/P000081.md
@@ -1,6 +1,6 @@
 ---
-space: S001103
-property: P000103
+space: S000222
+property: P000081
 value: false
 refs:
 - zb: "0684.54001"
@@ -11,7 +11,7 @@ The space contains a subspace homeomorphic to the Cantor cube $\{0,1\}^{\aleph_1
 which, according to Theorem 6.2.16 in {{zb:0684.54001}}, contains
 a copy of {S36}, since {S36|P50},
 is {P2} and has weight $\aleph_1$.
-And {S36|P103}.
+And {S36|P81}.
 
 <!-- The proof should be written once, for an uncountable "Cantor cube",
 if ever added; Embedding of \omega_1+1 into a Cantor cube can be used. -->

--- a/spaces/S000222/properties/P000087.md
+++ b/spaces/S000222/properties/P000087.md
@@ -1,5 +1,5 @@
 ---
-space: S001103
+space: S000222
 property: P000087
 value: true
 ---

--- a/spaces/S000222/properties/P000103.md
+++ b/spaces/S000222/properties/P000103.md
@@ -1,6 +1,6 @@
 ---
-space: S001103
-property: P000081
+space: S000222
+property: P000103
 value: false
 refs:
 - zb: "0684.54001"
@@ -11,7 +11,7 @@ The space contains a subspace homeomorphic to the Cantor cube $\{0,1\}^{\aleph_1
 which, according to Theorem 6.2.16 in {{zb:0684.54001}}, contains
 a copy of {S36}, since {S36|P50},
 is {P2} and has weight $\aleph_1$.
-And {S36|P81}.
+And {S36|P103}.
 
 <!-- The proof should be written once, for an uncountable "Cantor cube",
 if ever added; Embedding of \omega_1+1 into a Cantor cube can be used. -->

--- a/spaces/S000222/properties/P000140.md
+++ b/spaces/S000222/properties/P000140.md
@@ -1,5 +1,5 @@
 ---
-space: S001103
+space: S000222
 property: P000140
 value: false
 refs:

--- a/spaces/S000222/properties/P000162.md
+++ b/spaces/S000222/properties/P000162.md
@@ -1,5 +1,5 @@
 ---
-space: S001103
+space: S000222
 property: P000162
 value: true
 ---

--- a/spaces/S000222/properties/P000164.md
+++ b/spaces/S000222/properties/P000164.md
@@ -1,5 +1,5 @@
 ---
-space: S001103
+space: S000222
 property: P000164
 value: true
 ---

--- a/spaces/S000222/properties/P000172.md
+++ b/spaces/S000222/properties/P000172.md
@@ -1,5 +1,5 @@
 ---
-space: S001103
+space: S000222
 property: P000172
 value: false
 ---

--- a/spaces/S000222/properties/P000191.md
+++ b/spaces/S000222/properties/P000191.md
@@ -1,9 +1,9 @@
 ---
-space: S001103
+space: S000222
 property: P000191
 value: false
 ---
 
 {S101}
-can be embedded as a subspace of {S1103}
+can be embedded as a subspace of {S222}
 and {S101|P191}.

--- a/spaces/S000222/properties/P000197.md
+++ b/spaces/S000222/properties/P000197.md
@@ -1,5 +1,5 @@
 ---
-space: S001103
+space: S000222
 property: P000197
 value: false
 ---

--- a/spaces/S000222/properties/P000206.md
+++ b/spaces/S000222/properties/P000206.md
@@ -1,5 +1,5 @@
 ---
-space: S001103
+space: S000222
 property: P000206
 value: true
 ---

--- a/spaces/S000222/properties/P000209.md
+++ b/spaces/S000222/properties/P000209.md
@@ -1,5 +1,5 @@
 ---
-space: S001103
+space: S000222
 property: P000209
 value: true
 refs:

--- a/spaces/S000222/properties/P000214.md
+++ b/spaces/S000222/properties/P000214.md
@@ -1,5 +1,5 @@
 ---
-space: S001103
+space: S000222
 property: P000214
 value: false
 refs:

--- a/spaces/S000222/properties/P000227.md
+++ b/spaces/S000222/properties/P000227.md
@@ -1,5 +1,5 @@
 ---
-space: S001103
+space: S000222
 property: P000227
 value: true
 ---


### PR DESCRIPTION
It has always confused that for some reason there is a space S1103. I think this may have to do with S101? In any case, it's prettier not to have 1 big UID for no reason.