### PR TITLE
Add "iff Kolmogorov ..." for most remaining properties

### DIFF
--- a/properties/P000010.md
+++ b/properties/P000010.md
@@ -14,6 +14,7 @@ Defined in 14E of {{zb:1052.54001}}.
 ----
 ### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is hereditary with respect to open sets.
 - This property is not hereditary with respect to closed sets
 (Example: {S11|P10}

--- a/properties/P000014.md
+++ b/properties/P000014.md
@@ -22,4 +22,5 @@ Defined on page 11 of {{zb:0386.54001}} (as $T_5$).
 ----
 #### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is hereditary.

--- a/properties/P000015.md
+++ b/properties/P000015.md
@@ -31,4 +31,5 @@ Defined on page 16 of {{zb:0386.54001}} (as perfectly $T_4$).
 ----
 #### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is hereditary (see Theorem 2.1.6 in {{zb:0684.54001}}).

--- a/properties/P000017.md
+++ b/properties/P000017.md
@@ -9,3 +9,8 @@ refs:
 A space which is the union of countably many {P16} subsets.
 
 Defined on page 19 of {{zb:0386.54001}}.
+
+----
+#### Meta-properties
+
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.

--- a/properties/P000019.md
+++ b/properties/P000019.md
@@ -19,4 +19,5 @@ Defined on page 19 of {{zb:0386.54001}}.  See for example {{wikipedia:Countably_
 ----
 #### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is hereditary with respect to closed sets.

--- a/properties/P000020.md
+++ b/properties/P000020.md
@@ -15,5 +15,6 @@ Defined on page 19 of {{zb:0386.54001}}.
 ---
 ### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is hereditary with respect to closed sets.
 - This property is preserved by countable products (see Theorem 3.10.35 in {{zb:0684.54001}}).

--- a/properties/P000022.md
+++ b/properties/P000022.md
@@ -13,4 +13,5 @@ Defined on page 20 of {{zb:0386.54001}}.
 ----
 #### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is preserved in any coarser topology.

--- a/properties/P000024.md
+++ b/properties/P000024.md
@@ -16,3 +16,8 @@ Equivalently (see Condition 2 of {{wikipedia:Locally_compact_space}}), every poi
 a closed and compact neighborhood.
 
 Defined on page 20 of {{zb:0386.54001}} as "strongly locally compact". Contrast with {P130}.
+
+----
+#### Meta-properties
+
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.

--- a/properties/P000025.md
+++ b/properties/P000025.md
@@ -22,3 +22,8 @@ Equivalently, $X=\bigcup_{n<\omega}K_n$ for $K_n$ compact, and such that $K_n\su
 The equivalences above can be shown using the ideas in {{mathse:4568032}}.
 
 Defined on page 21 of {{zb:0386.54001}} as "$\sigma$-locally compact".
+
+----
+#### Meta-properties
+
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.

--- a/properties/P000027.md
+++ b/properties/P000027.md
@@ -13,4 +13,5 @@ Defined on page 7 of {{zb:0386.54001}}.
 ----
 #### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is hereditary.

--- a/properties/P000029.md
+++ b/properties/P000029.md
@@ -17,3 +17,8 @@ A space in which every collection of pairwise-disjoint nonempty open sets is cou
 
 Defined on page 22 of {{zb:0386.54001}}.
 Also referred to as the "Suslin/Souslin property" as in e.g. 1.7.12 of {{zb:0684.54001}}.
+
+----
+#### Meta-properties
+
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.

--- a/properties/P000031.md
+++ b/properties/P000031.md
@@ -18,4 +18,5 @@ Defined on page 23 of {{zb:0386.54001}}.
 ----
 #### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is hereditary with respect to closed sets.

--- a/properties/P000032.md
+++ b/properties/P000032.md
@@ -13,4 +13,5 @@ Defined on page 23 of {{zb:0386.54001}}.
 ----
 #### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is hereditary with respect to closed sets.

--- a/properties/P000034.md
+++ b/properties/P000034.md
@@ -35,3 +35,8 @@ Also see [Henno Brandsma: On paracompactness, full normality and the like](http:
 
 (Note: {{zb:0386.54001}} defines this property on page 23 as "fully $T_4$".
 Misleadingly, it also calls "star refinement" what all other major sources call a barycentric refinement.)
+
+----
+#### Meta-properties
+
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.

--- a/properties/P000039.md
+++ b/properties/P000039.md
@@ -24,6 +24,7 @@ See {{wikipedia:Hyperconnected_space}} for other equivalent characterizations.
 ----
 #### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is hereditary with respect to open sets.
 - This property is preserved by arbitrary products.
 - This property is preserved by continuous images.

--- a/properties/P000040.md
+++ b/properties/P000040.md
@@ -14,3 +14,8 @@ Equivalently ({{mathse:5006424}}), the only neighborhood of the space's
 diagonal $\Delta=\{\langle x,x\rangle:x\in X\}$ is $X^2$.
 
 Defined on page 29 of {{zb:0386.54001}}.
+
+----
+#### Meta-properties
+
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.

--- a/properties/P000041.md
+++ b/properties/P000041.md
@@ -32,4 +32,5 @@ Defined on page 30 of {{zb:0386.54001}}.
 ----
 #### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is hereditary with respect to open sets.

--- a/properties/P000042.md
+++ b/properties/P000042.md
@@ -44,4 +44,5 @@ Compare with {P43} and {P96}.
 ----
 ### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is hereditary with respect to open sets.

--- a/properties/P000046.md
+++ b/properties/P000046.md
@@ -13,5 +13,4 @@ Defined on page 31 of {{zb:0386.54001}}.
 ----
 #### Meta-properties
 
-- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is hereditary.

--- a/properties/P000046.md
+++ b/properties/P000046.md
@@ -13,4 +13,5 @@ Defined on page 31 of {{zb:0386.54001}}.
 ----
 #### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is hereditary.

--- a/properties/P000049.md
+++ b/properties/P000049.md
@@ -26,6 +26,7 @@ which we do not assume here.
 ----
 #### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is hereditary with respect to open sets (see Problem 15G.2 in {{zb:1052.54001}}).
 - This property is hereditary with respect to dense sets (see {{mathse:3769214}}).
 - This property is hereditary with respect to locally dense sets (equivalent to previous two meta-properties; see also Proposition 1 of {{mathse:5025114}}).

--- a/properties/P000050.md
+++ b/properties/P000050.md
@@ -13,5 +13,6 @@ Defined on page 33 of {{zb:0386.54001}}.
 ----
 #### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is hereditary.
 - This property is preserved by arbitrary products.

--- a/properties/P000054.md
+++ b/properties/P000054.md
@@ -15,5 +15,6 @@ Defined on page 37 of {{zb:0386.54001}}.
 ----
 #### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is hereditary.
 - This property is preserved by arbitrary disjoint unions.

--- a/properties/P000056.md
+++ b/properties/P000056.md
@@ -17,4 +17,5 @@ Defined on page 7 of {{zb:0386.54001}}.
 ----
 #### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is preserved by arbitrary disjoint unions.

--- a/properties/P000060.md
+++ b/properties/P000060.md
@@ -13,3 +13,8 @@ refs:
 Every continuous function $f:X \to \mathbb R$ is constant.
 
 Defined on page 223 of {{zb:0386.54001}}.
+
+----
+#### Meta-properties
+
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.

--- a/properties/P000062.md
+++ b/properties/P000062.md
@@ -11,6 +11,7 @@ Every open cover of $X$ has a countable subcollection whose union is dense in $X
 ----
 ### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is hereditary with respect to clopen sets.
 - This property is preserved in any coarser topology.
 - If a nonempty product space satisfies the property, so does every factor.

--- a/properties/P000064.md
+++ b/properties/P000064.md
@@ -11,3 +11,8 @@ refs:
 A space such that the countable union of closed nowhere dense subsets has empty interior; equivalently, such that the countable intersection of open dense subsets is still dense.
 
 See {{wikipedia:Baire_space}} for several other equivalent characterizations.
+
+----
+#### Meta-properties
+
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.

--- a/properties/P000066.md
+++ b/properties/P000066.md
@@ -16,4 +16,5 @@ See section 5 of {{doi:10.1016/0166-8641(95)00067-4}}.
 ----
 #### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is hereditary with respect to closed sets.

--- a/properties/P000068.md
+++ b/properties/P000068.md
@@ -17,4 +17,5 @@ See section 6 of {{doi:10.1016/0166-8641(95)00067-4}}.
 
 #### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is hereditary with respect to closed subspaces.

--- a/properties/P000069.md
+++ b/properties/P000069.md
@@ -21,3 +21,8 @@ Strategic Menger: The second player has a winning strategy in the Menger game. S
 Strategically $\Omega$-Menger: The second player has a winning strategy in the game $\mathsf{G}_{\mathrm{fin}}(\Omega_X,\Omega_X)$. See pages 2 and 3 of {{doi:10.1016/j.topol.2019.07.008}} for more details.
 
 The equivalence of Strategic Menger and Strategically $\Omega$-Menger is Theorem 35 of {{doi:10.1016/j.topol.2019.02.062}}.
+
+----
+#### Meta-properties
+
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.

--- a/properties/P000070.md
+++ b/properties/P000070.md
@@ -18,3 +18,8 @@ Markov Menger: The second player has a Markov winning strategy in the Menger gam
 Markov $\Omega$-Menger: The second player has a Markov winning strategy in the game $\mathsf{G}_{\mathrm{fin}}(\Omega_X,\Omega_X)$ (relying on only the round number and most recent move of the opponent). See pages 2 and 3 of {{doi:10.1016/j.topol.2019.07.008}} for more details.
 
 The equivalence of Markov Menger with Markov $\Omega$-Menger is established in {{mathse:4730419}}.
+
+----
+#### Meta-properties
+
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.

--- a/properties/P000079.md
+++ b/properties/P000079.md
@@ -17,6 +17,7 @@ Equivalently, for every set $A\subseteq X$ that is *not* closed in $X$, there is
 ----
 ### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is hereditary with respect to closed sets (see {{mathse:479808}}).
 - This property is hereditary with respect to open sets (see {{mathse:479808}}).
 - This property is preserved by quotient maps.

--- a/properties/P000080.md
+++ b/properties/P000080.md
@@ -17,5 +17,6 @@ Compare with {P172}.
 ----
 #### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is hereditary.
 

--- a/properties/P000090.md
+++ b/properties/P000090.md
@@ -27,6 +27,7 @@ See also {{zb:0944.54018}}.
 ----
 #### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is hereditary.
 - This property is preserved by arbitrary disjoint unions.
 - This property is preserved by finite products.

--- a/properties/P000098.md
+++ b/properties/P000098.md
@@ -22,3 +22,8 @@ its intersection with each $K_n$ is closed (resp. open) in $K_n$.
 Defined as "$k_\omega$-space" on page 13 of {{zb:0288.22006}}.
 The corresponding notion requiring that each $K_n$ be {P3} is {P92}.
 See also {P140}, {P141}, and {P142}.
+
+----
+#### Meta-properties
+
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.

--- a/properties/P000105.md
+++ b/properties/P000105.md
@@ -13,4 +13,5 @@ Defined on page 200 of {{zb:1059.54001}}.
 ----
 #### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is preserved by arbitrary disjoint unions.

--- a/properties/P000108.md
+++ b/properties/P000108.md
@@ -24,5 +24,6 @@ For the equivalence of the conditions above, see {{mathse:4737011}}.
 ----
 #### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is hereditary.
 - This property is preserved by arbitrary disjoint unions.

--- a/properties/P000117.md
+++ b/properties/P000117.md
@@ -15,4 +15,5 @@ See for example page 127 of {{zb:0684.54001}}.
 ----
 #### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is hereditary.

--- a/properties/P000128.md
+++ b/properties/P000128.md
@@ -9,3 +9,8 @@ refs:
 Every open $k$-cover of $X$ has a countable $k$-subcover.  (A family $\mathcal U$ of open subsets of $X$ is called a *$k$-cover* if each compact subset of $X$ is contained in an element of $\mathcal U$ and $X \notin \mathcal U$.)
 
 Defined on page 3279 of {{doi:10.1016/j.topol.2005.07.015}}.
+
+----
+#### Meta-properties
+
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.

--- a/properties/P000129.md
+++ b/properties/P000129.md
@@ -15,4 +15,5 @@ See 3.2d of {{zb:1052.54001}}.
 ----
 #### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is hereditary.

--- a/properties/P000130.md
+++ b/properties/P000130.md
@@ -12,6 +12,7 @@ Given as condition (3) in {{wikipedia:Locally_compact_space}}.  See also the art
 ----
 #### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is hereditary with respect to open sets.
 - This property is hereditary with respect to closed sets.
 - This property is hereditary with respect to locally closed sets (equivalent to previous two meta-properties).

--- a/properties/P000140.md
+++ b/properties/P000140.md
@@ -22,6 +22,7 @@ Equivalently, a space whose topology coincides with the final topology with resp
 ----
 #### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is hereditary with respect to closed sets.
 - This property is not hereditary with respect to open sets
 (e.g., {S23}, open in {S165}).

--- a/properties/P000146.md
+++ b/properties/P000146.md
@@ -21,4 +21,5 @@ The equivalence between the two definitions is shown in Lemma 1.3 and Corollary 
 ----
 #### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is preserved by arbitrary disjoint unions.

--- a/properties/P000149.md
+++ b/properties/P000149.md
@@ -26,4 +26,5 @@ as the fifth item "$\varepsilon$" in a list from
 ---
 #### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is hereditary with respect to closed sets.

--- a/properties/P000150.md
+++ b/properties/P000150.md
@@ -12,3 +12,8 @@ The space satisfies the selection principle $\mathsf S_1(\Omega,\Omega)$: for ev
 Equivalently, every finite power of $X$ is {P68}.
 
 See {{doi:10.1090/S0002-9939-1988-0964873-0}}; the equivalence with every finite power being {P68} is on page 918.
+
+----
+#### Meta-properties
+
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.

--- a/properties/P000152.md
+++ b/properties/P000152.md
@@ -21,3 +21,8 @@ Equivalent conditions:
 - Topologically countable: There is a set $\{ x_n : n \in \omega \} \subseteq X$ so that, for every $x \in X$, there is some $n \in \omega$ so that every neighborhood of $x_n$ contains $x$. See {{zb:1555.54009}} for more on this property.
 
 The equivalence is shown in Theorem 4.17 of {{zb:1555.54009}} and also at {{mathse:4737285}}.
+
+----
+#### Meta-properties
+
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.

--- a/properties/P000153.md
+++ b/properties/P000153.md
@@ -12,3 +12,8 @@ The space satisfies the selection principle $\mathsf S_{\mathrm{fin}}(\Omega,\Om
 Equivalently, every finite power of $X$ is {P66}.
 
 See {{doi:10.1016/S0166-8641(96)00075-2}}; the equivalence with every finite power being {P66} is Theorem 3.9.
+
+----
+#### Meta-properties
+
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.

--- a/properties/P000156.md
+++ b/properties/P000156.md
@@ -8,3 +8,8 @@ refs:
 
 The space satisfies the selection principle $\mathsf S_1(\mathcal K,\mathcal K)$: for every sequence $\langle \mathscr U_n : n \in \omega \rangle$ of $k$-covers of $X$, there exist choices $U_n \in \mathscr U_n$ so that $\{ U_n :n \in \omega \}$ is a $k$-cover of $X$.
 (A family $\mathcal U$ of open subsets of $X$ is called a *$k$-cover* if each compact subset of $X$ is contained in an element of $\mathcal U$ and $X \notin \mathcal U$.)
+
+----
+#### Meta-properties
+
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.

--- a/properties/P000157.md
+++ b/properties/P000157.md
@@ -6,3 +6,8 @@ refs:
   name: Selection games and the Vietoris space
 ---
 The second player has a winning strategy in the game $\mathsf{G}_1(\mathcal K_X,\mathcal K_X)$. See Remark 2.4 and Definition 2.7 of {{doi:10.1016/j.topol.2021.107772}} for more details.
+
+----
+#### Meta-properties
+
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.

--- a/properties/P000159.md
+++ b/properties/P000159.md
@@ -8,3 +8,8 @@ refs:
 
 The space satisfies the selection principle $\mathsf S_{\mathrm{fin}}(\mathcal K,\mathcal K)$: for every sequence $\langle \mathscr U_n : n \in \omega \rangle$ of $k$-covers of $X$, there exist choices $\mathcal F_n$, a finite subset of $\mathscr U_n$, so that $\bigcup_{n\in\omega} \mathcal F_n$ is a $k$-cover of $X$.
 (A family $\mathcal U$ of open subsets of $X$ is called a *$k$-cover* if each compact subset of $X$ is contained in an element of $\mathcal U$ and $X \notin \mathcal U$.)
+
+----
+#### Meta-properties
+
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.

--- a/properties/P000160.md
+++ b/properties/P000160.md
@@ -6,3 +6,8 @@ refs:
   name: Selection games and the Vietoris space
 ---
 The second player has a winning strategy in the game $\mathsf{G}_{\mathrm{fin}}(\mathcal K_X,\mathcal K_X)$. See Remark 2.4 and Definition 2.7 of {{doi:10.1016/j.topol.2021.107772}} for more details.
+
+----
+#### Meta-properties
+
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.

--- a/properties/P000161.md
+++ b/properties/P000161.md
@@ -6,3 +6,8 @@ refs:
   name: Selection games and the Vietoris space
 ---
 The second player has a Markov winning strategy in the game $\mathsf{G}_{\mathrm{fin}}(\mathcal K_X,\mathcal K_X)$ (relying on only the round number and most recent move of the opponent). See Remark 2.4 and Definition 2.7 of {{doi:10.1016/j.topol.2021.107772}} for more details.
+
+----
+#### Meta-properties
+
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.

--- a/properties/P000173.md
+++ b/properties/P000173.md
@@ -11,3 +11,8 @@ refs:
 A space in which every radially closed set is closed, where a set $A\subseteq X$ is *radially closed* if it contains the limits of all convergent transfinite sequences consisting of points of $A$.  In other words, for every non-closed set $A\subseteq X$ there is a point $p\in \overline A\setminus A$ and a transfinite sequence $(x_\alpha)_{\alpha<\lambda}$ of points of $A$ that converges to $p$.  (Here $\lambda$ is a limit ordinal and can always be taken to be a regular cardinal.)
 
 See the chapter "d-4 Pseudoradial spaces" in {{zb:1059.54001}}.
+
+----
+#### Meta-properties
+
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.

--- a/properties/P000180.md
+++ b/properties/P000180.md
@@ -13,4 +13,5 @@ Defined on page 182 of {{doi:10.1016/B978-0-444-50355-8.X5000-4}}.
 ----
 #### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is hereditary.

--- a/properties/P000182.md
+++ b/properties/P000182.md
@@ -15,5 +15,6 @@ Defined on page 127 of {{zb:0684.54001}}.
 ---
 ### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is hereditary.
 - This property is preserved by countable products.

--- a/properties/P000183.md
+++ b/properties/P000183.md
@@ -32,6 +32,7 @@ See {{mr:206907}}, available at <https://www.jstor.org/stable/24901448>.
 ---
 ### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is hereditary.
 - This property is preserved by countable products (see Corollary in {{mo:506308}}).
 

--- a/properties/P000187.md
+++ b/properties/P000187.md
@@ -20,6 +20,7 @@ See also section 2 of {{zb:1141.54020}}.
 ----
 #### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is hereditary.
 - This property is preserved by countable products (see Theorem 4.1 of {{zb:0327.54019}}).
 - This property is preserved by $\Sigma$-products (see Theorem 4.6 of {{zb:0327.54019}}).

--- a/properties/P000193.md
+++ b/properties/P000193.md
@@ -15,3 +15,8 @@ refs:
 A space in which every open cover admits a shrinking; that is, a space $X$ in which, given any open cover $\{ U_\alpha : \alpha \in A\}$, there is an open cover $\{ V_\alpha : \alpha \in A\}$ such that $\overline{V_\alpha} \subseteq U_\alpha$ for each $\alpha \in A$.
 
 See also [Dan Ma's Topology Blog post on Spaces with shrinking properties](https://dantopology.wordpress.com/2017/01/05/spaces-with-shrinking-properties/).
+
+----
+#### Meta-properties
+
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.

--- a/properties/P000194.md
+++ b/properties/P000194.md
@@ -18,4 +18,6 @@ This property was introduced in {{zb:0132.18401}} under the name of *$\theta$-re
 
 ---
 #### Meta-properties
+
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is hereditary with respect to closed sets.

--- a/properties/P000196.md
+++ b/properties/P000196.md
@@ -22,5 +22,6 @@ For proof of the equivalences and further characterizations, see section 12 of {
 ----
 #### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is hereditary.
 - This property is preserved in any coarser topology.

--- a/properties/P000199.md
+++ b/properties/P000199.md
@@ -21,4 +21,5 @@ Defined on page 4 of {{zb:1044.55001}}.
 ----
 #### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is preserved by arbitrary products. (see {{mathse:4463999}})

--- a/properties/P000201.md
+++ b/properties/P000201.md
@@ -27,4 +27,5 @@ See Definition 1.1.7 on page 3 of {{zb:1325.14001}}.
 ----
 #### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is preserved in any coarser topology.

--- a/properties/P000202.md
+++ b/properties/P000202.md
@@ -26,4 +26,5 @@ Compare with {P201} and {P203}.
 ----
 #### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is preserved in any coarser topology.

--- a/properties/P000207.md
+++ b/properties/P000207.md
@@ -30,5 +30,6 @@ See also {{doi:10.1090/S0002-9939-1981-0630058-4}}.
 ----
 #### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is preserved by arbitrary disjoint unions.
 - This property is hereditary with respect to closed sets (corollary of Theorem 4.1 in {{zb:0078.14803}}).

--- a/properties/P000208.md
+++ b/properties/P000208.md
@@ -30,6 +30,7 @@ Compare with {P226}.
 ----
 #### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is hereditary.
 - This property is preserved by finite products (see Theorem 3 in {{mathse:5118758}}).
 - This property is preserved by finite disjoint unions.

--- a/properties/P000209.md
+++ b/properties/P000209.md
@@ -7,4 +7,6 @@ There exists a dense subset with cardinality $\leq \mathfrak c=2^{\aleph_0}=|\ma
 
 ----
 #### Meta-properties
+
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is preserved by countable products.

--- a/properties/P000210.md
+++ b/properties/P000210.md
@@ -34,4 +34,5 @@ are due to Arkhangel'skii ({{zb:0275.54004}}).
 ----
 #### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is hereditary.

--- a/properties/P000211.md
+++ b/properties/P000211.md
@@ -33,4 +33,5 @@ This property was introduced by Nyikos in {{zb:0774.54019}}.
 ----
 #### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is hereditary.

--- a/properties/P000212.md
+++ b/properties/P000212.md
@@ -33,4 +33,5 @@ are due to Arkhangel'skii ({{zb:0275.54004}}).
 ----
 #### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is hereditary.

--- a/properties/P000213.md
+++ b/properties/P000213.md
@@ -33,4 +33,5 @@ are due to Arkhangel'skii ({{zb:0275.54004}}).
 ----
 #### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is hereditary.

--- a/properties/P000214.md
+++ b/properties/P000214.md
@@ -33,4 +33,5 @@ are due to Arkhangel'skii ({{zb:0275.54004}}).
 ----
 #### Meta-properties
 
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is hereditary.

--- a/properties/P000218.md
+++ b/properties/P000218.md
@@ -25,3 +25,8 @@ See also page 1 of {{doi:10.48550/arXiv.1306.6086}}.
 
 The book {{zb:1471.54001}} uses "strongly zero-dimensional"
 for a space that is {P218} and non-empty (see page 9); {P218} is equivalent to either one of $\dim(X), \text{Ind}(X)$ or $\text{Ind}_0(X)$ being $\leq 0$. See chapters 2 and 13 for definitions of $\dim, \text{Ind}, \text{Ind}_0$.
+
+----
+#### Meta-properties
+
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.

--- a/properties/P000230.md
+++ b/properties/P000230.md
@@ -17,3 +17,8 @@ Equivalently, for each $x \in X$, every neighborhood of $x$ contains a simply co
 Defined on page 298 of {{zb:1209.57001}}, and listed as property $P_1$ in {{mo:487326}}.
 
 Has also been called "strongly locally simply connected", for example in {{zb:0209.54802}}.
+
+----
+#### Meta-properties
+
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.

--- a/properties/P000231.md
+++ b/properties/P000231.md
@@ -11,3 +11,8 @@ refs:
 Every point of $X$ has a neighborhood which is {P200}. 
 
 Defined as "locally simply connected" on page 54 of {{zb:0063.00842}} and listed as property $P_4$ in {{mo:487326}}.
+
+----
+#### Meta-properties
+
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.

--- a/properties/P000232.md
+++ b/properties/P000232.md
@@ -36,4 +36,6 @@ Listed as property $P_{10}$ in {{mo:487326}}.
 
 ----
 #### Meta-properties
+
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is preserved by retractions (use Theorem 16.2 on p. 29 of {{zb:0153.52905}}).


### PR DESCRIPTION
Add "property holds iff for kolmogorov quotient" for almost all proerties where it is true. For weakly first countable for example, it could be true.

This is kind of a big PR, but most of the additions are trivial or at least easy (similar to #1674). I dont think it makes sense to artificially split this up.
Most of the addtions are originally by @danflapjax in his spreadsheet in #1198, which I expanded.

It's plausible there are some mistakes (sometimes taking the quotient can be confusing, i.e. for Sequential), so please check carefully.

(as you might can guess I used AI to get the data from the spreadsheet to the property files)

**This PR has medium to high priority**