### PR TITLE
Semilocally Contractible Initial PR

### DIFF
--- a/properties/P000224.md
+++ b/properties/P000224.md
@@ -1,11 +1,6 @@
 ---
 uid: P000224
 name: Weakly locally contractible
-refs:
-  - zb: "0087.38203"
-    name: On fiber spaces (Fadell)
-  - zb: "0642.54014"
-    name: LECS, local mixers, topological groups and special products (Borges)
 ---
 
 Every point of $X$ has a neighborhood which is {P199}. 
@@ -14,4 +9,4 @@ The name we have chosen for this property conforms to the [pi-base naming conven
 However, we have not seen this property mentioned with a specific name in the literature.
 
 The terminology "weakly locally contractible" has been used for multiple concepts different from this one, but the name is not standardized.
-A relatively common usage among those is as a synonym for "semilocally contractible" (see {{zb:0087.38203}} and {{zb:0642.54014}}).
+A relatively common usage among those is as a synonym for {P239}.

--- a/properties/P000239.md
+++ b/properties/P000239.md
@@ -3,7 +3,6 @@ uid: P000239
 name: Semilocally contractible
 aliases:
   - Weakly locally contractible
-  - wlc
 refs:
   - zb: "0087.38203"
     name: On fiber spaces (Fadell)

--- a/properties/P000239.md
+++ b/properties/P000239.md
@@ -1,0 +1,33 @@
+---
+uid: P000239
+name: Semilocally contractible
+aliases:
+  - Weakly locally contractible
+  - wlc
+refs:
+  - zb: "0087.38203"
+    name: On fiber spaces (Fadell)
+  - zb: "0506.54015"
+    name: A characterization of local equi-connectedness (Sakai)
+---
+
+Every point $x \in X$ has a neighborhood (equivalently, an open neighborhood) $U$ that is
+contractible in $X$; i.e., such that the inclusion map
+$U \hookrightarrow X$ is a null-homotopy.
+
+Equivalently, every point $x \in X$ has a neighborhood
+(equivalently, an open neighborhood) $U$ of
+$x$ such that the inclusion map $U \hookrightarrow X$ is
+homotopic to the constant map with value $x$.
+
+Defined as "weakly locally contractible" and given the
+acronym "wlc" in {{zb:0087.38203}}. Defined as "semi-locally contractible" in {{zb:0506.54015}}.
+
+----
+#### Meta-properties
+
+- This property is hereditary with respect to clopen sets.
+- $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
+- This property is preserved by arbitrary disjoint unions.
+- This property is preserved by finite products.
+- If each point has a neighborhood with the property, $X$ also has the property.

--- a/theorems/T000873.md
+++ b/theorems/T000873.md
@@ -6,4 +6,6 @@ then:
   P000233: true
 ---
 
-A homotopy restricts to a path.
+Given a point $x$ with a neighborhood $U$ such that the inclusion map $U \hookrightarrow X$ is null-homotopic via a homotopy $H:U\times[0,1]\to X$,
+the image $H(U\times[0,1])$ is path connected and contains $U$,
+and thus is a path connected neighborhood of $x$.

--- a/theorems/T000873.md
+++ b/theorems/T000873.md
@@ -1,0 +1,9 @@
+---
+uid: T000873
+if:
+  P000239: true
+then:
+  P000229: true
+---
+
+Immediate from the definitions.

--- a/theorems/T000873.md
+++ b/theorems/T000873.md
@@ -3,7 +3,7 @@ uid: T000873
 if:
   P000239: true
 then:
-  P000229: true
+  P000233: true
 ---
 
-Immediate from the definitions.
+A homotopy restricts to a path.

--- a/theorems/T000874.md
+++ b/theorems/T000874.md
@@ -6,4 +6,4 @@ then:
   P000229: true
 ---
 
-Immediate from the definitions.
+Follows from the definitions.

--- a/theorems/T000874.md
+++ b/theorems/T000874.md
@@ -1,9 +1,9 @@
 ---
 uid: T000874
 if:
-  P000224: true
-then:
   P000239: true
+then:
+  P000229: true
 ---
 
 Immediate from the definitions.

--- a/theorems/T000874.md
+++ b/theorems/T000874.md
@@ -1,0 +1,9 @@
+---
+uid: T000874
+if:
+  P000224: true
+then:
+  P000239: true
+---
+
+Immediate from the definitions.

--- a/theorems/T000875.md
+++ b/theorems/T000875.md
@@ -1,10 +1,9 @@
 ---
 uid: T000875
 if:
-  P000225: true
+  P000224: true
 then:
   P000239: true
 ---
 
-For subsets $V \subset U \subset X$, if $V$
-is contractible in $U$, then it is contractible in $X$.
+Immediate from the definitions.

--- a/theorems/T000875.md
+++ b/theorems/T000875.md
@@ -1,0 +1,10 @@
+---
+uid: T000875
+if:
+  P000225: true
+then:
+  P000239: true
+---
+
+For subsets $V \subset U \subset X$, if $V$
+is contractible in $U$, then it is contractible in $X$.

--- a/theorems/T000876.md
+++ b/theorems/T000876.md
@@ -1,0 +1,10 @@
+---
+uid: T000876
+if:
+  P000225: true
+then:
+  P000239: true
+---
+
+For subsets $V \subset U \subset X$, if $V$
+is contractible in $U$, then $V$ is contractible in $X$.


### PR DESCRIPTION
Suggested in the comment https://github.com/pi-base/data/issues/1672#issuecomment-4061215144. There are some references to it in this comment https://github.com/pi-base/data/issues/1672#issuecomment-4083819037.  We planned to modify weakly locally contractible upon adding this here https://github.com/pi-base/data/issues/1672#issuecomment-4193809842.

For this PR:

- I changed the reference from Borges to Sakai because Borges's definition is actually slightly different (though equivalent), and this subtlety seems distracting.

- This MSE [post](https://math.stackexchange.com/q/5133100/444923) shows that Semilocally contractible + Has a group topology implies LC. This theorem could be included now or in a future PR.

- Note that, unlike SLSC, this property does not satisfy the meta-property "X satisfies this property iff each of its path components does." I.e. a totally path disconnected + semilocally contractible space is discrete, so $\mathbb{Q}$ is not semilocally contractible. SLSC (which is standard terminology) does not include semilocally 0-connected (= has open path components); maybe it's better to read semilocally simply connected as semilocally 1-connected to remember this. On the other hand, semilocally contractible does imply semilocally 0-connected.
