### PR TITLE
Hereditary traits for Sorgenfrey plane (S76)

### DIFF
--- a/spaces/S000076/properties/P000093.md
+++ b/spaces/S000076/properties/P000093.md
@@ -1,0 +1,7 @@
+---
+space: S000076
+property: P000093
+value: false
+---
+
+$X$ contains {S43} as a subspace and {S43|P93}.

--- a/spaces/S000076/properties/P000102.md
+++ b/spaces/S000076/properties/P000102.md
@@ -1,0 +1,7 @@
+---
+space: S000076
+property: P000102
+value: false
+---
+
+$X$ contains {S43} as a subspace and {S43|P102}.

--- a/spaces/S000076/properties/P000177.md
+++ b/spaces/S000076/properties/P000177.md
@@ -1,0 +1,7 @@
+---
+space: S000076
+property: P000177
+value: false
+---
+
+$X$ contains {S43} as a subspace and {S43|P177}.


### PR DESCRIPTION
Traits automatically deduced by tracking subspaces for the Sorgenfrey plane (S76). This PR was created with the help of Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)