### PR TITLE
Dieudonne complete + monotonically normal implies paracompact

### DIFF
--- a/theorems/T000924.md
+++ b/theorems/T000924.md
@@ -1,0 +1,14 @@
+---
+uid: T000924
+if:
+  and:
+  - P000109: true
+  - P000221: true
+then:
+  P000030: true
+refs:
+  - mathse: 5144646
+    name: Is any Dieudonne complete monotonically normal space, a paracompact space?
+---
+
+See {{mathse:5144646}}


### PR DESCRIPTION
Follows from theorem of Balogh and Rudin as in the link. I have read the proof of theorem II before, so all I had to do is brush up on what screenable means and equivalence with paracompactness + the article of Engelking and Lutzer. So I can vouch for correctness of theorem I.