### PR TITLE
Add CW complex trait to eight spaces (#1798)

### DIFF
--- a/spaces/S000025/properties/P000240.md
+++ b/spaces/S000025/properties/P000240.md
@@ -1,0 +1,14 @@
+---
+space: S000025
+property: P000240
+value: true
+refs:
+  - zb: "1044.55001"
+    name: Algebraic Topology (Hatcher)
+---
+
+The real line can be given a CW complex structure with $0$-cells indexed by $\mathbb Z$ and one $1$-cell for each interval $[n,n+1]$, where $n \in \mathbb Z$.
+
+This cell structure is locally finite, so the CW topology is the usual Euclidean topology on $\mathbb R$.
+
+See the definition of CW complexes in {{zb:1044.55001}}.

--- a/spaces/S000025/properties/P000240.md
+++ b/spaces/S000025/properties/P000240.md
@@ -4,6 +4,6 @@ property: P000240
 value: true
 ---
 
-The real line can be given a CW complex structure with $0$-cells indexed by $\mathbb Z$ and one $1$-cell for each interval $[n,n+1]$, where $n \in \mathbb Z$.
+The real line has a CW structure whose $0$-cells are the points of $\mathbb Z$ and with one $1$-cell for each interval $[n,n+1]$, $n \in \mathbb Z$, attached by the inclusion of its endpoints.
 
-This cell structure is locally finite, so the CW topology is the usual Euclidean topology on $\mathbb R$.
+A subset of $\mathbb R$ is closed exactly when its intersection with each closed cell $[n,n+1]$ is closed, so the weak topology of this cell structure is the usual topology on $\mathbb R$.

--- a/spaces/S000025/properties/P000240.md
+++ b/spaces/S000025/properties/P000240.md
@@ -6,4 +6,4 @@ value: true
 
 The real line has a CW structure whose $0$-cells are the points of $\mathbb Z$ and with one $1$-cell for each interval $[n,n+1]$, $n \in \mathbb Z$, attached by the inclusion of its endpoints.
 
-A subset of $\mathbb R$ is closed exactly when its intersection with each closed cell $[n,n+1]$ is closed, so the weak topology of this cell structure is the usual topology on $\mathbb R$.
+This cell structure is locally finite, so its weak topology is the usual Euclidean topology on $\mathbb R$.

--- a/spaces/S000025/properties/P000240.md
+++ b/spaces/S000025/properties/P000240.md
@@ -2,13 +2,8 @@
 space: S000025
 property: P000240
 value: true
-refs:
-  - zb: "1044.55001"
-    name: Algebraic Topology (Hatcher)
 ---
 
 The real line can be given a CW complex structure with $0$-cells indexed by $\mathbb Z$ and one $1$-cell for each interval $[n,n+1]$, where $n \in \mathbb Z$.
 
 This cell structure is locally finite, so the CW topology is the usual Euclidean topology on $\mathbb R$.
-
-See the definition of CW complexes in {{zb:1044.55001}}.

--- a/spaces/S000139/properties/P000240.md
+++ b/spaces/S000139/properties/P000240.md
@@ -1,0 +1,14 @@
+---
+space: S000139
+property: P000240
+value: true
+refs:
+  - zb: "1044.55001"
+    name: Algebraic Topology (Hatcher)
+---
+
+The quotient $\mathbb R/\mathbb Z$ can be given a CW complex structure with one $0$-cell, namely the image of $\mathbb Z$, and one $1$-cell for each interval $[n,n+1]$, where $n \in \mathbb Z$, with both endpoints attached to the $0$-cell.
+
+This is the standard CW structure on a countable wedge of circles. The weak topology is the quotient topology described in the README, not the coarser topology on {S201}.
+
+See the definition of CW complexes in {{zb:1044.55001}}.

--- a/spaces/S000139/properties/P000240.md
+++ b/spaces/S000139/properties/P000240.md
@@ -4,6 +4,6 @@ property: P000240
 value: true
 ---
 
-The quotient $\mathbb R/\mathbb Z$ can be given a CW complex structure with one $0$-cell, namely the image of $\mathbb Z$, and one $1$-cell for each interval $[n,n+1]$, where $n \in \mathbb Z$, with both endpoints attached to the $0$-cell.
+The quotient $\mathbb R/\mathbb Z$ has a CW structure with one $0$-cell, the image of $\mathbb Z$, and one $1$-cell for each interval $[n,n+1]$, $n \in \mathbb Z$, both of whose endpoints are attached to the $0$-cell. This is the standard CW structure on a countable wedge of circles.
 
-This is the standard CW structure on a countable wedge of circles. The weak topology is the quotient topology described in the README, not the coarser topology on {S201}.
+A subset of $X$ is closed exactly when its preimage in $\mathbb R$ is closed, so the weak topology of this cell structure is the quotient topology that defines $X$.

--- a/spaces/S000139/properties/P000240.md
+++ b/spaces/S000139/properties/P000240.md
@@ -2,13 +2,8 @@
 space: S000139
 property: P000240
 value: true
-refs:
-  - zb: "1044.55001"
-    name: Algebraic Topology (Hatcher)
 ---
 
 The quotient $\mathbb R/\mathbb Z$ can be given a CW complex structure with one $0$-cell, namely the image of $\mathbb Z$, and one $1$-cell for each interval $[n,n+1]$, where $n \in \mathbb Z$, with both endpoints attached to the $0$-cell.
 
 This is the standard CW structure on a countable wedge of circles. The weak topology is the quotient topology described in the README, not the coarser topology on {S201}.
-
-See the definition of CW complexes in {{zb:1044.55001}}.

--- a/spaces/S000158/properties/P000240.md
+++ b/spaces/S000158/properties/P000240.md
@@ -2,13 +2,8 @@
 space: S000158
 property: P000240
 value: true
-refs:
-  - zb: "1044.55001"
-    name: Algebraic Topology (Hatcher)
 ---
 
 The unit interval can be given a CW complex structure with two $0$-cells, $\{0\}$ and $\{1\}$, and one $1$-cell attached between them.
 
 The resulting CW topology is the usual topology on $[0,1]$.
-
-See the definition of CW complexes in {{zb:1044.55001}}.

--- a/spaces/S000158/properties/P000240.md
+++ b/spaces/S000158/properties/P000240.md
@@ -1,0 +1,14 @@
+---
+space: S000158
+property: P000240
+value: true
+refs:
+  - zb: "1044.55001"
+    name: Algebraic Topology (Hatcher)
+---
+
+The unit interval can be given a CW complex structure with two $0$-cells, $\{0\}$ and $\{1\}$, and one $1$-cell attached between them.
+
+The resulting CW topology is the usual topology on $[0,1]$.
+
+See the definition of CW complexes in {{zb:1044.55001}}.

--- a/spaces/S000162/properties/P000240.md
+++ b/spaces/S000162/properties/P000240.md
@@ -1,7 +1,0 @@
----
-space: S000162
-property: P000240
-value: true
----
-
-The singleton has a CW structure consisting of a single $0$-cell and no cells of higher dimension.

--- a/spaces/S000162/properties/P000240.md
+++ b/spaces/S000162/properties/P000240.md
@@ -1,0 +1,7 @@
+---
+space: S000162
+property: P000240
+value: true
+---
+
+The singleton has a CW structure consisting of a single $0$-cell and no cells of higher dimension.

--- a/spaces/S000168/properties/P000240.md
+++ b/spaces/S000168/properties/P000240.md
@@ -1,0 +1,14 @@
+---
+space: S000168
+property: P000240
+value: true
+refs:
+  - zb: "1044.55001"
+    name: Algebraic Topology (Hatcher)
+---
+
+The real projective plane can be given the standard CW complex structure with one cell in each dimension $0$, $1$, and $2$. The $1$-skeleton is a circle, and the $2$-cell is attached by the degree-$2$ map $S^1 \to S^1$.
+
+This gives the usual quotient topology on $\mathbb RP^2$.
+
+See Example 0.4 in {{zb:1044.55001}}.

--- a/spaces/S000176/properties/P000240.md
+++ b/spaces/S000176/properties/P000240.md
@@ -6,4 +6,4 @@ value: true
 
 The Euclidean plane has a CW structure given by the integer grid: the $0$-cells are the lattice points $\mathbb Z^2$, the $1$-cells are the horizontal and vertical unit grid segments, and the $2$-cells are the unit squares, each attached by the inclusion of its boundary.
 
-A subset of $\mathbb R^2$ is closed exactly when its intersection with each closed unit square is closed, so the weak topology of this cell structure is the usual topology on $\mathbb R^2$.
+This cell structure is locally finite, so its weak topology is the usual Euclidean topology on $\mathbb R^2$.

--- a/spaces/S000176/properties/P000240.md
+++ b/spaces/S000176/properties/P000240.md
@@ -1,0 +1,14 @@
+---
+space: S000176
+property: P000240
+value: true
+refs:
+  - zb: "1044.55001"
+    name: Algebraic Topology (Hatcher)
+---
+
+The Euclidean plane can be given a CW complex structure using the integer grid: $0$-cells are the lattice points $\mathbb Z^2$, $1$-cells are the horizontal and vertical unit grid segments, and $2$-cells are the unit squares.
+
+This cell structure is locally finite, so the CW topology is the usual Euclidean topology on $\mathbb R^2$.
+
+See the definition of CW complexes in {{zb:1044.55001}}.

--- a/spaces/S000176/properties/P000240.md
+++ b/spaces/S000176/properties/P000240.md
@@ -4,6 +4,6 @@ property: P000240
 value: true
 ---
 
-The Euclidean plane can be given a CW complex structure using the integer grid: $0$-cells are the lattice points $\mathbb Z^2$, $1$-cells are the horizontal and vertical unit grid segments, and $2$-cells are the unit squares.
+The Euclidean plane has a CW structure given by the integer grid: the $0$-cells are the lattice points $\mathbb Z^2$, the $1$-cells are the horizontal and vertical unit grid segments, and the $2$-cells are the unit squares, each attached by the inclusion of its boundary.
 
-This cell structure is locally finite, so the CW topology is the usual Euclidean topology on $\mathbb R^2$.
+A subset of $\mathbb R^2$ is closed exactly when its intersection with each closed unit square is closed, so the weak topology of this cell structure is the usual topology on $\mathbb R^2$.

--- a/spaces/S000176/properties/P000240.md
+++ b/spaces/S000176/properties/P000240.md
@@ -2,13 +2,8 @@
 space: S000176
 property: P000240
 value: true
-refs:
-  - zb: "1044.55001"
-    name: Algebraic Topology (Hatcher)
 ---
 
 The Euclidean plane can be given a CW complex structure using the integer grid: $0$-cells are the lattice points $\mathbb Z^2$, $1$-cells are the horizontal and vertical unit grid segments, and $2$-cells are the unit squares.
 
 This cell structure is locally finite, so the CW topology is the usual Euclidean topology on $\mathbb R^2$.
-
-See the definition of CW complexes in {{zb:1044.55001}}.

--- a/spaces/S000198/properties/P000240.md
+++ b/spaces/S000198/properties/P000240.md
@@ -1,0 +1,14 @@
+---
+space: S000198
+property: P000240
+value: true
+refs:
+  - zb: "1044.55001"
+    name: Algebraic Topology (Hatcher)
+---
+
+The space $\mathbb R\sqcup\{\star\}$ is the disjoint union of the real line and a singleton. Use the CW structure on $\mathbb R$ from {S25|P240}, and add $\{\star\}$ as one further $0$-cell in a separate component.
+
+Equivalently, CW complexes are preserved by arbitrary disjoint unions.
+
+See the definition of CW complexes in {{zb:1044.55001}}.

--- a/spaces/S000198/properties/P000240.md
+++ b/spaces/S000198/properties/P000240.md
@@ -2,13 +2,6 @@
 space: S000198
 property: P000240
 value: true
-refs:
-  - zb: "1044.55001"
-    name: Algebraic Topology (Hatcher)
 ---
 
-The space $\mathbb R\sqcup\{\star\}$ is the disjoint union of the real line and a singleton. Use the CW structure on $\mathbb R$ from {S25|P240}, and add $\{\star\}$ as one further $0$-cell in a separate component.
-
-Equivalently, CW complexes are preserved by arbitrary disjoint unions.
-
-See the definition of CW complexes in {{zb:1044.55001}}.
+{S25|P240} and {S162|P240}, hence so is their disjoint union.

--- a/spaces/S000210/properties/P000240.md
+++ b/spaces/S000210/properties/P000240.md
@@ -2,13 +2,8 @@
 space: S000210
 property: P000240
 value: true
-refs:
-  - zb: "1044.55001"
-    name: Algebraic Topology (Hatcher)
 ---
 
 Let $a_0=0$ and $a_k=1-2^{-k}$ for $k\geq 1$. The interval $[0,1)$ can be given a CW complex structure with $0$-cells $\{a_k:k\geq 0\}$ and one $1$-cell for each interval $[a_k,a_{k+1}]$.
 
 The only accumulation point of the $0$-cells is $1$, which is not in the space. Hence this cell structure is locally finite, so the CW topology is the usual subspace topology on $[0,1)$.
-
-See the definition of CW complexes in {{zb:1044.55001}}.

--- a/spaces/S000210/properties/P000240.md
+++ b/spaces/S000210/properties/P000240.md
@@ -4,6 +4,6 @@ property: P000240
 value: true
 ---
 
-Let $a_0=0$ and $a_k=1-2^{-k}$ for $k\geq 1$. The interval $[0,1)$ can be given a CW complex structure with $0$-cells $\{a_k:k\geq 0\}$ and one $1$-cell for each interval $[a_k,a_{k+1}]$.
+Let $a_0=0$ and $a_k=1-2^{-k}$ for $k\geq 1$. The interval $[0,1)$ has a CW structure with $0$-cells $\{a_k:k\geq 0\}$ and one $1$-cell for each interval $[a_k,a_{k+1}]$, attached by the inclusion of its endpoints.
 
-The only accumulation point of the $0$-cells is $1$, which is not in the space. Hence this cell structure is locally finite, so the CW topology is the usual subspace topology on $[0,1)$.
+Every point of $[0,1)$ lies in $[0,a_k]$ for some $k$, which is covered by the first $k$ cells. A subset of $[0,1)$ is therefore closed exactly when its intersection with each closed cell $[a_k,a_{k+1}]$ is closed, so the weak topology of this cell structure is the usual subspace topology on $[0,1)$.

--- a/spaces/S000210/properties/P000240.md
+++ b/spaces/S000210/properties/P000240.md
@@ -6,4 +6,4 @@ value: true
 
 Let $a_0=0$ and $a_k=1-2^{-k}$ for $k\geq 1$. The interval $[0,1)$ has a CW structure with $0$-cells $\{a_k:k\geq 0\}$ and one $1$-cell for each interval $[a_k,a_{k+1}]$, attached by the inclusion of its endpoints.
 
-Every point of $[0,1)$ lies in $[0,a_k]$ for some $k$, which is covered by the first $k$ cells. A subset of $[0,1)$ is therefore closed exactly when its intersection with each closed cell $[a_k,a_{k+1}]$ is closed, so the weak topology of this cell structure is the usual subspace topology on $[0,1)$.
+The only accumulation point of the $0$-cells is $1$, which is not in the space, so this cell structure is locally finite. Hence its weak topology is the usual subspace topology on $[0,1)$.

--- a/spaces/S000210/properties/P000240.md
+++ b/spaces/S000210/properties/P000240.md
@@ -1,0 +1,14 @@
+---
+space: S000210
+property: P000240
+value: true
+refs:
+  - zb: "1044.55001"
+    name: Algebraic Topology (Hatcher)
+---
+
+Let $a_0=0$ and $a_k=1-2^{-k}$ for $k\geq 1$. The interval $[0,1)$ can be given a CW complex structure with $0$-cells $\{a_k:k\geq 0\}$ and one $1$-cell for each interval $[a_k,a_{k+1}]$.
+
+The only accumulation point of the $0$-cells is $1$, which is not in the space. Hence this cell structure is locally finite, so the CW topology is the usual subspace topology on $[0,1)$.
+
+See the definition of CW complexes in {{zb:1044.55001}}.

--- a/spaces/S000225/properties/P000240.md
+++ b/spaces/S000225/properties/P000240.md
@@ -1,0 +1,14 @@
+---
+space: S000225
+property: P000240
+value: true
+refs:
+  - zb: "1044.55001"
+    name: Algebraic Topology (Hatcher)
+---
+
+The closed upper half-plane can be given a CW complex structure using the integer grid in $\mathbb R\times[0,\infty)$: $0$-cells are the lattice points $\mathbb Z\times\mathbb Z_{\geq 0}$, $1$-cells are the horizontal and vertical unit grid segments, and $2$-cells are the unit squares above the boundary line.
+
+The boundary line $y=0$ is a subcomplex. This cell structure is locally finite, so the CW topology is the usual subspace topology on $\mathbb R^2_+$.
+
+See the definition of CW complexes in {{zb:1044.55001}}.

--- a/spaces/S000225/properties/P000240.md
+++ b/spaces/S000225/properties/P000240.md
@@ -4,6 +4,6 @@ property: P000240
 value: true
 ---
 
-The closed upper half-plane can be given a CW complex structure using the integer grid in $\mathbb R\times[0,\infty)$: $0$-cells are the lattice points $\mathbb Z\times\mathbb Z_{\geq 0}$, $1$-cells are the horizontal and vertical unit grid segments, and $2$-cells are the unit squares above the boundary line.
+The closed upper half-plane has a CW structure given by the integer grid in $\mathbb R\times[0,\infty)$: the $0$-cells are the lattice points $\mathbb Z\times\mathbb Z_{\geq 0}$, the $1$-cells are the horizontal and vertical unit grid segments, and the $2$-cells are the unit squares above the boundary line, each attached by the inclusion of its boundary. The boundary line $y=0$ is a subcomplex.
 
-The boundary line $y=0$ is a subcomplex. This cell structure is locally finite, so the CW topology is the usual subspace topology on $\mathbb R^2_+$.
+A subset of $\mathbb R^2_+$ is closed exactly when its intersection with each closed unit square is closed, so the weak topology of this cell structure is the usual subspace topology on $\mathbb R^2_+$.

--- a/spaces/S000225/properties/P000240.md
+++ b/spaces/S000225/properties/P000240.md
@@ -2,13 +2,8 @@
 space: S000225
 property: P000240
 value: true
-refs:
-  - zb: "1044.55001"
-    name: Algebraic Topology (Hatcher)
 ---
 
 The closed upper half-plane can be given a CW complex structure using the integer grid in $\mathbb R\times[0,\infty)$: $0$-cells are the lattice points $\mathbb Z\times\mathbb Z_{\geq 0}$, $1$-cells are the horizontal and vertical unit grid segments, and $2$-cells are the unit squares above the boundary line.
 
 The boundary line $y=0$ is a subcomplex. This cell structure is locally finite, so the CW topology is the usual subspace topology on $\mathbb R^2_+$.
-
-See the definition of CW complexes in {{zb:1044.55001}}.

--- a/spaces/S000225/properties/P000240.md
+++ b/spaces/S000225/properties/P000240.md
@@ -6,4 +6,4 @@ value: true
 
 The closed upper half-plane has a CW structure given by the integer grid in $\mathbb R\times[0,\infty)$: the $0$-cells are the lattice points $\mathbb Z\times\mathbb Z_{\geq 0}$, the $1$-cells are the horizontal and vertical unit grid segments, and the $2$-cells are the unit squares above the boundary line, each attached by the inclusion of its boundary. The boundary line $y=0$ is a subcomplex.
 
-A subset of $\mathbb R^2_+$ is closed exactly when its intersection with each closed unit square is closed, so the weak topology of this cell structure is the usual subspace topology on $\mathbb R^2_+$.
+This cell structure is locally finite, so its weak topology is the usual subspace topology on $\mathbb R^2_+$.


### PR DESCRIPTION
Adds the CW complex trait to the eight spaces listed in #1798 — S25, S139, S158, S168, S176, S198, S210, S225 — each with an explicit cell structure following the existing S169/S170 format (Hatcher, Ch. 0). S179 is left untouched (consistent-with-ZFC open case), and the secondary closed-world "everything else is not a CW complex" claim is not asserted, since it depends on the still-open #1769. 

Open to all feedback and review. 

Following the policy I also include this:
I used the AI program Claude Code CLI from Anthropic (model version Opus 4.8) to assist in these examples and the coding.