### PR TITLE
P50 (zero dimensional) in terms of ind

### DIFF
--- a/properties/P000050.md
+++ b/properties/P000050.md
@@ -6,7 +6,11 @@ refs:
     name: Counterexamples in Topology
 ---
 
-A space with a basis of clopen sets.
+$X$ has a base consisting of clopen sets.
+
+In terms of the [small inductive dimension](https://en.wikipedia.org/wiki/Inductive_dimension),
+this corresponds to $\text{ind}(X)\le 0$.
+(In particular, the empty space is {P50}.)
 
 Defined on page 33 of {{zb:0386.54001}}.
 


### PR DESCRIPTION
Add characterization of P50 (zero dimensional) in terms of the small inductive dimension.

As discussed in #1825.
