### PR TITLE
Change meta-property of First countable to wiki standard phrasing

### DIFF
--- a/properties/P000028.md
+++ b/properties/P000028.md
@@ -16,7 +16,6 @@ Defined on page 7 of {{zb:0386.54001}}.
 #### Meta-properties
 
 - This property is hereditary.
-- A space that is locally {P28} (every point has a neighborhood with the property)
-has the property.
+- If each point has a neighborhood with the property, $X$ also has the property.
 - $X$ satisfies this property iff its Kolmogorov quotient $\text{Kol}(X)$ does.
 - This property is preserved by countable products. (Corollary 2.3.14 in {{zb:0684.54001}})


### PR DESCRIPTION
I figured since this change is minor we might not need to open an issue to discuss it, though feel free to disagree with this change of course. I noticed this while working on a recent [MSE question](https://math.stackexchange.com/q/5134305/444923) in which I tried to explore meanings of "local".

(1) The [list of meta-properties on the wiki](https://github.com/pi-base/data/wiki/Conventions-and-Style#user-content-meta-properties) has standardized phrasings which this property file wasn't totally in agreement with. 

(2) Also, the current version on pi-base writes, "locally [First countable](https://topology.pi-base.org/properties/P28) (every point has a neighborhood with the property)", but this usage of "locally" is in conflict with the [pi-base convention stated on the wiki](https://github.com/pi-base/data/wiki/Conventions-and-Style#user-content-local-properties). 

(3) Locally First countable is logically identical to First countable in every sense of "locally", so from one perspective the text currently says "if a space is first countable it is first countable". Maybe it makes more sense to write that version of first countable as an equivalent definition if it really is desirable to have, though I think it can be skipped. 

(4) There are no instances of the usage "locally First countable" appearing in pi-base other than this one.

(5) ["locally first countable"](https://scholar.google.com/scholar?hl=en&as_sdt=0%2C39&q=%22locally+first+countable%22&btnG=) on Google scholar suggests this terminology is really not used in literature as a descriptor of spaces. (It appears once in a 1971 article by Tanaka, which is a general study of the construction "locally (P)-space".)