### PR TITLE
New theorems with pi-character

### DIFF
--- a/theorems/T000908.md
+++ b/theorems/T000908.md
@@ -1,0 +1,11 @@
+---
+uid: T000908
+if:
+  and:
+  - P000203: true
+  - P000026: true
+then:
+  P000057: true
+---
+
+Letting $x$ be the only point which is not isolated, and $Y$ be a countable dense set, for every $y \neq x$, $\{y\}$ is nonempty and open, so $\{y\} \cap Y \neq \emptyset$, so $y \in Y$. Therefore $X \setminus \{x\} \subseteq Y$, so $X \setminus \{x\}$ is countable, so $X$ is countable.

--- a/theorems/T000908.md
+++ b/theorems/T000908.md
@@ -8,4 +8,6 @@ then:
   P000057: true
 ---
 
-Letting $x$ be the only point which is not isolated, $\{y\}$ is nonempty and open for every $y \neq x$. Since $\{\{y\}: y \neq x\}$ is a family of pairwise disjoint open sets, it is countable, so $X \setminus \{x\}$ and hence $X$ are countable.
+Let $p$ be the unique non-isolated point.
+By {P29}, $X$ has countably many isolated points.
+Therefore $X\setminus\{p\}$ is countable, and so is $X$.

--- a/theorems/T000908.md
+++ b/theorems/T000908.md
@@ -3,9 +3,9 @@ uid: T000908
 if:
   and:
   - P000203: true
-  - P000026: true
+  - P000029: true
 then:
   P000057: true
 ---
 
-Letting $x$ be the only point which is not isolated, and $Y$ be a countable dense set, for every $y \neq x$, $\{y\}$ is nonempty and open, so $\{y\} \cap Y \neq \emptyset$, so $y \in Y$. Therefore $X \setminus \{x\} \subseteq Y$, so $X \setminus \{x\}$ is countable, so $X$ is countable.
+Letting $x$ be the only point which is not isolated, $\{y\}$ is nonempty and open for every $y \neq x$. Since $\{\{y\}: y \neq x\}$ is a family of pairwise disjoint open sets, it is countable, so $X \setminus \{x\}$ and hence $X$ are countable.

--- a/theorems/T000909.md
+++ b/theorems/T000909.md
@@ -4,14 +4,14 @@ if:
   and:
   - P000174: true
   - P000244: true
-  - P000002: true
+  - P000135: true
 then:
   P000028: true
 ---
 
 Fix some point $x$; we wish to find a countable local base for $x$. Let $\mathcal{U}$ be a local base for $x$, linearly ordered by inclusion, and $\mathcal{A}$ be a countable local $\pi$-base for $x$. WLOG assume $x$ is not isolated (otherwise $\{\{x\}\}$ is a countable local base for $x$).
 Therefore, for any $A \in \mathcal{A}$, there is some $a \in A \setminus \{x\}$.
-By {P2} we can choose some $U_A\in\mathscr U$ that avoids the point $a$; hence $A\not\subseteq U_A$.
+By {P135} we can choose some $U_A\in\mathscr U$ that avoids the point $a$; hence $A\not\subseteq U_A$.
 
 Clearly, $\{U_A: A \in \mathcal{A}\}$ is a countable family of neighbourhoods of $x$; we show that it is cofinal in $\mathcal{U}$ with respect to reverse inclusion, hence a local base for $x$.
 But if $U \in \mathcal{U}$, there is $A \in \mathcal{A}$ with $A \subseteq U$, but since $A \not \subseteq U_A$, we cannot have $U \subseteq U_A$. By the hypothesis that $\mathcal{U}$ is linearly ordered by inclusion, we must have $U_A \subset U$ instead.

--- a/theorems/T000909.md
+++ b/theorems/T000909.md
@@ -11,4 +11,5 @@ then:
 
 Fix some point $x$; we wish to find a countable local base for $x$. Let $\mathcal{U}$ be a local base for $x$, linearly ordered by inclusion, and $\mathcal{A}$ be a countable local $\pi$-base for $x$. WLOG assume $x$ is not isolated (otherwise $\{\{x\}\}$ is a countable local base for $x$). Therefore, for any $A \in \mathcal{A}$, there is some $a \in A \setminus \{x\}$; by $T_1$, we can choose some $U_A \in \mathcal{U}$ with $U_A \subseteq A \setminus \{a\}$.
 
-Clearly, $\{U_A: A \in \mathcal{A}\}$ is a countable family of neighbourhoods of $x$; we show that it is cofinal in $\mathcal{U}$, hence a local base for $x$. But if $U \in \mathcal{U}$, there is $A \in \mathcal{A}$ with $A \subseteq U$, but since $A \not \subseteq U_A$, we cannot have $U \subseteq U_A$. By the hypothesis that $\mathcal{U}$ is linearly ordered by inclusion, we must have $U_A \subset U$ instead.
+Clearly, $\{U_A: A \in \mathcal{A}\}$ is a countable family of neighbourhoods of $x$; we show that it is cofinal in $\mathcal{U}$ with respect to reverse inclusion, hence a local base for $x$.
+But if $U \in \mathcal{U}$, there is $A \in \mathcal{A}$ with $A \subseteq U$, but since $A \not \subseteq U_A$, we cannot have $U \subseteq U_A$. By the hypothesis that $\mathcal{U}$ is linearly ordered by inclusion, we must have $U_A \subset U$ instead.

--- a/theorems/T000909.md
+++ b/theorems/T000909.md
@@ -9,4 +9,6 @@ then:
   P000028: true
 ---
 
-Placeholder!!!!!
+Fix some point $x$; we wish to find a countable local base for $x$. Let $\mathcal{U}$ be a local base for $x$, linearly ordered by inclusion, and $\mathcal{A}$ be a countable local $\pi$-base for $x$. WLOG assume $x$ is not isolated (otherwise $\{\{x\}\}$ is a countable local base for $x$). Therefore, for any $A \in \mathcal{A}$, there is some $a \in A \setminus \{x\}$; by $T_1$, we can choose some $U_A \in \mathcal{U}$ with $U_A \subseteq A \setminus \{a\}$.
+
+Clearly, $\{U_A: A \in \mathcal{A}\}$ is a countable family of neighbourhoods of $x$; we show that it is cofinal in $\mathcal{U}$, hence a local base for $x$. But if $U \in \mathcal{U}$, there is $A \in \mathcal{A}$ with $A \subseteq U$, but since $A \not \subseteq U_A$, we cannot have $U \subseteq U_A$. By the hypothesis that $\mathcal{U}$ is linearly ordered by inclusion, we must have $U_A \subset U$ instead.

--- a/theorems/T000909.md
+++ b/theorems/T000909.md
@@ -9,7 +9,9 @@ then:
   P000028: true
 ---
 
-Fix some point $x$; we wish to find a countable local base for $x$. Let $\mathcal{U}$ be a local base for $x$, linearly ordered by inclusion, and $\mathcal{A}$ be a countable local $\pi$-base for $x$. WLOG assume $x$ is not isolated (otherwise $\{\{x\}\}$ is a countable local base for $x$). Therefore, for any $A \in \mathcal{A}$, there is some $a \in A \setminus \{x\}$; by $T_1$, we can choose some $U_A \in \mathcal{U}$ with $U_A \subseteq A \setminus \{a\}$.
+Fix some point $x$; we wish to find a countable local base for $x$. Let $\mathcal{U}$ be a local base for $x$, linearly ordered by inclusion, and $\mathcal{A}$ be a countable local $\pi$-base for $x$. WLOG assume $x$ is not isolated (otherwise $\{\{x\}\}$ is a countable local base for $x$).
+Therefore, for any $A \in \mathcal{A}$, there is some $a \in A \setminus \{x\}$.
+By {P2} we can choose some $U_A\in\mathscr U$ that avoids the point $a$; hence $A\not\subseteq U_A$.
 
 Clearly, $\{U_A: A \in \mathcal{A}\}$ is a countable family of neighbourhoods of $x$; we show that it is cofinal in $\mathcal{U}$ with respect to reverse inclusion, hence a local base for $x$.
 But if $U \in \mathcal{U}$, there is $A \in \mathcal{A}$ with $A \subseteq U$, but since $A \not \subseteq U_A$, we cannot have $U \subseteq U_A$. By the hypothesis that $\mathcal{U}$ is linearly ordered by inclusion, we must have $U_A \subset U$ instead.

--- a/theorems/T000909.md
+++ b/theorems/T000909.md
@@ -9,9 +9,13 @@ then:
   P000028: true
 ---
 
+Below is a proof that uses {P2} instead of {P135}:
+
 Fix some point $x$; we wish to find a countable local base for $x$. Let $\mathcal{U}$ be a local base for $x$, linearly ordered by inclusion, and $\mathcal{A}$ be a countable local $\pi$-base for $x$. WLOG assume $x$ is not isolated (otherwise $\{\{x\}\}$ is a countable local base for $x$).
 Therefore, for any $A \in \mathcal{A}$, there is some $a \in A \setminus \{x\}$.
-By {P135} we can choose some $U_A\in\mathscr U$ that avoids the point $a$; hence $A\not\subseteq U_A$.
+By {P2} we can choose some $U_A\in\mathscr U$ that avoids the point $a$; hence $A\not\subseteq U_A$.
 
 Clearly, $\{U_A: A \in \mathcal{A}\}$ is a countable family of neighbourhoods of $x$; we show that it is cofinal in $\mathcal{U}$ with respect to reverse inclusion, hence a local base for $x$.
 If $U \in \mathcal{U}$, there is $A \in \mathcal{A}$ with $A \subseteq U$, but since $A \not \subseteq U_A$, we cannot have $U \subseteq U_A$. By the hypothesis that $\mathcal{U}$ is linearly ordered by inclusion, we must have $U_A \subset U$ instead.
+
+By passing to Kolmogorov quotients and appealing to metaproperties, the theorem holds with only {P135}.

--- a/theorems/T000909.md
+++ b/theorems/T000909.md
@@ -14,4 +14,4 @@ Therefore, for any $A \in \mathcal{A}$, there is some $a \in A \setminus \{x\}$.
 By {P135} we can choose some $U_A\in\mathscr U$ that avoids the point $a$; hence $A\not\subseteq U_A$.
 
 Clearly, $\{U_A: A \in \mathcal{A}\}$ is a countable family of neighbourhoods of $x$; we show that it is cofinal in $\mathcal{U}$ with respect to reverse inclusion, hence a local base for $x$.
-But if $U \in \mathcal{U}$, there is $A \in \mathcal{A}$ with $A \subseteq U$, but since $A \not \subseteq U_A$, we cannot have $U \subseteq U_A$. By the hypothesis that $\mathcal{U}$ is linearly ordered by inclusion, we must have $U_A \subset U$ instead.
+If $U \in \mathcal{U}$, there is $A \in \mathcal{A}$ with $A \subseteq U$, but since $A \not \subseteq U_A$, we cannot have $U \subseteq U_A$. By the hypothesis that $\mathcal{U}$ is linearly ordered by inclusion, we must have $U_A \subset U$ instead.

--- a/theorems/T000909.md
+++ b/theorems/T000909.md
@@ -1,0 +1,12 @@
+---
+uid: T000909
+if:
+  and:
+  - P000002: true
+  - P000174: true
+  - P000244: true
+then:
+  P000028: true
+---
+
+Placeholder!!!!!

--- a/theorems/T000909.md
+++ b/theorems/T000909.md
@@ -2,9 +2,9 @@
 uid: T000909
 if:
   and:
-  - P000002: true
   - P000174: true
   - P000244: true
+  - P000002: true
 then:
   P000028: true
 ---

--- a/theorems/T000909.md
+++ b/theorems/T000909.md
@@ -9,8 +9,7 @@ then:
   P000028: true
 ---
 
-Below is a proof that uses {P2} instead of {P135}:
-
+We first handle the case where $X$ is {P2}.
 Fix some point $x$; we wish to find a countable local base for $x$. Let $\mathcal{U}$ be a local base for $x$, linearly ordered by inclusion, and $\mathcal{A}$ be a countable local $\pi$-base for $x$. WLOG assume $x$ is not isolated (otherwise $\{\{x\}\}$ is a countable local base for $x$).
 Therefore, for any $A \in \mathcal{A}$, there is some $a \in A \setminus \{x\}$.
 By {P2} we can choose some $U_A\in\mathscr U$ that avoids the point $a$; hence $A\not\subseteq U_A$.

--- a/theorems/T000909.md
+++ b/theorems/T000909.md
@@ -17,5 +17,6 @@ By {P2} we can choose some $U_A\in\mathscr U$ that avoids the point $a$; hence $
 
 Clearly, $\{U_A: A \in \mathcal{A}\}$ is a countable family of neighbourhoods of $x$; we show that it is cofinal in $\mathcal{U}$ with respect to reverse inclusion, hence a local base for $x$.
 If $U \in \mathcal{U}$, there is $A \in \mathcal{A}$ with $A \subseteq U$, but since $A \not \subseteq U_A$, we cannot have $U \subseteq U_A$. By the hypothesis that $\mathcal{U}$ is linearly ordered by inclusion, we must have $U_A \subset U$ instead.
+This concludes the proof for the {P2} case.
 
-By passing to Kolmogorov quotients and appealing to metaproperties, the theorem holds with only {P135}.
+The general case with {P135} instead of {P2} follows by passing to the Kolmogorov quotient.

--- a/theorems/T000910.md
+++ b/theorems/T000910.md
@@ -8,6 +8,10 @@ then:
   P000057: true
 ---
 
-Let $x \in X$ and $\mathcal{V}$ be a countable local $\pi$-base around $x$. Set $W = \bigcup\{X \setminus V: V \in \mathcal{V}\}$. For any $y \neq x$, $X \setminus \{y\}$ is a neighbourhood of $x$ and so there is $V \in \mathcal{V}$ with $V \subseteq X \setminus \{y\}$. Therefore $y \in X \setminus V \subseteq W$ so, since $y$ was arbitrary, $X \setminus \{x\} \subseteq W$. But $W$ is a countable union of finite sets, so $W$ is countable, so $X$ is countable.
+Let $x \in X$ and let $\mathcal{V}$ be a countable local $\pi$-base around $x$.
+The complement of every $V\in\mathcal V$ is finite; so $W := \bigcup\{X \setminus V: V \in \mathcal{V}\}$ is countable.
+For any point $y \neq x$, $X \setminus \{y\}$ is a neighbourhood of $x$ and so there is some $V \in \mathcal{V}$ with $V \subseteq X \setminus \{y\}$.
+Therefore $y \in X \setminus V \subseteq W$.
+It follows that $X \setminus \{x\} \subseteq W$ and $X$ is countable.
 
 Observe that the above argument only requires some point to have a countable local $\pi$-base, not every point.

--- a/theorems/T000910.md
+++ b/theorems/T000910.md
@@ -1,0 +1,11 @@
+---
+uid: T000910
+if:
+  and:
+  - P000222: true
+  - P000244: true
+then:
+  P000057: true
+---
+
+Placeholder!!!!!

--- a/theorems/T000910.md
+++ b/theorems/T000910.md
@@ -8,4 +8,6 @@ then:
   P000057: true
 ---
 
-Placeholder!!!!!
+Let $x \in X$ and $\mathcal{V}$ be a countable local $\pi$-base around $x$. Set $W = \bigcup\{X \setminus V: V \in \mathcal{V}\}$. For any $y \neq x$, $X \setminus \{y\}$ is a neighbourhood of $x$ and so there is $V \in \mathcal{V}$ with $V \subseteq X \setminus \{y\}$. Therefore $y \in X \setminus V \subseteq W$ so, since $y$ was arbitrary, $X \setminus \{x\} \subseteq W$. But $W$ is a countable union of finite sets, so $W$ is countable, so $X$ is countable.
+
+Observe that the above argument only requires some point to have a countable local $\pi$-base, not every point.

--- a/theorems/T000910.md
+++ b/theorems/T000910.md
@@ -13,5 +13,3 @@ The complement of every $V\in\mathcal V$ is finite; so $W := \bigcup\{X \setminu
 For any point $y \neq x$, $X \setminus \{y\}$ is a neighbourhood of $x$ and so there is some $V \in \mathcal{V}$ with $V \subseteq X \setminus \{y\}$.
 Therefore $y \in X \setminus V \subseteq W$.
 It follows that $X \setminus \{x\} \subseteq W$ and $X$ is countable.
-
-Observe that the above argument only requires some point to have a countable local $\pi$-base, not every point.

--- a/theorems/T000911.md
+++ b/theorems/T000911.md
@@ -8,4 +8,6 @@ then:
   P000244: true
 ---
 
-Let $p$ be the point so that all points other than $p$ are isolated. Since $p$ is not isolated, $X \setminus \{p\}$ is dense so $p \in \overline{X \setminus \{p\}}$. Let $D \subseteq X \setminus \{p\}$ be countable with $p \in \overline{D}$. Then $\{\{x\}: x \in D\}$ forms a countable local $\pi$-base for $p$.
+Let $p$ be the unique non-isolated point.
+Then $p \in \overline{X \setminus \{p\}}$.
+Let $D \subseteq X \setminus \{p\}$ be countable with $p \in \overline{D}$. Then $\{\{x\}: x \in D\}$ forms a countable local $\pi$-base for $p$.

--- a/theorems/T000911.md
+++ b/theorems/T000911.md
@@ -1,0 +1,11 @@
+---
+uid: T000911
+if:
+  and:
+  - P000203: true
+  - P000081: true
+then:
+  P000244: true
+---
+
+Let $p$ be the point so that all points other than $p$ are isolated. Since $p$ is not isolated, $X \setminus \{p\}$ is dense so $p \in \overline{X \setminus \{p\}}$. Let $D \subseteq X \setminus \{p\}$ be countable with $p \in \overline{D}$. Then $\{\{x\}: x \in D\}$ forms a countable local $\pi$-base for $p$.

--- a/theorems/T000912.md
+++ b/theorems/T000912.md
@@ -1,0 +1,11 @@
+---
+uid: T000912
+if:
+  and:
+  - P000203: true
+  - P000167: false
+then:
+  P000244: true
+---
+
+Let $p$ be the unique non-isolated point. Fix a convergent non-eventually constant sequence $(s_n: n \in \mathbb{N})$. Necessarily, its limit is $p$. By passing to a subsequence, we may assume $s_n \neq p$ for all $n$. Then $\{\{s_n\}: n \in \mathbb{N}\}$ is a countable local $\pi$-base for $p$.


### PR DESCRIPTION
- Almost discrete + separable => countable.
- $T_1$ + well-based + has countable $\pi$-character => first countable.
- Has a cofinite topology + has countable $\pi$-character => Countable.

As recommanded in #1712. Any feedback?