### PR TITLE
Locally contractible initial PR

### DIFF
--- a/properties/P000223.md
+++ b/properties/P000223.md
@@ -1,8 +1,11 @@
 ---
 uid: P000223
 name: Locally contractible
+refs:
+  - zb: "1044.55001"
+    name: Algebraic Topology (Hatcher)
 ---
 
 $X$ admits a basis of open sets which are {P199}.
 
-The naming of this property follows pi-base conventions.
+The naming of this property follows pi-base conventions. Defined in Proposition A.4 of {{zb:"1044.55001"}}. 

--- a/properties/P000223.md
+++ b/properties/P000223.md
@@ -8,4 +8,6 @@ refs:
 
 $X$ admits a basis of open sets which are {P199}.
 
+Equivalently, for each $x \in X$, every neighborhood of $x$ contains a contractible open neighborhood of $x$.
+
 The naming of this property follows pi-base conventions. Defined in Proposition A.4 of {{zb:"1044.55001"}}. 

--- a/properties/P000223.md
+++ b/properties/P000223.md
@@ -1,0 +1,8 @@
+---
+uid: P000223
+name: Locally contractible
+---
+
+$X$ admits a basis of open sets which are {P199}.
+
+The naming of this property follows pi-base conventions.

--- a/properties/P000223.md
+++ b/properties/P000223.md
@@ -10,4 +10,4 @@ $X$ admits a basis of open sets which are {P199}.
 
 Equivalently, for each $x \in X$, every neighborhood of $x$ contains a contractible open neighborhood of $x$.
 
-"Locally contractible" is used in {{zb:1044.55001}}, where it is defined informally with the meaning above as part of the statement of Proposition A.4 on page 522.  (As explained on page 61, the book follows the convention of a space being "locally P" for a property P to mean that every point has arbitrarily small open neighborhoods with the property; this is very close to the general convention used in pi-base.)
+"Locally contractible" is used in {{zb:1044.55001}}, where it is defined informally with the meaning above as part of the statement of Proposition A.4 on page 522.  (As explained on page 61, the book follows the convention of a space being "locally P" for a property P to mean that every point has arbitrarily small open neighborhoods with the property; this is very close to the [general convention used in pi-base](https://github.com/pi-base/data/wiki/Conventions-and-Style#Local-Properties).)

--- a/properties/P000223.md
+++ b/properties/P000223.md
@@ -10,4 +10,4 @@ $X$ admits a basis of open sets which are {P199}.
 
 Equivalently, for each $x \in X$, every neighborhood of $x$ contains a contractible open neighborhood of $x$.
 
-The naming of this property follows pi-base conventions. Defined in Proposition A.4 of {{zb:"1044.55001"}}. 
+"Locally contractible" is used in {{zb:1044.55001}}, where it is defined informally with the meaning above as part of the statement of Proposition A.4 on page 522.  (As explained on page 61, the book follows the convention of a space being "locally P" for a property P to mean that every point has arbitrarily small open neighborhoods with the property; this is very close to the general convention used in pi-base.)

--- a/properties/P000223.md
+++ b/properties/P000223.md
@@ -8,6 +8,6 @@ refs:
 
 $X$ admits a basis of open sets which are {P199}.
 
-Equivalently, for each $x \in X$, every neighborhood of $x$ contains a contractible open neighborhood of $x$.
+Equivalently, for each $x \in X$, every neighborhood of $x$ contains a {P199} open neighborhood of $x$.
 
 "Locally contractible" is used in {{zb:1044.55001}}, where it is defined informally with the meaning above as part of the statement of Proposition A.4 on page 522.  (As explained on page 61, the book follows the convention of a space being "locally P" for a property P to mean that every point has arbitrarily small open neighborhoods with the property; this is very close to the [general convention used in pi-base](https://github.com/pi-base/data/wiki/Conventions-and-Style#Local-Properties).)

--- a/properties/P000224.md
+++ b/properties/P000224.md
@@ -1,0 +1,13 @@
+---
+uid: P000224
+name: Weakly locally contractible
+refs:
+  - zb: "0087.38203"
+    name: On fiber spaces (Fadell)
+  - zb: "0642.54014"
+    name: LECS, local mixers, topological groups and special products (Borges)
+---
+
+Every point of $X$ has a neighborhood which is {P199}. 
+
+The naming of this property follows pi-base conventions. The name "weakly locally contractible" is commonly used in literature instead as an alias for "semi-locally contractible"; see for instance {{zb:"0087.38203"}} and {{zb:"0642.54014"}}.

--- a/properties/P000224.md
+++ b/properties/P000224.md
@@ -10,4 +10,8 @@ refs:
 
 Every point of $X$ has a neighborhood which is {P199}. 
 
-The naming of this property follows pi-base conventions. The name "weakly locally contractible" is commonly used in literature instead as an alias for "semi-locally contractible"; see for instance {{zb:0087.38203}} and {{zb:0642.54014}}.
+The name we have chosen for this property conforms to the [pi-base naming conventions](https://github.com/pi-base/data/wiki/Conventions-and-Style#Local-Properties) and fits well with related properties.
+However, we have not seen this property mentioned with a specific name in the literature.
+
+The terminology "weakly locally contractible" has been used for multiple concepts different from this one, but the name is not standardized.
+A relatively common usage among those is as a synonym for "semilocally contractible" (see {{zb:0087.38203}} and {{zb:0642.54014}}).

--- a/properties/P000224.md
+++ b/properties/P000224.md
@@ -10,7 +10,7 @@ refs:
 
 Every point of $X$ has a neighborhood which is {P199}. 
 
-The name we have chosen for this property conforms to the [pi-base naming conventions](https://github.com/pi-base/data/wiki/Conventions-and-Style#Local-Properties) and fits well with related properties.
+The name we have chosen for this property conforms to the [pi-base naming conventions](https://github.com/pi-base/data/wiki/Conventions-and-Style#Local-Properties).
 However, we have not seen this property mentioned with a specific name in the literature.
 
 The terminology "weakly locally contractible" has been used for multiple concepts different from this one, but the name is not standardized.

--- a/properties/P000224.md
+++ b/properties/P000224.md
@@ -10,4 +10,4 @@ refs:
 
 Every point of $X$ has a neighborhood which is {P199}. 
 
-The naming of this property follows pi-base conventions. The name "weakly locally contractible" is commonly used in literature instead as an alias for "semi-locally contractible"; see for instance {{zb:"0087.38203"}} and {{zb:"0642.54014"}}.
+The naming of this property follows pi-base conventions. The name "weakly locally contractible" is commonly used in literature instead as an alias for "semi-locally contractible"; see for instance {{zb:0087.38203}} and {{zb:0642.54014}}.

--- a/properties/P000225.md
+++ b/properties/P000225.md
@@ -1,0 +1,23 @@
+---
+uid: P000225
+name: $LC$
+aliases:
+  - Locally contractible
+refs:
+  - zb: "0153.52905"
+    name: Theory of retracts (Borsuk)
+  - zb: "1280.54001"
+    name: Geometric aspects of general topology. (Sakai)
+  - zb: "1059.54001"
+    name: Encyclopedia of general topology
+---
+
+$X$ is $LC$ if every neighborhood $U$ of any point $x$ contains a neighborhood $V$ of $x$ that is contractible in $U$. 
+
+Equivalently, $X$ is locally contractible at each of its points. A space $X$ is *locally contractible at a point* $x \in X$ if every neighborhood $U$ of $x$ contains a neighborhood $V$ of $x$ such that the inclusion map $V \to U$ is null-homotopic.
+
+This is the standard definition of "locally contractible" in the theory of ANRs. Defined as "locally contractible" on page 28 of {{zb:0153.52905}}, page 347 of {{zb:"1280.54001"}}, and page 341 of {{zb:"1059.54001"}}.
+
+----
+#### Meta-properties
+- This property is preserved by retractions (Theorem 15.3 on p. 28 of {{zb:0153.52905}}).

--- a/properties/P000225.md
+++ b/properties/P000225.md
@@ -14,7 +14,7 @@ refs:
 
 Every neighborhood $U$ of any point $x$ contains a neighborhood of $x$ that is contractible in $U$. 
 
-Equivalently, $X$ is locally contractible at each of its points. A space $X$ is *locally contractible at a point* $x \in X$ if every neighborhood $U$ of $x$ contains a neighborhood $V$ of $x$ such that the inclusion map $V \to U$ is null-homotopic.
+Equivalently, $X$ is *locally contractible at a point* $x$ for all $x \in X$, in the sense that every neighborhood $U$ of $x$ contains a neighborhood $V$ of $x$ such that the inclusion map $V \hookrightarrow U$ is null-homotopic.
 
 This is the standard definition of "locally contractible" in the theory of ANRs, as originally introduced by Borsuk. Defined as *locally contractible* on page 28 of {{zb:0153.52905}}, page 347 of {{zb:1280.54001}}, and page 341 of {{zb:1059.54001}}.
 

--- a/properties/P000225.md
+++ b/properties/P000225.md
@@ -19,7 +19,7 @@ i.e., such that the inclusion map $V \hookrightarrow U$ is null-homotopic.
 Equivalently, every neighborhood $U$ of any point $x$ contains a neighborhood (or an open neighborhood) $V$ of $x$
 such that the inclusion map $V \hookrightarrow U$ is homotopic to the constant map with value $x$.
 
-This is the standard definition of "locally contractible" in the theory of ANRs, as originally introduced by Borsuk. Defined as *locally contractible* on page 28 of {{zb:0153.52905}}, page 347 of {{zb:1280.54001}}, and page 341 of {{zb:1059.54001}}.
+This is the standard definition of "locally contractible" in the theory of ANRs, as originally introduced by Borsuk. Defined as *locally contractible* on page 28 of {{zb:0153.52905}}, page 347 of {{zb:1280.54001}}, and page 341 of {{zb:1059.54001}}. The abbreviation $LC$ is commonly used in this context.
 
 ----
 #### Meta-properties

--- a/properties/P000225.md
+++ b/properties/P000225.md
@@ -12,7 +12,7 @@ refs:
     name: Encyclopedia of general topology
 ---
 
-$X$ is $LC$ if every neighborhood $U$ of any point $x$ contains a neighborhood $V$ of $x$ that is contractible in $U$. 
+Every neighborhood $U$ of any point $x$ contains a neighborhood of $x$ that is contractible in $U$. 
 
 Equivalently, $X$ is locally contractible at each of its points. A space $X$ is *locally contractible at a point* $x \in X$ if every neighborhood $U$ of $x$ contains a neighborhood $V$ of $x$ such that the inclusion map $V \to U$ is null-homotopic.
 

--- a/properties/P000225.md
+++ b/properties/P000225.md
@@ -12,9 +12,12 @@ refs:
     name: Encyclopedia of general topology
 ---
 
-Every neighborhood $U$ of any point $x$ contains a neighborhood of $x$ that is contractible in $U$. 
+$X$ is *locally contractible at the point* $x$ for all $x \in X$,
+in the sense that every neighborhood $U$ of $x$ contains a neighborhood (equivalently, an open neighborhood) $V$ of $x$ that is contractible in $U$;
+i.e., such that the inclusion map $V \hookrightarrow U$ is null-homotopic.
 
-Equivalently, $X$ is *locally contractible at a point* $x$ for all $x \in X$, in the sense that every neighborhood $U$ of $x$ contains a neighborhood $V$ of $x$ such that the inclusion map $V \hookrightarrow U$ is null-homotopic.
+Equivalently, every neighborhood $U$ of any point $x$ contains a neighborhood (or an open neighborhood) $V$ of $x$
+such that the inclusion map $V \hookrightarrow U$ is homotopic to the constant map with value $x$.
 
 This is the standard definition of "locally contractible" in the theory of ANRs, as originally introduced by Borsuk. Defined as *locally contractible* on page 28 of {{zb:0153.52905}}, page 347 of {{zb:1280.54001}}, and page 341 of {{zb:1059.54001}}.
 

--- a/properties/P000225.md
+++ b/properties/P000225.md
@@ -16,7 +16,7 @@ Every neighborhood $U$ of any point $x$ contains a neighborhood of $x$ that is c
 
 Equivalently, $X$ is locally contractible at each of its points. A space $X$ is *locally contractible at a point* $x \in X$ if every neighborhood $U$ of $x$ contains a neighborhood $V$ of $x$ such that the inclusion map $V \to U$ is null-homotopic.
 
-This is the standard definition of "locally contractible" in the theory of ANRs. Defined as "locally contractible" on page 28 of {{zb:0153.52905}}, page 347 of {{zb:"1280.54001"}}, and page 341 of {{zb:"1059.54001"}}.
+This is the standard definition of "locally contractible" in the theory of ANRs, as originally introduced by Borsuk. Defined as *locally contractible* on page 28 of {{zb:0153.52905}}, page 347 of {{zb:1280.54001}}, and page 341 of {{zb:1059.54001}}.
 
 ----
 #### Meta-properties

--- a/theorems/T000847.md
+++ b/theorems/T000847.md
@@ -3,12 +3,9 @@ uid: T000847
 if:
   P000122: true
 then:
-  P000230: true
-refs:
-  - zb: "0951.54001"
-    name: Topology (Munkres)
+  P000223: true
 ---
 
-A locally Euclidean space admits a basis of Euclidean open balls.
-For a Euclidean open ball $U$ and $x \in U$, $\pi_1(U,x)$ is trivial (see Example 1 on page 331 of {{zb:0951.54001}}).
-A Euclidean open ball is also path-connected. 
+A locally Euclidean space admits a basis of Euclidean open balls. A Euclidean open ball is homeomorphic to
+$\mathbb{R}^n$. Then the claim follows because the map $\mathbb{R}^n \times [0, 1] \to \mathbb{R}^n$,
+$(p, t) \mapsto (1-t)p$, is a homotopy from the identity map of Euclidean space to a constant map.

--- a/theorems/T000847.md
+++ b/theorems/T000847.md
@@ -6,6 +6,5 @@ then:
   P000223: true
 ---
 
-A locally Euclidean space admits a basis of Euclidean open balls. A Euclidean open ball is homeomorphic to
-$\mathbb{R}^n$. Then the claim follows because the map $\mathbb{R}^n \times [0, 1] \to \mathbb{R}^n$,
-$(p, t) \mapsto (1-t)p$, is a homotopy from the identity map of Euclidean space to a constant map.
+For each $x\in X$, every neighborhood of $x$ contains an open neighborhood homeomorphic to some Euclidean space $\mathbb R^n$.
+And $\mathbb R^n$ is {P199} as it can be deformation retracted to a point using a straight-line homotopy.

--- a/theorems/T000848.md
+++ b/theorems/T000848.md
@@ -3,10 +3,10 @@ uid: T000848
 if:
   P000090: true
 then:
-  P000230: true
+  P000223: true
 refs:
 - mathse: 2965374
   name: Answer to "Are minimal neighborhoods in an Alexandrov topology path-connected?"
 ---
 
-For each point $x \in X$, the minimal neighborhood $U_x$ of $x$ is open and {P199} (see {{mathse:2965374}}). By {T583}, $U_x$ is {P200}.
+For each point $x \in X$, the minimal neighborhood $U_x$ of $x$ is open and {P199} (see {{mathse:2965374}}).

--- a/theorems/T000867.md
+++ b/theorems/T000867.md
@@ -6,4 +6,4 @@ then:
   P000224: true
 ---
 
-Immediate by the definitions.
+Immediate from the definitions.

--- a/theorems/T000867.md
+++ b/theorems/T000867.md
@@ -1,0 +1,9 @@
+---
+uid: T000867
+if:
+  P000223: true
+then:
+  P000224: true
+---
+
+Immediate by the definitions.

--- a/theorems/T000868.md
+++ b/theorems/T000868.md
@@ -6,4 +6,4 @@ then:
   P000225: true
 ---
 
-Immediate by the definitions.
+Immediate from the definitions.

--- a/theorems/T000868.md
+++ b/theorems/T000868.md
@@ -1,0 +1,9 @@
+---
+uid: T000868
+if:
+  P000223: true
+then:
+  P000225: true
+---
+
+Immediate by the definitions.

--- a/theorems/T000869.md
+++ b/theorems/T000869.md
@@ -1,0 +1,9 @@
+---
+uid: T000869
+if:
+  P000223: true
+then:
+  P000230: true
+---
+
+A contractible space is simply connected.

--- a/theorems/T000869.md
+++ b/theorems/T000869.md
@@ -6,4 +6,4 @@ then:
   P000230: true
 ---
 
-A contractible space is simply connected.
+By {T583}.

--- a/theorems/T000870.md
+++ b/theorems/T000870.md
@@ -1,0 +1,9 @@
+---
+uid: T000870
+if:
+  P000224: true
+then:
+  P000231: true
+---
+
+A contractible space is simply connected.

--- a/theorems/T000870.md
+++ b/theorems/T000870.md
@@ -6,4 +6,4 @@ then:
   P000231: true
 ---
 
-A contractible space is simply connected.
+By {T583}.

--- a/theorems/T000871.md
+++ b/theorems/T000871.md
@@ -1,0 +1,9 @@
+---
+uid: T000871
+if:
+  P000225: true
+then:
+  P000232: true
+---
+
+If $V$ is contractible in $U$, then any map $Y \to V$ is null-homotopic in $U$.

--- a/theorems/T000871.md
+++ b/theorems/T000871.md
@@ -6,4 +6,5 @@ then:
   P000232: true
 ---
 
-If $V$ is contractible in $U$, then any map $Y \to V$ is null-homotopic in $U$.
+If $V$ is contractible in $U$, any map $Y \to V$ is null-homotopic in $U$.
+Apply this to $Y=S^0, S^1$.

--- a/theorems/T000872.md
+++ b/theorems/T000872.md
@@ -1,0 +1,9 @@
+---
+uid: T000872
+if:
+  P000199: true
+then:
+  P000224: true
+---
+
+Immediate by the definitions.

--- a/theorems/T000872.md
+++ b/theorems/T000872.md
@@ -6,4 +6,4 @@ then:
   P000224: true
 ---
 
-Immediate by the definitions.
+Immediate from the definitions.


### PR DESCRIPTION
Based on discussion from https://github.com/pi-base/data/issues/1672 and the older thread https://github.com/pi-base/data/issues/1150. Also see https://github.com/pi-base/data/issues/1654 (on locally simply connected). There is a lot of work remaining to be added from those threads in future PRs; see for instance https://github.com/pi-base/data/issues/1672#issuecomment-4061215144 and https://github.com/pi-base/data/issues/1672#issuecomment-4083819037. Also, adding this was a blocking issue for the suggestion in https://github.com/pi-base/data/issues/1671.

For this PR:

(1) I included two near-identical definitions of LC (maybe also see [LC^1](https://topology.pi-base.org/properties/P000232)), but the second (or first) could be considered redundant. The first is slicker and nicely fits on the page with the big list of properties, but the second emphasizes that this property is pointwise defined.

(2) I have no references for "weakly locally contractible". Surely there must be some published theorem using this or its negation as a hypothesis or conclusion, but I don't know of any. I don't think it's great that the only reference on "weakly locally contractible" is to a source defining it with a different definition (this is done because of a suggestion in this comment https://github.com/pi-base/data/issues/1672#issuecomment-4084935153).

(3) I include a reference to Fadell's paper for "weakly contractible", since I think that is the origin of his variant of the term, but since I also connect it to "semi-locally contractible", I also include a reference (Borges) to a paper which has both terms. Possibly this could be simplified or some other reference(s) could be used (maybe from my comment https://github.com/pi-base/data/issues/1672#issuecomment-4086337555).

(4) ~~I have no references for [P223](https://topology.pi-base.org/properties/P000223) ("locally contractible"), although that property does have some use in the literature. The issue was that I did not find any ideal source.~~ (Edit: I remembered this is Hatcher's definition, though it's unfortunately buried in a proposition statement and the text seems slightly ambiguous since it could look like 'has an open basis of contractible sets' is stronger than whatever 'locally contractible' is supposed to mean.)

(5) This PR lacks counterexamples. Some of the converses have relatively easy counterexamples, but some are highly non-trivial. It felt burdensome to include counterexamples in this PR.

(6) There's a good chance I'm missing several of the basic theorems that could be added now.