### PR TITLE
S226: Gluing of Fortissimo and Sierpinski spaces

### DIFF
--- a/properties/P000021.md
+++ b/properties/P000021.md
@@ -15,3 +15,8 @@ Every infinite set in $X$ has a limit point.
 Equivalently, every closed discrete subset of $X$ is finite.
 
 Defined on page 19 of {{zb:0386.54001}}.
+
+----
+#### Meta-properties
+
+- This property is hereditary with respect to closed sets.

--- a/spaces/S000226/README.md
+++ b/spaces/S000226/README.md
@@ -12,4 +12,4 @@ Two subspaces are worth noting:
 
 $X$ could also be described as the result of "gluing"
 {S155} and {S10} at their limit points;
-that is, $X$ is the quotient of the topological sum of these two spaces with their limit points identified.
+that is, $X$ is homeomorphic to the quotient of the topological sum of these two spaces with their limit points identified.

--- a/spaces/S000226/README.md
+++ b/spaces/S000226/README.md
@@ -3,17 +3,13 @@ uid: S000226
 name: Fortissimo space of size $\aleph_1$ and Sierpinski space glued at their limit points
 ---
 
-$X$ is the quotient of the topological sum of {S155}
-and {S10} with the two limit points identified.
-In more detail, let
-- $Y=$ {S155} with $p$ as non-isolated point;
-- $Z=\{a,b\}$ be {S10} with $a$ as closed non-isolated point and $b$ as isolated point.
+Let $X$ be a set of cardinality $\aleph_1$ with two distinguished points $p,q\in X$.
+Every point $x\ne p$ is isolated and the open neighborhoods of $p$ are the cocountable subsets of $X$ containing both $p$ and $q$.
 
-Then $X=(Y\coprod Z)/{\sim}$ with $p$ and $a$ identified.
+Two subspaces are worth noting:
+- $Y=X\setminus\{q\}$ is homeomorphic to {S155} with $p$ as limit point;
+- $Z=\{p,q\}$ is homeomorphic to {S10} with $p$ as limit point.
 
-*Note*: Both $Y$ and $Z$ embed into $X$ via the quotient map.
-For ease of notation, we'll treat them as subspaces of $X$ and
-also write $p$ for the common limit point in the quotient.
-
-$X$ could also be described as extending {S155}
-by adding one isolated point $b$ with $\overline{\{b\}}=\{b,p\}$.
+$X$ could also be described as the result of "gluing"
+{S155} and {S10} at their limit points;
+that is, $X$ is the quotient of the topological sum of these two spaces with their limit points identified.

--- a/spaces/S000226/README.md
+++ b/spaces/S000226/README.md
@@ -1,0 +1,19 @@
+---
+uid: S000226
+name: Fortissimo space of size $\aleph_1$ and Sierpinski space glued at their limit points
+---
+
+$X$ is the quotient of the topological sum of {S155}
+and {S10} with the two limit points identified.
+In more detail, let
+- $Y=$ {S155} with $p$ as non-isolated point;
+- $Z=\{a,b\}$ be {S10} with $a$ as closed non-isolated point and $b$ as isolated point.
+
+Then $X=(Y\coprod Z)/{\sim}$ with $p$ and $a$ identified.
+
+*Note*: Both $Y$ and $Z$ embed into $X$ via the quotient map.
+For ease of notation, we'll treat them as subspaces of $X$ and
+also write $p$ for the common limit point in the quotient.
+
+$X$ could also be described as extending {S155}
+by adding one isolated point $b$ with $\overline{\{b\}}=\{b,p\}$.

--- a/spaces/S000226/properties/P000002.md
+++ b/spaces/S000226/properties/P000002.md
@@ -1,0 +1,7 @@
+---
+space: S000226
+property: P000002
+value: false
+---
+
+{S10} embeds into $X$ and {S10|P2}.

--- a/spaces/S000226/properties/P000018.md
+++ b/spaces/S000226/properties/P000018.md
@@ -1,0 +1,10 @@
+---
+space: S000226
+property: P000018
+value: true
+---
+
+Let $\mathscr U$ be an open cover of $X$.
+There is a countable $\mathscr V\subseteq\mathscr U$ with $Y\subseteq\bigcup\mathscr V$
+because {S155|P18}.
+Since every neighborhood of $p$ contains $Z$, $\mathscr V$ is also a cover of $X$.

--- a/spaces/S000226/properties/P000021.md
+++ b/spaces/S000226/properties/P000021.md
@@ -1,0 +1,8 @@
+---
+space: S000226
+property: P000021
+value: false
+---
+
+$Y$ is a closed subspace of $X$
+and {S155|P21}.

--- a/spaces/S000226/properties/P000114.md
+++ b/spaces/S000226/properties/P000114.md
@@ -1,0 +1,7 @@
+---
+space: S000226
+property: P000114
+value: true
+---
+
+By construction.

--- a/spaces/S000226/properties/P000136.md
+++ b/spaces/S000226/properties/P000136.md
@@ -1,0 +1,9 @@
+---
+space: S000226
+property: P000136
+value: true
+---
+
+The subspace $Y$ is closed in $X$
+and anticompact ({S155|P136}).
+So every compact subset of $X$ intersects $Y$ in a finite set, and is itself finite.

--- a/spaces/S000226/properties/P000147.md
+++ b/spaces/S000226/properties/P000147.md
@@ -1,0 +1,10 @@
+---
+space: S000226
+property: P000147
+value: true
+---
+
+The neighborhoods of $p$ in $X$ are the sets $V\cup Z$ with $V$ neighborhood of $p$ in $Y$.
+Since {S155|P147},
+$p$ is also a P-point in $X$.
+And every other (isolated) point is trivially a P-point.

--- a/spaces/S000226/properties/P000174.md
+++ b/spaces/S000226/properties/P000174.md
@@ -1,0 +1,11 @@
+---
+space: S000226
+property: P000174
+value: true
+---
+
+The neighborhoods of $p$ in $X$ are the sets $V\cup Z$ with $V$ neighborhood of $p$ in $Y$.
+Since {S155|P174},
+there is a neighborhood base $\mathscr N$ for $p$ in $Y$ that is totally ordered by inclusion.
+Then $\{V\cup Z:V\in\mathscr N\}$ is a totally ordered neighborhood base for $p$ in $X$.
+And $X$ is trivially well-based at each of the other (isolated) points.

--- a/spaces/S000226/properties/P000203.md
+++ b/spaces/S000226/properties/P000203.md
@@ -1,0 +1,7 @@
+---
+space: S000226
+property: P000203
+value: true
+---
+
+All points except $p$ are isolated.

--- a/spaces/S000226/properties/P000229.md
+++ b/spaces/S000226/properties/P000229.md
@@ -1,0 +1,12 @@
+---
+space: S000226
+property: P000229
+value: true
+---
+
+The path components of $X$ are $Z$ and the singletons $\{x\}$ with $x\in Y\setminus\{p\}$
+(because {S10|P37} and
+every $\{x\}$ with $x\in Y\setminus\{p\}$ is clopen in $X$).
+
+And since {S10|P229},
+every path component of $X$ is {P229}.

--- a/spaces/S000226/properties/P000234.md
+++ b/spaces/S000226/properties/P000234.md
@@ -1,0 +1,8 @@
+---
+space: S000226
+property: P000234
+value: false
+---
+
+Every neighborhood $V$ of $p$ contains a point $x\in Y\setminus\{p\}$.
+Hence $V$ is not connected since $\{x\}$ is clopen in $X$.


### PR DESCRIPTION
New S226: Fortissimo space of size $\aleph_1$​ and Sierpinski space glued at their limit points.

This provides an example of both of these:
[π-Base, Search for `Well-based + Has countable $\pi$-character + ~First countable`](https://topology.pi-base.org/spaces?q=Well-based+%2B+Has+countable+%24%5Cpi%24-character+%2B+%7EFirst+countable)
[π-Base, Search for `Almost discrete + ~ Sequentially discrete + ~ Countably tight`](https://topology.pi-base.org/spaces?q=Almost+discrete+%2B+%7E+Sequentially+discrete+%2B+%7E+Countably+tight)

As discussed in https://github.com/pi-base/data/issues/1712#issuecomment-4588227811 and https://github.com/pi-base/data/pull/1807#issuecomment-4821626305.
