### PR TITLE
T906: Urysohn's metrization theorem

### DIFF
--- a/theorems/T000906.md
+++ b/theorems/T000906.md
@@ -1,0 +1,14 @@
+---
+uid: T000906
+if:
+  and:
+  - P000027: true
+  - P000005 : true
+then:
+  P000053: true
+refs:
+- zb: "1052.54001"
+  name: General Topology (Willard)
+---
+
+This is *Urysohn's metrization theorem* (Theorem 23.1 in {{zb:1052.54001}}).


### PR DESCRIPTION
Adding the Urysohn's metrization theorem:
- second countable + T3 => metrizable.

Previously, it was derivable from some non-trivial results about $\aleph$-spaces.  Since it's such an important result, it seems worth to have it explicitly.
