### PR TITLE
P145 hypocompact alias

### DIFF
--- a/properties/P000145.md
+++ b/properties/P000145.md
@@ -1,9 +1,13 @@
 ---
 uid: P000145
 name: Strongly paracompact
+aliases:
+  - Hypocompact
 refs:
   - zb: "0684.54001"
     name: General Topology (Engelking, 1989)
+  - zb: "0207.52704"
+    name: On some generalized compactness properties (J. Greever)
 ---
 
 Every open cover has a star-finite open refinement.
@@ -11,6 +15,7 @@ Every open cover has a star-finite open refinement.
 A family $\mathscr A$ of subsets of $X$ is called *star-finite* if each element of $\mathscr A$ meets at most finitely many elements of $\mathscr A$.
 
 Defined on p. 326 of {{zb:0684.54001}} together with the condition that the space is {P3}.  Here we do not assume any separation axiom as part of the definition.
+Also called *hypocompact*, for example in Definition 2 of {{zb:0207.52704}}.
 
 ----
 #### Meta-properties


### PR DESCRIPTION
Add *hypocompact* as alias for P145 (strongly paracompact).

See #1783.