### PR TITLE
3 new alpha1 theorems

### DIFF
--- a/theorems/T000895.md
+++ b/theorems/T000895.md
@@ -1,0 +1,9 @@
+---
+uid: T000895
+if:
+  P000174: true
+then:
+  P000210: true
+---
+
+Utilising the metaproperties of {P210} and {P174}, we may assume that $X$ is {P57}. But then the assertion follows from already known theorems ([Explore](https://topology.pi-base.org/spaces?q=Countable+%2B+Well-based+%2B+%7E%24%5Calpha_1%24)).

--- a/theorems/T000895.md
+++ b/theorems/T000895.md
@@ -6,7 +6,7 @@ then:
   P000210: true
 ---
 
-To prove the result it is enough to show each of the countable subspaces of $X$ is {P210}.
+To prove the result it is enough to show every countable subspace of $X$ is {P210}.
 Note that each subspace of $X$ is also {P174}.
 So wlog we may assume $X$ is {P57}, and hence {P28}
 [(Explore)](https://topology.pi-base.org/spaces?q=Countable%2BWell-based%2B%7EFirst+countable).

--- a/theorems/T000895.md
+++ b/theorems/T000895.md
@@ -6,4 +6,4 @@ then:
   P000210: true
 ---
 
-Utilising the metaproperties of {P210} and {P174}, we may assume that $X$ is {P57}. But then the assertion follows from already known theorems ([Explore](https://topology.pi-base.org/spaces?q=Countable+%2B+Well-based+%2B+%7E%24%5Calpha_1%24)).
+Utilising the metaproperties of {P210} and {P174}, we may assume that $X$ is {P57}. But then the assertion follows from {T238}, {T748}, {T186} and {T217}.

--- a/theorems/T000895.md
+++ b/theorems/T000895.md
@@ -6,4 +6,8 @@ then:
   P000210: true
 ---
 
-Utilising the metaproperties of {P210} and {P174}, we may assume that $X$ is {P57}. But then the assertion follows from {T238}, {T748}, {T186} and {T217}.
+To prove the result it is enough to show each of the countable subspaces of $X$ is {P210}.
+Note that each subspace of $X$ is also {P174}.
+So wlog we may assume $X$ is {P57}, and hence {P28}
+[(Explore)](https://topology.pi-base.org/spaces?q=Countable%2BWell-based%2B%7EFirst+countable).
+And {T748}.

--- a/theorems/T000896.md
+++ b/theorems/T000896.md
@@ -1,0 +1,9 @@
+---
+uid: T000896
+if:
+  P000147: true
+then:
+  P000210: true
+---
+
+Utilising the metaproperties of {P210} and {P147}, we may assume that $X$ is {P57}. But then the assertion follows from already known theorems ([Explore](https://topology.pi-base.org/spaces?q=Countable+%2B+P-space+%2B+%7E%24%5Calpha_1%24)).

--- a/theorems/T000896.md
+++ b/theorems/T000896.md
@@ -6,4 +6,4 @@ then:
   P000210: true
 ---
 
-Utilising the metaproperties of {P210} and {P147}, we may assume that $X$ is {P57}. But then the assertion follows from already known theorems ([Explore](https://topology.pi-base.org/spaces?q=Countable+%2B+P-space+%2B+%7E%24%5Calpha_1%24)).
+Utilising the metaproperties of {P210} and {P147}, we may assume that $X$ is {P57}. But then the assertion follows from {T238}, {T748}, {T894} and {T285}.

--- a/theorems/T000896.md
+++ b/theorems/T000896.md
@@ -6,4 +6,8 @@ then:
   P000210: true
 ---
 
-Utilising the metaproperties of {P210} and {P147}, we may assume that $X$ is {P57}. But then the assertion follows from {T238}, {T748}, {T894} and {T285}.
+To prove the result it is enough to show every countable subspace of $X$ is {P210}.
+Note that each subspace of $X$ is also {P147}.
+So wlog we may assume $X$ is {P57}, and hence {P28}
+[(Explore)](https://topology.pi-base.org/spaces?q=Countable%2BP-space%2B%7EFirst+countable).
+And {T748}.

--- a/theorems/T000897.md
+++ b/theorems/T000897.md
@@ -1,0 +1,9 @@
+---
+uid: T000897
+if:
+  P000187: true
+then:
+  P000210: true
+---
+
+Utilising the metaproperties of {P210} and {P187}, we may assume that $X$ is {P57}. But then the assertion follows from already known theorems ([Explore](https://topology.pi-base.org/spaces?q=Countable+%2B+W-space+%2B+%7E%24%5Calpha_1%24)).

--- a/theorems/T000897.md
+++ b/theorems/T000897.md
@@ -6,4 +6,8 @@ then:
   P000210: true
 ---
 
-Utilising the metaproperties of {P210} and {P187}, we may assume that $X$ is {P57}. But then the assertion follows from {T238}, {T580} and {T748}.
+To prove the result it is enough to show every countable subspace of $X$ is {P210}.
+Note that each subspace of $X$ is also {P187}.
+So wlog we may assume $X$ is {P57}, and hence {P28}
+[(Explore)](https://topology.pi-base.org/spaces?q=Countable%2BW-space%2B%7EFirst+countable).
+And {T748}.

--- a/theorems/T000897.md
+++ b/theorems/T000897.md
@@ -6,4 +6,4 @@ then:
   P000210: true
 ---
 
-Utilising the metaproperties of {P210} and {P187}, we may assume that $X$ is {P57}. But then the assertion follows from already known theorems ([Explore](https://topology.pi-base.org/spaces?q=Countable+%2B+W-space+%2B+%7E%24%5Calpha_1%24)).
+Utilising the metaproperties of {P210} and {P187}, we may assume that $X$ is {P57}. But then the assertion follows from {T238}, {T580} and {T748}.


### PR DESCRIPTION
(I know I said I wouldnt open new PRs for now, but I really like the results here.)

This implements the missing theorems from [this](https://github.com/pi-base/data/pull/1619#issuecomment-3919090335) comment.

This gives two more traits, but very plausible many more (since for 14/17 remaining spaces either W-space, P-space or well based is still unknown).

We cant use explore to refer the the theorems used in the proof, otherwise the explore will just refer to the theorem itself, I tested this.
(Except for some reason for the third one it works as intended; to keep consistent and more stable to potential changes to pibase, lets keep it like it is however)

**This PR has medium priority!**