### PR TITLE
T913: cid + not discrete => uncountable pi-character

### DIFF
--- a/theorems/T000913.md
+++ b/theorems/T000913.md
@@ -1,0 +1,16 @@
+---
+uid: T000913
+if:
+  and:
+  - P000168: true
+  - P000052: false
+then:
+  P000244: false
+---
+
+Let $x$ be a non-isolated point in $X$
+and let $\mathscr V$ be a countable collection of nonempty open sets.
+To show $X$ has uncountable $\pi$-character, we show that $\mathscr V$ is not a local $\pi$-base for $x$.
+Each $V\in\mathscr V$ contains a point $x_V\ne x$.
+The set $F:=\{x_V:V\in\mathscr V\}$ is countable, hence closed since $X$ is {P168}.
+Then $X\setminus F$ is an open neighborhood of $x$ not containing any $V\in\mathscr V$.

--- a/theorems/T000913.md
+++ b/theorems/T000913.md
@@ -12,5 +12,6 @@ Let $x$ be a non-isolated point in $X$
 and let $\mathscr V$ be a countable collection of nonempty open sets.
 To show $X$ has uncountable $\pi$-character, we show that $\mathscr V$ is not a local $\pi$-base for $x$.
 Each $V\in\mathscr V$ contains a point $x_V\ne x$.
-The set $F:=\{x_V:V\in\mathscr V\}$ is countable, hence closed since $X$ is {P168}.
-Then $X\setminus F$ is an open neighborhood of $x$ not containing any $V\in\mathscr V$.
+One characterization of {P168} is that every countable set is closed.
+So the countable set $F:=\{x_V:V\in\mathscr V\}$ is closed in $X$.
+Its complement $X\setminus F$ is an open neighborhood of $x$ not containing any $V\in\mathscr V$.


### PR DESCRIPTION
New T913: `cid + ~ discrete => ~ countable pi-character`

This allows to derive that 8 more spaces have uncountable pi-character:
[π-Base, Search for `cid + ~ discrete + ? Has countable $\pi$-character`](https://topology.pi-base.org/spaces?q=cid+%2B+%7E+discrete+%2B+%3F+Has+countable+%24%5Cpi%24-character)
