### PR TITLE
Right ray topologies on omega_1 are not injectively path connected

### DIFF
--- a/properties/P000037.md
+++ b/properties/P000037.md
@@ -18,3 +18,4 @@ Compare with {P38} and {P95}.
 
 - $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is preserved by arbitrary products.
+- This property is preserved in any coarser topology.

--- a/properties/P000038.md
+++ b/properties/P000038.md
@@ -17,3 +17,8 @@ and {P95}, which requires the path to be a homeomorphism onto its image.
 Defined on page 29 of {{zb:0386.54001}} with the name "arc connected".
 Here we reserve that name for the stronger property {P95},
 which is the more common usage in the literature.
+
+#### Meta-properties
+
+- This property is preserved by arbitrary products.
+- This property is preserved in any coarser topology.

--- a/spaces/S000220/properties/P000038.md
+++ b/spaces/S000220/properties/P000038.md
@@ -1,0 +1,7 @@
+---
+space: S000220
+property: P000038
+value: false
+---
+
+{S221} has a coarser topology than $X$, but {S221|P38}.

--- a/spaces/S000221/properties/P000038.md
+++ b/spaces/S000221/properties/P000038.md
@@ -1,0 +1,12 @@
+---
+space: S000221
+property: P000038
+value: false
+---
+
+Let $f:[0,1]\to X$ be a path in $X$.
+Take a countable dense subset $E$ of $[0,1]$.
+Its image $f(E)$ is countable and thus bounded in $X$, say by some $u\in\omega_1$.
+So $f(E)$ is contained in the closed set $[0,u]$.
+And by density of $E$ in $[0,1]$, $f([0,1])$ is also contained in $[0,u]$.
+Since $[0,u]$ is countable, $f$ cannot be injective.


### PR DESCRIPTION
The right ray topologies on $\omega_1 (S220 and S221) are not injectively path connected.

Based on https://github.com/pi-base/data/pull/1685#issuecomment-4095258294 from @felixpernegger.

I added a metaproperty for P38 (injectively path connected) that is being used here.  And took the opportunity to add some other ones, also for P37 (path connected) even if it's not used here.