### PR TITLE
Manifold with boundary and related properties (part 2)

### DIFF
--- a/properties/P000122.md
+++ b/properties/P000122.md
@@ -9,13 +9,13 @@ refs:
 ---
 
 Each point has a neighborhood homeomorphic to an open subset of $\mathbb R^n$
-with its Euclidean topology for some $n\ge 0$. Equivalently, each point has a neighborhood
+with its Euclidean topology for some integer $n\ge 0$. Equivalently, each point has a neighborhood
 homeomorphic to $\mathbb R^n$ for some $n$. Note that the value of $n$ is allowed
 to differ between points; if it does not vary, then the space has the stronger
 property {P123}.
 
-In the case that $n=0$, the point having a neighborhood homeomorphic to
-$\mathbb R^0=\{0\}$ means it is an isolated point.
+In the case $n=0$, a point with a neighborhood homeomorphic to
+$\mathbb R^0=\{0\}$ is an isolated point.
 
 *Note*: In all the above, one can equivalently require the neighborhoods to be open.
 

--- a/properties/P000206.md
+++ b/properties/P000206.md
@@ -16,7 +16,8 @@ Let $V_{-1}=X$. During round $n<\omega$
 of this game, Player 1 chooses a point $x_n$ with an open neighborhood $U_n\subseteq V_{n-1}$,
 and Player 2 chooses some open neighborhood $V_n\subseteq U_n$ of $x_n$.
 
-Player 2 wins this game provided $\bigcap\{U_n:n<\omega\}\not=\emptyset$.
+Player 2 wins this game provided
+$\bigcap\{U_n:n<\omega\}\; (= \bigcap\{V_n:n<\omega\}) \not=\emptyset$.
 
 Note: We consider the {P137} space to be {P206} in the sense that
 Player 1 cannot make a legal move to start the game, and therefore loses immediately according

--- a/theorems/T000082.md
+++ b/theorems/T000082.md
@@ -6,7 +6,7 @@ then:
   P000096: true
 ---
 
-Every point $x\in X$ has an open neighborhood $U$ homeomorphic to some $\mathbb R^n_+$.
+Every point $x\in X$ has an open neighborhood $U$ homeomorphic to some convex open subset of $\mathbb R^n_+$.
 The open balls centered at $x$ within the metric space $U$
 (identified with a subset of $\mathbb R^n_+$)
 form a local base of neighborhoods open in $X$ and {P95}.

--- a/theorems/T000082.md
+++ b/theorems/T000082.md
@@ -1,11 +1,12 @@
 ---
 uid: T000082
 if:
-  P000122: true
+  P000235: true
 then:
   P000096: true
 ---
 
-Every point $x\in X$ has an open neighborhood $U$ homeomorphic to some $\mathbb R^n$.
-The open balls centered at $x$ within $U$
+Every point $x\in X$ has an open neighborhood $U$ homeomorphic to some $\mathbb R^n_+$.
+The open balls centered at $x$ within the metric space $U$
+(identified with a subset of $\mathbb R^n_+$)
 form a local base of neighborhoods open in $X$ and {P95}.

--- a/theorems/T000171.md
+++ b/theorems/T000171.md
@@ -2,16 +2,13 @@
 uid: T000171
 if:
   and:
-  - P000122: true
+  - P000235: true
   - P000125: true
 then:
   P000039: false
-refs:
-- zb: "0951.54001"
-  name: Topology (Munkres)
 ---
 
-If there is a point $x\in X$ that has an open neighborhood $U$ homeomorphic to
-$\mathbb R^n$ with $n\ge 1$, the open set $U$ contains two disjoint
+If some point $x\in X$ has an open neighborhood $U$ homeomorphic to
+$\mathbb R^n$ or $\mathbb R^n_+$ with $n\ge 1$, the open set $U$ contains two disjoint
 nonempty open sets, themselves open in $X$.  Otherwise, every point is isolated;
 so two distinct points are contained in two disjoint nonempty open sets.

--- a/theorems/T000172.md
+++ b/theorems/T000172.md
@@ -8,7 +8,7 @@ then:
 
 After Player 1 chooses an open set $U_0$ and a point $x_0\in U_0$,
 Player 2 can choose a open neighborhood $V_0\subseteq U_0$ of $x_0$
-with $V_0$ homeomorphic to some $\mathbb R^n$ or $\mathbb R^n_+$.
+homeomorphic to some $\mathbb R^n$ or $\mathbb R^n_+$.
 The rest of the game is played on $V_0$ and Player 2 has a winning strategy
 since $\mathbb R^n$ and $\mathbb R^n_+$ are both {P206}
 [(Explore)](https://topology.pi-base.org/spaces?q=Completely+metrizable+%2B+%7EStrongly+Choquet).

--- a/theorems/T000172.md
+++ b/theorems/T000172.md
@@ -1,10 +1,14 @@
 ---
 uid: T000172
 if:
-  P000122: true
+  P000235: true
 then:
   P000206: true
 ---
 
-Player 2 can choose a neighborhood $V_0$ that is homeomorphic to some $\mathbb R^n$.
-Then the game is played on $\mathbb R^n$ and Player 2 can win because $\mathbb R^n$ is {P206} [(Explore)](https://topology.pi-base.org/spaces?q=Completely+metrizable+%2B+%7EEmpty+%2B+%7EStrongly+Choquet).
+After Player 1 chooses an open set $U_0$ and a point $x_0\in U_0$,
+Player 2 can choose a open neighborhood $V_0\subseteq U_0$ of $x_0$
+with $V_0$ homeomorphic to some $\mathbb R^n$ or $\mathbb R^n_+$.
+The rest of the game is played on $V_0$ and Player 2 has a winning strategy
+since $\mathbb R^n$ and $\mathbb R^n_+$ are both {P206}
+[(Explore)](https://topology.pi-base.org/spaces?q=Completely+metrizable+%2B+%7EStrongly+Choquet).

--- a/theorems/T000175.md
+++ b/theorems/T000175.md
@@ -2,7 +2,7 @@
 uid: T000175
 if:
   and:
-  - P000122: true
+  - P000235: true
   - P000018: true
 then:
   P000027: true
@@ -10,4 +10,6 @@ refs:
 - mathse: 4416020
   name: Lindelof and locally Euclidean implies second countable
 ---
-See {{mathse:4416020}}.
+
+Apply the argument in {{mathse:4416020}},
+using the fact that both $\mathbb R^n$ and $\mathbb R^n_+$ are {P27}.

--- a/theorems/T000329.md
+++ b/theorems/T000329.md
@@ -1,11 +1,9 @@
 ---
 uid: T000329
 if:
-  P000122: true
+  P000235: true
 then:
   P000082: true
-refs:
-- zb: "0951.54001"
-  name: Topology (Munkres)
 ---
-Every point has a neighborhood that is homeomorphic to an open subset of some $\mathbb R^n$, hence {P53}.  See Exercise 1 on p. 317 of {{zb:0951.54001}}.
+
+Every point has a neighborhood homeomorphic to some $\mathbb R^n_+$, hence {P53}.

--- a/theorems/T000332.md
+++ b/theorems/T000332.md
@@ -1,12 +1,14 @@
 ---
 uid: T000332
 if:
-  P000122: true
+  P000235: true
 then:
   P000130: true
-
 refs:
   - mathse: 103774
     name: Every manifold is locally compact?
 ---
-Every point has a neighborhood that is homeomorphic to $\mathbb R^n$ for some non-negative integer $n$. Since $\mathbb R^n$ is {P130}, it produces a local base of compact sets.
+
+Every point $p$ has a neighborhood $U$ homeomorphic to some $\mathbb R^n_+$.
+Since $\mathbb R^n_+$ is {P130}, $p$ has a local base of compact neighborhoods in $U$,
+which also form a local base in $X$.

--- a/theorems/T000438.md
+++ b/theorems/T000438.md
@@ -2,11 +2,11 @@
 uid: T000438
 if:
   and:
-  - P000123: true
+  - P000236: true
   - P000139: true
 then:
   P000052: true
 ---
 
-A point is isolated iff it has a neighborhood homeomorphic to $\mathbb R^0$.
+A point is isolated iff it has a neighborhood homeomorphic to $\mathbb R^0_+=\mathbb R^0=\{0\}$.
 So if this holds for one point, it holds for all the points and the space is {P52}.

--- a/theorems/T000537.md
+++ b/theorems/T000537.md
@@ -10,4 +10,4 @@ then:
 
 If one point $x$ has an open neighborhood $U$ homeomorphic to some $\mathbb R^n_+$,
 some point (maybe different from $x$) in $U$ has a neighborhood homeomorphic to $\mathbb R^n$.
-By homomogeneity, every point has a neighborhood homeomorphic to $\mathbb R^n$.
+By homogeneity, every point has a neighborhood homeomorphic to $\mathbb R^n$.

--- a/theorems/T000537.md
+++ b/theorems/T000537.md
@@ -2,11 +2,12 @@
 uid: T000537
 if:
   and:
-  - P000122: true
+  - P000235: true
   - P000086: true
 then:
   P000123: true
 ---
 
-If one point has a neighborhood homeomorphic to $\mathbb R^n$ for some $n$,
-then all points do with the same $n$ via self-homeomorphisms of the space.
+If one point $x$ has an open neighborhood $U$ homeomorphic to some $\mathbb R^n_+$,
+some point (maybe different from $x$) in $U$ has a neighborhood homeomorphic to $\mathbb R^n$.
+By homomogeneity, every point has a neighborhood homeomorphic to $\mathbb R^n$.

--- a/theorems/T000842.md
+++ b/theorems/T000842.md
@@ -11,10 +11,18 @@ refs:
     name: Invariance of domain on Wikipedia
 ---
 
-Suppose a point $x$ has at the same time an open neighborhood homeomorphic to $\mathbb R^n$ or $\mathbb R^n_+$,
-and an open neighborhood homeomorphic to $\mathbb R^m$ or $\mathbb R^m_+$ with $n\ne m$.
-Their intersection is an open set in $X$ homeomorphic to an open set in $\mathbb R^n_+$ and to an open set in $\mathbb R^m_+$.
-And a further open subset of it is homeomorphic to an open set in $\mathbb R^n$ and to an open set in $\mathbb R^m$.
+Suppose a point $x$ has at the same time an open neighborhood homeomorphic to an open subset of $\mathbb R^n_+$,
+and an open neighborhood homeomorphic to an open subset of $\mathbb R^m_+$ with $n\ne m$.
+Their intersection $U\subseteq X$ is a nonempty open set in $X$ homeomorphic to an open set in $\mathbb R^n_+$ and to an open set in $\mathbb R^m_+$.
+
+If $n$ or $m$ equals $0$, the point $x$ is isolated in $X$ and by connectedness $X$ is a singleton, which is {P236};
+so we may assume that $n,m\ge 1$.
+
+Every nonempty open set in $\mathbb R^n_+$ contains a nonempty open set homeomorphic to an open set in $\mathbb R^n$.
+So there is a nonempty open set $V\subseteq U$ homeomorphic to an open set in $\mathbb R^n$.
+Since $V$ is also homeomorphic to an open set in $\mathbb R^m_+$,
+there is a nonempty open set $W\subseteq V$ homeomorphic to an open set in $\mathbb R^m$
+(and also to an open set in $\mathbb R^n$).
 But this is not possible by invariance of domain ({{wikipedia:Invariance_of_domain}}).
 
 It follows that the dimension $n$ at the point $x$ is completely determined by the point,

--- a/theorems/T000842.md
+++ b/theorems/T000842.md
@@ -15,9 +15,6 @@ Suppose a point $x$ has at the same time an open neighborhood homeomorphic to an
 and an open neighborhood homeomorphic to an open subset of $\mathbb R^m_+$ with $n\ne m$.
 Their intersection $U\subseteq X$ is a nonempty open set in $X$ homeomorphic to an open set in $\mathbb R^n_+$ and to an open set in $\mathbb R^m_+$.
 
-If $n$ or $m$ equals $0$, the point $x$ is isolated in $X$ and by connectedness $X$ is a singleton, which is {P236};
-so we may assume that $n,m\ge 1$.
-
 Every nonempty open set in $\mathbb R^n_+$ contains a nonempty open set homeomorphic to an open set in $\mathbb R^n$.
 So there is a nonempty open set $V\subseteq U$ homeomorphic to an open set in $\mathbb R^n$.
 Since $V$ is also homeomorphic to an open set in $\mathbb R^m_+$,

--- a/theorems/T000842.md
+++ b/theorems/T000842.md
@@ -1,0 +1,22 @@
+---
+uid: T000842
+if:
+  and:
+  - P000235: true
+  - P000036: true
+then:
+  P000236: true
+refs:
+  - wikipedia: Invariance_of_domain
+    name: Invariance of domain on Wikipedia
+---
+
+Suppose a point $x$ has at the same time an open neighborhood homeomorphic to $\mathbb R^n$ or $\mathbb R^n_+$,
+and an open neighborhood homeomorphic to $\mathbb R^m$ or $\mathbb R^m_+$ with $n\ne m$.
+Their intersection is an open set in $X$ homeomorphic to an open set in $\mathbb R^n_+$ and to an open set in $\mathbb R^m_+$.
+And a further open subset of it is homeomorphic to an open set in $\mathbb R^n$ and to an open set in $\mathbb R^m$.
+But this is not possible by invariance of domain ({{wikipedia:Invariance_of_domain}}).
+
+It follows that the dimension $n$ at the point $x$ is completely determined by the point,
+and by definition of {P235} the set of points of a given dimension $n$ is open in $X$.
+Since $X$ is {P36}, the dimension must be the same at every point.

--- a/theorems/T000842.md
+++ b/theorems/T000842.md
@@ -13,7 +13,8 @@ refs:
 
 Suppose a point $x$ has at the same time an open neighborhood homeomorphic to an open subset of $\mathbb R^n_+$,
 and an open neighborhood homeomorphic to an open subset of $\mathbb R^m_+$ with $n\ne m$.
-Their intersection $U\subseteq X$ is a nonempty open set in $X$ homeomorphic to an open set in $\mathbb R^n_+$ and to an open set in $\mathbb R^m_+$.
+Their intersection $U$ is a nonempty open set in $X$
+which is homeomorphic to an open set in $\mathbb R^n_+$ and to an open set in $\mathbb R^m_+$.
 
 Every nonempty open set in $\mathbb R^n_+$ contains a nonempty open set homeomorphic to an open set in $\mathbb R^n$.
 So there is a nonempty open set $V\subseteq U$ homeomorphic to an open set in $\mathbb R^n$.


### PR DESCRIPTION
Part 2 of changes for #1736. (Part 1 was #1744)

Updates most theorems with P122 (locally Euclidean) to use P235 (locally a Euclidean half-space).

I did not update the two theorems below, but I think they should also be true for manifolds with boundary.  Hope someone with more background in this area can update them in a separate PR.
- (T461) n-manifold => embeddable into Euclidean space
- (T685) n-manifold + compact + multiple points => not contractible

Part 3 will updates traits for various spaces.
