### PR TITLE
Spaces with a dispersion point are not cut point spaces

### DIFF
--- a/spaces/S000008/properties/P000205.md
+++ b/spaces/S000008/properties/P000205.md
@@ -1,7 +1,0 @@
----
-space: S000008
-property: P000205
-value: false
----
-
-If $x\neq p$ then any bijection $f:X\setminus\{x\}\to X$ with $f(p) = p$ is a homeomorphism, and {S8|P36}, so no $x\in X\setminus \{p\}$ is a cut point.

--- a/spaces/S000009/properties/P000205.md
+++ b/spaces/S000009/properties/P000205.md
@@ -1,8 +1,0 @@
----
-space: S000009
-property: P000205
-value: false
----
-
-Removing any point other than the particular point from $X$ results in a space homeomorphic to $X$
-and {S9|P36}.

--- a/theorems/T000928.md
+++ b/theorems/T000928.md
@@ -1,15 +1,16 @@
 ---
 uid: T000928
 if:
-  and:
-  - P000045: true
-  - P000175: true
+  P000045: true
 then:
-  P000086: false
+  P000205: false
 refs:
   - mathse: 5146777
     name: Answer to "A connected space cannot have more than one dispersion point"
 ---
 
-If $|X|\ge 3$, $X$ can have at most one dispersion point.
-See Proposition 1 in {{mathse:5146777}}.
+Let $p$ be a dispersion point of $X$. If $|X|\ge 2$ and $q$ is a point distinct from $p$,
+the set $X\setminus\{q\}$ is connected by Proposition 2 in {{mathse:5146777}},
+so $q$ is not a cut point.
+And if $|X|\le 1$, $X$ has no cut point since {T558}.
+In both cases $X$ is not a {P205}.


### PR DESCRIPTION
Replace T928 `has a dispersion point + size at least 3 => not homogeneous` with a stronger version
`has a dispersion point => not a cut point space`.

This allows to derive that two more spaces are not cut point spaces:
https://topology.pi-base.org/spaces?q=Has+a+dispersion+point+%2B+%3FCut+point+space

The old T928 result can be derived from the new version together with existing theorems:
https://topology.pi-base.org/spaces?q=Has+a+dispersion+point+%2B+Cardinality+%24%5Cgeq+3%24+%2B+Homogeneous
