### PR TITLE
Sphere is not weakly contractible

### DIFF
--- a/spaces/S000169/properties/P000242.md
+++ b/spaces/S000169/properties/P000242.md
@@ -1,0 +1,7 @@
+---
+space: S000169
+property: P000242
+value: false
+---
+
+The identity map $\mathrm{id} : S^2 \to S^2$ is not homotopic to the constant map. Equivalently, $\pi_2(S^2) \cong \mathbb{Z}\neq \{e\}$.


### PR DESCRIPTION
Simple trait addition.
This gives a non-empty counterexample to converse of [weakly contractible => simply connected](https://topology.pi-base.org/theorems/T000890).
I wrote this in two equivalent formulations, let me know which one is preferred 👍 .