### PR TITLE
Add Ellentuck topology S000223.

### DIFF
--- a/spaces/S000223/README.md
+++ b/spaces/S000223/README.md
@@ -17,4 +17,6 @@ $$[s, A] = \{B \in X: s \subseteq B \subseteq s \cup A \;\text{ and }\; \max(s) 
 for a finite $s\subseteq\omega$ and an infinite $A\subseteq\omega$.
 If $s = \emptyset$ we let $\max(s) = -1$.
 
+*Note*: Omitting the condition $\max(s) < \min(B \setminus s)$ would give another base for the same topology, but the form chosen above is usually more convenient.
+
 Introduced by Ellentuck in {{zb:0292.02054}} (<https://www.jstor.org/stable/2272356>). See also Definition 26.25 in {{zb:1007.03002}} and the section "The Ellentuck Topology" on p. 248 of {{zb:1400.03002}}

--- a/spaces/S000223/README.md
+++ b/spaces/S000223/README.md
@@ -1,6 +1,6 @@
 ---
 uid: S000223
-name: Ellentuck topology
+name: Ellentuck topology on $[\omega]^\omega$
 refs:
   - zb: "0546.03029"
     name: Random isols (E. Ellentuck)

--- a/spaces/S000223/README.md
+++ b/spaces/S000223/README.md
@@ -3,7 +3,7 @@ uid: S000223
 name: Ellentuck topology
 refs:
   - zb: "0546.03029"
-    name: Random isols.
+    name: Random isols (E. Ellentuck)
 ---
 
 Let $X = [\omega]^\omega$, the set of infinite sets of natural numbers, and give it the basis consisting of $[s, A] = \{B \in X: s \subseteq B \subseteq A \cup s \land \max(s) < \min(B \setminus s)\}$ for finite and infinite, respectively, $s, A \subseteq \omega$. If $s = \emptyset$ we let $\max(s) = 0$.

--- a/spaces/S000223/README.md
+++ b/spaces/S000223/README.md
@@ -2,13 +2,19 @@
 uid: S000223
 name: Ellentuck topology on $[\omega]^\omega$
 refs:
-  - zb: "0546.03029"
-    name: Random isols (E. Ellentuck)
+  - zb: "0292.02054"
+    name: A new proof that analytic sets are Ramsey (E. Ellentuck)
+  - zb: "1007.03002"
+    name: Set theory. The third millennium edition, revised and expanded (T. Jech)
+  - zb: "1400.03002"
+    name: Combinatorial set theory. With a gentle introduction to forcing. 2nd edition (L. J. Halbeisen)
 ---
 
-Let $X = [\omega]^\omega$, the set of infinite sets of natural numbers, and give it the topology with basis consisting of all sets
+Let $X = [\omega]^\omega$, the set of infinite sets of nonnegative integers, and give it the topology with basis consisting of all sets
 
 $$[s, A] = \{B \in X: s \subseteq B \subseteq s \cup A \;\text{ and }\; \max(s) < \min(B \setminus s)\}$$
 
 for a finite $s\subseteq\omega$ and an infinite $A\subseteq\omega$.
-If $s = \emptyset$ we let $\max(s) = 0$.
+If $s = \emptyset$ we let $\max(s) = -1$.
+
+Introduced by Ellentuck in {{zb:0292.02054}} (<https://www.jstor.org/stable/2272356>). See also Definition 26.25 in {{zb:1007.03002}} and the section "The Ellentuck Topology" on p. 248 of {{zb:1400.03002}}

--- a/spaces/S000223/README.md
+++ b/spaces/S000223/README.md
@@ -5,9 +5,9 @@ refs:
   - zb: "0292.02054"
     name: A new proof that analytic sets are Ramsey (E. Ellentuck)
   - zb: "1007.03002"
-    name: Set theory. The third millennium edition, revised and expanded (T. Jech)
+    name: Set theory (T. Jech, 2003)
   - zb: "1400.03002"
-    name: Combinatorial set theory. With a gentle introduction to forcing. 2nd edition (L. J. Halbeisen)
+    name: Combinatorial set theory (L. Halbeisen, 2017)
 ---
 
 Let $X = [\omega]^\omega$, the set of infinite sets of nonnegative integers, and give it the topology with basis consisting of all sets

--- a/spaces/S000223/README.md
+++ b/spaces/S000223/README.md
@@ -1,0 +1,9 @@
+---
+uid: S000223
+name: Ellentuck topology
+refs:
+  - zb: "0546.03029"
+    name: Random isols.
+---
+
+Let $X = [\omega]^\omega$, the set of infinite sets of natural numbers, and give it the basis consisting of $[s, A] = \{B \in X: s \subseteq B \subseteq A \cup s \land \max(s) < \min(B \setminus s)\}$ for finite and infinite, respectively, $s, A \subseteq \omega$. If $s = \emptyset$ we let $\max(s) = 0$.

--- a/spaces/S000223/README.md
+++ b/spaces/S000223/README.md
@@ -6,4 +6,9 @@ refs:
     name: Random isols (E. Ellentuck)
 ---
 
-Let $X = [\omega]^\omega$, the set of infinite sets of natural numbers, and give it the basis consisting of $[s, A] = \{B \in X: s \subseteq B \subseteq A \cup s \land \max(s) < \min(B \setminus s)\}$ for finite and infinite, respectively, $s, A \subseteq \omega$. If $s = \emptyset$ we let $\max(s) = 0$.
+Let $X = [\omega]^\omega$, the set of infinite sets of natural numbers, and give it the topology with basis consisting of all sets
+
+$$[s, A] = \{B \in X: s \subseteq B \subseteq s \cup A \;\text{ and }\; \max(s) < \min(B \setminus s)\}$$
+
+for a finite $s\subseteq\omega$ and an infinite $A\subseteq\omega$.
+If $s = \emptyset$ we let $\max(s) = 0$.

--- a/spaces/S000223/properties/P000013.md
+++ b/spaces/S000223/properties/P000013.md
@@ -8,3 +8,4 @@ refs:
 ---
 
 See the remark after Proposition 4 of {{zb:0632.04005}}.
+$X$ is shown to be non-normal by applying Jones' lemma ({T836}) to a certain closed subspace $F\subseteq X$.

--- a/spaces/S000223/properties/P000013.md
+++ b/spaces/S000223/properties/P000013.md
@@ -4,7 +4,7 @@ property: P000013
 value: false
 refs:
   - zb: "0632.04005"
-    name: On completely Ramsey sets.
+    name: On completely Ramsey sets (S. Plewik)
 ---
 
 See the remark after Proposition 4 of {{zb:0632.04005}}.

--- a/spaces/S000223/properties/P000013.md
+++ b/spaces/S000223/properties/P000013.md
@@ -1,0 +1,10 @@
+---
+space: S000223
+property: P000013
+value: false
+refs:
+  - zb: "0632.04005"
+    name: On completely Ramsey sets.
+---
+
+See the remark after Proposition 4 of {{zb:0632.04005}}.

--- a/spaces/S000223/properties/P000028.md
+++ b/spaces/S000223/properties/P000028.md
@@ -1,0 +1,7 @@
+---
+space: S000223
+property: P000028
+value: true
+---
+
+$\{[x \cap n, x]: n < \omega\}$ is a countable local base around $x$, for any $x \in [\omega]^\omega$: if $s, A$ are so that $x \in [s, A]$, that is $s \subseteq x \subseteq A \cup s$ and $\max(s) < \min(x \setminus s)$, then $s = x \cap (\max(s) + 1)$ and $[s, x] \subseteq [s, A]$. 

--- a/spaces/S000223/properties/P000029.md
+++ b/spaces/S000223/properties/P000029.md
@@ -4,4 +4,4 @@ property: P000029
 value: false
 ---
 
-For $x: \omega \to 2$, let $A_x = \left\{\sum_{n = 0}^m x(n): m < \omega\right\}$. Then, when $x \neq y$, $A_x \cap A_y$ is finite, and so $\{[\emptyset, A_x]: x \in 2^\omega\}$ is an uncountable family of pairwise disjoint nonempty open sets.
+For $x: \omega \to 2$, let $A_x = \left\{\sum_{n = 0}^m 2^n x(n): m < \omega\right\}$. Then, when $x \neq y$, $A_x \cap A_y$ is finite, and so $\{[\emptyset, A_x]: x \in 2^\omega\}$ is an uncountable family of pairwise disjoint nonempty open sets.

--- a/spaces/S000223/properties/P000029.md
+++ b/spaces/S000223/properties/P000029.md
@@ -1,0 +1,7 @@
+---
+space: S000223
+property: P000029
+value: false
+---
+
+For $x: \omega \to 2$, let $A_x = \left\{\sum_{n = 0}^m x(n): m < \omega\right\}$. Then, when $x \neq y$, $A_x \cap A_y$ is finite, and so $\{[\emptyset, A_x]: x \in 2^\omega\}$ is an uncountable family of pairwise disjoint nonempty open sets.

--- a/spaces/S000223/properties/P000050.md
+++ b/spaces/S000223/properties/P000050.md
@@ -1,0 +1,7 @@
+---
+space: S000223
+property: P000050
+value: true
+---
+
+Each set $[s, A]$, where $s$ and $A$ are finite and infinite, respectively, is clopen, and they form a basis by construction. Namely, if $x \notin [s, A]$, either $x \not \subseteq A \cup s$, in which case we let $t = x \cap (\min(x \setminus (A \cup s)) + 1)$, or $s \not \subseteq x$ or $\min(x \setminus s) \leq \max(s)$, in which case we let $t = (x \cap s) \cup \{\min(x \setminus s)\}$, or else $s \not \subseteq x$. Then $x \in [t, x]$ and $[t, x] \cap [s, A] = \emptyset$.

--- a/spaces/S000223/properties/P000050.md
+++ b/spaces/S000223/properties/P000050.md
@@ -4,4 +4,8 @@ property: P000050
 value: true
 ---
 
-Each set $[s, A]$, where $s$ and $A$ are finite and infinite, respectively, is clopen, and they form a basis by construction. Namely, if $x \notin [s, A]$, either $x \not \subseteq A \cup s$, in which case we let $t = x \cap (\min(x \setminus (A \cup s)) + 1)$, or $s \not \subseteq x$ or $\min(x \setminus s) \leq \max(s)$, in which case we let $t = (x \cap s) \cup \{\min(x \setminus s)\}$, or else $s \not \subseteq x$. Then $x \in [t, x]$ and $[t, x] \cap [s, A] = \emptyset$.
+Each basic open set $[s, A]$ with $s$ finite and $A$ infinite is clopen.
+Indeed, suppose $x\notin[s,A]$.
+If $x\cap[0,\max(s)]\ne s$, let $t=x\cap[0,\max(s)]$.
+Otherwise, necessarily $s\subseteq x$ and $\max(s)<\min(x\setminus s)$, and therefore $x\not\subseteq(s\cup A)$, in which case let $t=x\cap[0,\min(x\setminus(s\cup A)]$.
+In both cases, $x \in [t, x]$ and $[t, x] \cap [s, A] = \emptyset$.

--- a/spaces/S000223/properties/P000064.md
+++ b/spaces/S000223/properties/P000064.md
@@ -1,0 +1,10 @@
+---
+space: S000223
+property: P000064
+value: true
+refs:
+  - zb: "0292.02054"
+    name: A new proof that analytic sets are Ramsey.
+---
+
+It is a theorem of Ellentuck that a countable union of nowhere dense sets is nowhere dense (Corollary 8 of {{zb:0292.02054}}), which is a strong form of being Baire.

--- a/spaces/S000223/properties/P000064.md
+++ b/spaces/S000223/properties/P000064.md
@@ -4,7 +4,10 @@ property: P000064
 value: true
 refs:
   - zb: "0292.02054"
-    name: A new proof that analytic sets are Ramsey.
+    name: A new proof that analytic sets are Ramsey (E. Ellentuck)
+  - zb: "1007.03002"
+    name: Set theory (T. Jech, 2003)
 ---
 
-It is a theorem of Ellentuck that a countable union of nowhere dense sets is nowhere dense (Corollary 8 of {{zb:0292.02054}}), which is a strong form of being Baire.
+Every meager set in $X$ is nowhere dense, which is a strong form of being Baire.
+See Corollary 8 in {{zb:0292.02054}} (<https://www.jstor.org/stable/2272356>) or Lemma 26.27(ii) in {{zb:1007.03002}}.

--- a/spaces/S000223/properties/P000065.md
+++ b/spaces/S000223/properties/P000065.md
@@ -1,0 +1,7 @@
+---
+space: S000223
+property: P000065
+value: true
+---
+
+By construction.

--- a/spaces/S000223/properties/P000093.md
+++ b/spaces/S000223/properties/P000093.md
@@ -1,0 +1,7 @@
+---
+space: S000223
+property: P000093
+value: false
+---
+
+Every non-empty open set has cardinality $\mathfrak{c}$ by construction.

--- a/spaces/S000223/properties/P000139.md
+++ b/spaces/S000223/properties/P000139.md
@@ -4,4 +4,4 @@ property: P000139
 value: false
 ---
 
-Every open set has cardinality $\mathfrak{c}$ by construction.
+Every nonempty open set has cardinality $\mathfrak{c}$.

--- a/spaces/S000223/properties/P000139.md
+++ b/spaces/S000223/properties/P000139.md
@@ -1,0 +1,7 @@
+---
+space: S000223
+property: P000139
+value: false
+---
+
+Every open set has cardinality $\mathfrak{c}$ by construction.

--- a/spaces/S000223/properties/P000166.md
+++ b/spaces/S000223/properties/P000166.md
@@ -1,0 +1,7 @@
+---
+space: S000223
+property: P000166
+value: true
+---
+
+When one only considers open sets $[s, A]$ where $A = \omega$, i.e. $\{x \in [\omega]^\omega: s \subseteq x \land \max(s) < \min(x \setminus s)\}$, then, the resulting topology is strictly finer than the Ellentuck topology and homeomorphic to {S28}. Namely, conceiving {S28} as the set of infinite sequences of natural numbers, the map sending $\{a_n: n < \omega\}$, where $a_n < a_m$ for $n < m$, to $f: \omega \to \omega$ given by $f(0) = a_0$ and $f(n+1) = a_{n+1} - (a_n + 1)$, is a homeomorphism.

--- a/spaces/S000223/properties/P000166.md
+++ b/spaces/S000223/properties/P000166.md
@@ -4,4 +4,4 @@ property: P000166
 value: true
 ---
 
-When one only considers open sets $[s, A]$ where $A = \omega$, i.e. $\{x \in [\omega]^\omega: s \subseteq x \land \max(s) < \min(x \setminus s)\}$, then, the resulting topology is strictly finer than the Ellentuck topology and homeomorphic to {S28}. Namely, conceiving {S28} as the set of infinite sequences of natural numbers, the map sending $\{a_n: n < \omega\}$, where $a_n < a_m$ for $n < m$, to $f: \omega \to \omega$ given by $f(0) = a_0$ and $f(n+1) = a_{n+1} - (a_n + 1)$, is a homeomorphism.
+When one only considers open sets $[s, A]$ where $A = \omega$, i.e. $\{x \in [\omega]^\omega: s \subseteq x \land \max(s) < \min(x \setminus s)\}$, then, the resulting topology is strictly coarser than the Ellentuck topology and homeomorphic to {S28}. Namely, conceiving {S28} as the set of infinite sequences of natural numbers, the map sending $\{a_n: n < \omega\}$, where $a_n < a_m$ for $n < m$, to $f: \omega \to \omega$ given by $f(0) = a_0$ and $f(n+1) = a_{n+1} - (a_n + 1)$, is a homeomorphism.


### PR DESCRIPTION
I added the Ellentuck topology, a topology of cardinality continuum which is frequent in combinatorial set theory, and included references or proofs for its following properties: not normal; first countable; not ccc; zero dimensional; Baire; cardinality continuum; not locally countable; has no isolated points; has a coarser separable metrizable topology. Even omitting the "not ccc" and "not locally countable", no space in pi-base right now has this combination of properties, so I think it's valuable to add. All feedback is appreciated!