### PR TITLE
omega+omega+1 is not Toronto

### DIFF
--- a/spaces/S000034/properties/P000219.md
+++ b/spaces/S000034/properties/P000219.md
@@ -1,0 +1,7 @@
+---
+space: S000034
+property: P000219
+value: false
+---
+
+The subset {S33} has the same cardinality as the whole space but they are not homeomorphic (for example {{S34|P16}} while {S33|P16}).


### PR DESCRIPTION
Another simple trait, resolves [S34|P219](https://topology.pi-base.org/spaces/S000034/properties/P000219).

It seems like there is no ordinal space that is Toronto and not discrete ([Explore](https://topology.pi-base.org/spaces?q=Ordinal+space+%2B+Toronto+%2B+%7EDiscrete)), but I don't really have a good clue on how to (dis)prove that. Maybe worth looking into later.