### PR TITLE
Hereditarily connected non-separable spaces are strongly Choquet

### DIFF
--- a/theorems/T000646.md
+++ b/theorems/T000646.md
@@ -9,8 +9,8 @@ then:
 ---
 
 Player 2 can win by choosing $V_n=U_n$ in each round.
-Indeed, the countable set $\{x_n:x<\omega\}$ is not dense in $X$.
-Hence there is a nonempty open set $W$ not containing any of the $x_n$,
+Indeed, since the countable set $\{x_n:x<\omega\}$ is not dense in $X$,
+there is a nonempty open set $W$ not containing any of the $x_n$,
 and thus not containing any of the $U_n$.
 Since $X$ is {P196}, $W$ is contained in all the $U_n$.
 It follows that $\bigcap_n U_n\ne\emptyset$.


### PR DESCRIPTION
New theorem: Hereditarily connected (P196) + not separable (P26) => strongly Choquet (P206).

This allows to derive that the two "right ray topologies" on $\omega_1$ (S220 and S221) are strongly Choquet.
