### PR TITLE
add "crowded" and "dense-in-itself" aliases

### DIFF
--- a/properties/P000139.md
+++ b/properties/P000139.md
@@ -8,7 +8,7 @@ refs:
 - mathse: 3823020
   name: "Reference request: crowded space"
 - wikipedia: Dense-in-itself
-  name: "Dense in itself on Wikipedia"
+  name: "Dense-in-itself on Wikipedia"
 ---
 
 Some singleton $\{x\}\subseteq X$ is an open set.


### PR DESCRIPTION
Several talks at STDC 2026 have used these terminologies, and I realized we don't have them in our property list.

Could probably use better reference than @prabau's random Math SE post.