### PR TITLE
Spaces with dispersion point and size >= 3 are not homogeneous

### DIFF
--- a/theorems/T000928.md
+++ b/theorems/T000928.md
@@ -9,9 +9,7 @@ then:
 refs:
   - mathse: 5146777
     name: Answer to "A connected space cannot have more than one dispersion point"
-  - zb: 48.0210.01
-    name: A theorem concerning connected point sets (J. R. Kline)
 ---
 
 If $|X|\ge 3$, $X$ can have at most one dispersion point.
-See Proposition 1 in {{mathse:5146777}} or {{zb:48.0210.01}}.
+See Proposition 1 in {{mathse:5146777}}.

--- a/theorems/T000928.md
+++ b/theorems/T000928.md
@@ -1,0 +1,17 @@
+---
+uid: T000928
+if:
+  and:
+  - P000045: true
+  - P000175: true
+then:
+  P000086: false
+refs:
+  - mathse: 5146777
+    name: Answer to "A connected space cannot have more than one dispersion point"
+  - zb: 48.0210.01
+    name: A theorem concerning connected point sets (J. R. Kline)
+---
+
+If $|X|\ge 3$, $X$ can have at most one dispersion point.
+See Proposition 1 in {{mathse:5146777}} or {{zb:48.0210.01}}.


### PR DESCRIPTION
New T928: `has dispersion point + cardinality at least 3 => not homogeneous`.

This allows to derive that two more spaces are not homogeneous, including S125 (Knaster-Kuratowki fan).
https://topology.pi-base.org/spaces?q=Has+a+dispersion+point+%2B+%3FHomogeneous

https://math.stackexchange.com/a/5146777/52912

