### PR TITLE
delete redundant t846

### DIFF
--- a/theorems/T000846.md
+++ b/theorems/T000846.md
@@ -1,9 +1,0 @@
----
-uid: T000846
-if:
-  P000200: true
-then:
-  P000229: true
----
-
-One can take $U := X$.


### PR DESCRIPTION
I came across this when formalising this theorem in https://github.com/felixpernegger/pibase-lean.

By T853 and T855 the theorem is redundant and I dont see a good reason to keep it. Iirc, someone mentioned that we can remove it when we were adding the locally simply connected stuff, but we apparently forgot about it.