### PR TITLE
Initial PR for countable pi-weight/pi-character

### DIFF
--- a/properties/P000243.md
+++ b/properties/P000243.md
@@ -6,7 +6,14 @@ refs:
     name: Cardinal functions I (R. Hodel), Ch. 1 of Handbook of set-theoretic topology
 ---
 
-$X$ has a countable *$\pi$-base*, meaning there is a countable family $\mathcal{V}$ of nonempty open subsets of $X$ such that, for every nonempty open $Y \subseteq X$, there is $Y' \in \mathcal{V}$ with $Y' \subseteq Y$.
+$X$ has a countable $\pi$-base.
+A *$\pi$-base* for $X$ is a collection $\mathcal{V}$ of nonempty open sets in $X$ such that every nonempty open $U\subseteq X$ contains some $V\in\mathcal V$.
+
+Such a space has countable $\pi$-weight, where the *$\pi$-weight* is defined as
+
+$\quad\quad\pi w(X):=\min\{|\mathcal V|:\mathcal V \text{ is a }\pi\text{-base for }X\}+\omega.$
+
+Defined on page 14 of {{zb:0559.54003}}.
 
 ----
 #### Meta-properties

--- a/properties/P000243.md
+++ b/properties/P000243.md
@@ -6,7 +6,7 @@ refs:
     name: Handbook of set-theoretic topology (Kunen, Vaughan)
 ---
 
-$X$ has a countable $\pi$-base, meaning there is a countable family $\mathcal{V}$ of nonempty open subsets of $X$ so that, for every nonempty open $Y \subseteq X$, there is $Y' \in \mathcal{V}$ with $Y' \subseteq Y$.
+$X$ has a countable *$\pi$-base*, meaning there is a countable family $\mathcal{V}$ of nonempty open subsets of $X$ such that, for every nonempty open $Y \subseteq X$, there is $Y' \in \mathcal{V}$ with $Y' \subseteq Y$.
 
 ----
 #### Meta-properties

--- a/properties/P000243.md
+++ b/properties/P000243.md
@@ -11,4 +11,4 @@ $X$ has a countable $\pi$-base, meaning there is a countable family $\mathcal{V}
 ----
 #### Meta-properties
 
-- This property is hereditary for dense subspaces.
+- This property is hereditary with respect to dense sets.

--- a/properties/P000243.md
+++ b/properties/P000243.md
@@ -2,8 +2,8 @@
 uid: P000243
 name: Has countable $\pi$-weight
 refs:
-  - zb: "0546.00022"
-    name: Handbook of set-theoretic topology (Kunen, Vaughan)
+  - zb: "0559.54003"
+    name: Cardinal functions I (R. Hodel), Ch. 1 of Handbook of set-theoretic topology
 ---
 
 $X$ has a countable *$\pi$-base*, meaning there is a countable family $\mathcal{V}$ of nonempty open subsets of $X$ such that, for every nonempty open $Y \subseteq X$, there is $Y' \in \mathcal{V}$ with $Y' \subseteq Y$.

--- a/properties/P000243.md
+++ b/properties/P000243.md
@@ -1,0 +1,14 @@
+---
+uid: P000243
+name: Has countable $\pi$-weight
+refs:
+  - zb: "0546.00022"
+    name: Handbook of set-theoretic topology (Kunen, Vaughan)
+---
+
+$X$ has a countable $\pi$-base, meaning there is a countable family $\mathcal{V}$ of nonempty open subsets of $X$ so that, for every nonempty open $Y \subseteq X$, there is $Y' \in \mathcal{V}$ with $Y' \subseteq Y$.
+
+----
+#### Meta-properties
+
+- This property is hereditary for dense subspaces.

--- a/properties/P000244.md
+++ b/properties/P000244.md
@@ -6,7 +6,7 @@ refs:
     name: Handbook of set-theoretic topology (Kunen, Vaughan)
 ---
 
-Every point $p \in X$ has a countable local $\pi$-base, meaning there is a countable family $\mathcal{V}$ of nonempty open subsets of $X$ so that, for every nonempty open $Y \subseteq X$ where $p \in Y$, there is $Y' \in \mathcal{V}$ with $Y' \subseteq Y$. (NB: We don't require that $p \in Y'$.)
+Every point $x \in X$ has a countable local *$\pi$-base*, meaning there is a countable family $\mathcal{V}_x$ of nonempty open subsets of $X$ such that, for every nonempty open $Y \subseteq X$ where $p \in Y$, there is $Y' \in \mathcal{V}_x$ with $Y' \subseteq Y$. (NB: We don't require that $p \in Y'$.)
 
 ----
 #### Meta-properties

--- a/properties/P000244.md
+++ b/properties/P000244.md
@@ -11,7 +11,7 @@ Every point in $X$ has a countable local $\pi$-base.
 A *local $\pi$-base* for $p \in X$ is a collection $\mathcal{V}_x$ of nonempty open sets in $X$ such that every nonempty open $U \subseteq X$ with $p \in U$ contains some $V \in \mathcal V_x$. (NB: We don't require that $p \in V$, i.e. that the elements of $\mathcal{V}_x$ are neighbourhoods of the point.)
 
 Such a space has countable $\pi$-character, where the *$\pi$-character* is defined as
-$\quad\quad\char_pi w(X):=\sup\{\min\{|\mathcal V|:\mathcal V \text{ is a local }\pi\text{-base for }p \in X\}+\omega: p \in X\}.$
+$\quad\quad\pi_\chi(X):=\sup\{\min\{|\mathcal V|:\mathcal V \text{ is a local }\pi\text{-base for }p \in X\}+\omega: p \in X\}.$
 
 ----
 #### Meta-properties

--- a/properties/P000244.md
+++ b/properties/P000244.md
@@ -2,11 +2,16 @@
 uid: P000244
 name: Has countable $\pi$-character
 refs:
-  - zb: "0546.00022"
-    name: Handbook of set-theoretic topology (Kunen, Vaughan)
+  - zb: "0559.54003"
+    name: Cardinal functions I (R. Hodel), Ch. 1 of Handbook of set-theoretic topology
 ---
 
-Every point $x \in X$ has a countable local *$\pi$-base*, meaning there is a countable family $\mathcal{V}_x$ of nonempty open subsets of $X$ such that, for every nonempty open $Y \subseteq X$ where $p \in Y$, there is $Y' \in \mathcal{V}_x$ with $Y' \subseteq Y$. (NB: We don't require that $p \in Y'$.)
+Every point in $X$ has a countable local $\pi$-base.
+
+A *local $\pi$-base* for $p \in X$ is a collection $\mathcal{V}$ of nonempty open sets in $X$ such that every nonempty open $U \subseteq X$ with $p \in U$ contains some $V \in \mathcal V$. (NB: We don't require that $p \in V$, i.e. that the elements of the local $\pi$-base are neighbourhoods of the point.)
+
+Such a space has countable $\pi$-character, where the *$\pi$-character* is defined as
+$\quad\quad\char_pi w(X):=\sup\{\min\{|\mathcal V|:\mathcal V \text{ is a local }\pi\text{-base for }p \in X\}+\omega: p \in X\}.$
 
 ----
 #### Meta-properties

--- a/properties/P000244.md
+++ b/properties/P000244.md
@@ -1,0 +1,14 @@
+---
+uid: P000244
+name: Has countable $\pi$-character
+refs:
+  - zb: "0546.00022"
+    name: Handbook of set-theoretic topology (Kunen, Vaughan)
+---
+
+Every point $p \in X$ has a countable local $\pi$-base, meaning there is a countable family $\mathcal{V}$ of nonempty open subsets of $X$ so that, for every nonempty open $Y \subseteq X$ where $p \in Y$, there is $Y' \in \mathcal{V}$ with $Y' \subseteq Y$. (NB: We don't require that $p \in Y'$.)
+
+----
+#### Meta-properties
+
+- This property is hereditary for dense subspaces.

--- a/properties/P000244.md
+++ b/properties/P000244.md
@@ -11,4 +11,4 @@ Every point $p \in X$ has a countable local $\pi$-base, meaning there is a count
 ----
 #### Meta-properties
 
-- This property is hereditary for dense subspaces.
+- This property is hereditary with respect to dense sets.

--- a/properties/P000244.md
+++ b/properties/P000244.md
@@ -8,7 +8,7 @@ refs:
 
 Every point in $X$ has a countable local $\pi$-base.
 
-A *local $\pi$-base* for $p \in X$ is a collection $\mathcal{V}$ of nonempty open sets in $X$ such that every nonempty open $U \subseteq X$ with $p \in U$ contains some $V \in \mathcal V$. (NB: We don't require that $p \in V$, i.e. that the elements of the local $\pi$-base are neighbourhoods of the point.)
+A *local $\pi$-base* for $p \in X$ is a collection $\mathcal{V}_x$ of nonempty open sets in $X$ such that every nonempty open $U \subseteq X$ with $p \in U$ contains some $V \in \mathcal V_x$. (NB: We don't require that $p \in V$, i.e. that the elements of $\mathcal{V}_x$ are neighbourhoods of the point.)
 
 Such a space has countable $\pi$-character, where the *$\pi$-character* is defined as
 $\quad\quad\char_pi w(X):=\sup\{\min\{|\mathcal V|:\mathcal V \text{ is a local }\pi\text{-base for }p \in X\}+\omega: p \in X\}.$

--- a/theorems/T000899.md
+++ b/theorems/T000899.md
@@ -6,4 +6,4 @@ then:
   P000244: true
 ---
 
-A countable $\pi$-base will also be a countable local $\pi$-base around any point.
+A countable $\pi$-base is also a countable local $\pi$-base around any point.

--- a/theorems/T000899.md
+++ b/theorems/T000899.md
@@ -1,0 +1,9 @@
+---
+uid: T000899
+if:
+  P000243: true
+then:
+  P000244: true
+---
+
+A countable $\pi$-base will also be a countable local $\pi$-base around any point.

--- a/theorems/T000900.md
+++ b/theorems/T000900.md
@@ -6,4 +6,6 @@ then:
   P000026: true
 ---
 
-Let $\mathcal{V} = \{Y_n: n < \omega\}$ be a countable $\pi$-base. Since $Y_n \neq \emptyset$ for all $n$, we may choose $x_n \in Y_n$. Then $\{x_n: n < \omega\}$ is dense, because if $O \neq \emptyset$ then there is $n$ so that $Y_n \subseteq O$, and then $x_n \in O$.
+Let $\mathcal{V} = \{Y_n: n < \omega\}$ be a countable $\pi$-base. Since $Y_n \neq \emptyset$ for all $n$, we may choose some $x_n \in Y_n$.
+
+Then $\{x_n: n < \omega\}$ is dense, because if $O$ is some nonempty open set, there is a $n$ such that $Y_n \subseteq O$ and thus $x_n \in O$.

--- a/theorems/T000900.md
+++ b/theorems/T000900.md
@@ -1,0 +1,9 @@
+---
+uid: T000900
+if:
+  P000243: true
+then:
+  P000026: true
+---
+
+Let $\mathcal{V} = \{Y_n: n < \omega\}$ be a countable $\pi$-base. Since $Y_n \neq \emptyset$ for all $n$, we may choose $x_n \in Y_n$. Then $\{x_n: n < \omega\}$ is dense, because if $O \neq \emptyset$ then there is $n$ so that $Y_n \subseteq O$, and then $x_n \in O$.

--- a/theorems/T000901.md
+++ b/theorems/T000901.md
@@ -1,0 +1,9 @@
+---
+uid: T000901
+if:
+  P000228: true
+then:
+  P000244: true
+---
+
+Let $(V_n(x))_{n \in \mathbb{N}}$ witness {P228} and choose $\mathcal{V}_x := \{V_n(x): n \in \mathbb{N}\}$.

--- a/theorems/T000902.md
+++ b/theorems/T000902.md
@@ -1,0 +1,9 @@
+---
+uid: T000902
+if:
+  P000027: true
+then:
+  P000243: true
+---
+
+Follows since a topological base is a $\pi$-base.


### PR DESCRIPTION
I added "Has countable $\pi$-weight" and "Has countable $\pi$-character" and the fact that the former implies the latter and separability.

See #1712